### PR TITLE
fix awaits when checking for reverts (TrueFiEng/Waffle#95)

### DIFF
--- a/test/bridge/BridgeConfigV3.ts
+++ b/test/bridge/BridgeConfigV3.ts
@@ -56,10 +56,12 @@ describe("Bridge Config V3", () => {
     it("should set max gas price for multiple chains", async () => {
       const mainnetGasPrice = BigNumber.from(10 ** 9)
 
-      expect(bridgeConfigV3.setMaxGasPrice(CHAIN_ID.BSC, bscGasPrice)).to.be.not
-        .reverted
-      expect(bridgeConfigV3.setMaxGasPrice(CHAIN_ID.MAINNET, mainnetGasPrice))
-        .to.be.not.reverted
+      await expect(bridgeConfigV3.setMaxGasPrice(CHAIN_ID.BSC, bscGasPrice)).to
+        .be.not.reverted
+
+      await expect(
+        bridgeConfigV3.setMaxGasPrice(CHAIN_ID.MAINNET, mainnetGasPrice),
+      ).to.be.not.reverted
 
       expect(await bridgeConfigV3.getMaxGasPrice(CHAIN_ID.BSC)).to.be.eq(
         bscGasPrice,
@@ -362,7 +364,7 @@ describe("Bridge Config V3", () => {
       testToken.minSwapFee = BigNumber.from("1000000000000000000")
       testToken.maxSwapFee = BigNumber.from("10000000000000000000")
 
-      expect(
+      await expect(
         bridgeConfigV3[
           "setTokenConfig(string,uint256,string,uint8,uint256,uint256,uint256,uint256,uint256,bool,bool)"
         ](


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I noticed when writing another test that the `.to.be.not.reverted` blocks that aren't awaited aren't actually checked (see: https://github.com/TrueFiEng/Waffle/issues/95#issuecomment-1036639670). This fixes that issue.

## Checklist

- [x] New Contracts have been tested
- [x] Lint has been run
- [x] I have checked my code and corrected any misspellings
