### PR TITLE
Group foundry tests by forked chain

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,11 @@ jobs:
           npm run test
   foundry-test:
     runs-on: ubuntu-latest
+    env:
+      ALCHEMY_API: ${{ secrets.ALCHEMY_API }}
+      AVAX_API: https://api.avax.network/ext/bc/C/rpc
+      MOVR_API: https://moonriver.api.onfinality.io/public
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/scripts/foundry.sh
+++ b/scripts/foundry.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
-forge test --match-contract "FraxMovrTest" --fork-url https://moonriver.api.onfinality.io/public --fork-block-number 1730000 -vvvv
-forge test --no-match-contract "FraxMovrTest" -vvvv
+# Test contracts ending with exactly "Test" don't require any forking
+forge test --match-contract "$1.*Test$" -vvvv
+
+# Test contracts ending with exactly "TestMovr" require Moonriver RPC and block number
+forge test --match-contract "$1.*TestMovr$" --fork-url $MOVR_API --fork-block-number 1730000 -vvvv

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+(set -a; source .env; set +a; ./scripts/foundry.sh $1)

--- a/test/bridge/wrappers/FraxWrapperMovr.t.sol
+++ b/test/bridge/wrappers/FraxWrapperMovr.t.sol
@@ -53,7 +53,7 @@ interface IBridge {
     ) external;
 }
 
-contract FraxMovrTest is Test {
+contract FraxWrapperTestMovr is Test {
     uint256 private constant SWAP_FEE = 4; // in bps
     uint256 private constant SWAP_DENOMINATOR = 10000;
 


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

- `env` included in `foundry-test` workflow, containing RPC URLs (including secrets)
- `scripts/foundry.sh` now properly separates tests based by the chain that needs to be forked.
- `scripts/tests.sh` can be used for local testing: variables describing RPC URLs from `.env` are used, but not exported outside of the script: https://medium.com/@charles.wautier/pipe-a-dotenv-in-a-process-with-the-shell-f9c663ff99a0

Allows a bit more flexible Foundry fork tests, until the cheatcode to fork chain & pin block is implemented (and the ability to load dotenv file).

Following naming convention is assumed for the Foundry Test Contracts:
- If test doesn't need any forking, the contract name should end with `Test`
- If test requires forking a chain, contract name should end with `TestChainName` (i.e. `TestEth`, `TestMovr`, etc).

Current setup assumes the same block number for the given chain, which is less than ideal, but workable. For different block number, one can modify `scripts/foundry.sh` and further separate tests for the same chain.

## Checklist

- [x] New Contracts have been tested
- [x] Lint has been run
- [x] I have checked my code and corrected any misspellings
