### PR TITLE
fix VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-  "solidity.packageDefaultDependenciesContractsDirectory": "src",
-  "solidity.packageDefaultDependenciesDirectory": "lib",
+  "solidity.packageDefaultDependenciesContractsDirectory": "",
+  "solidity.packageDefaultDependenciesDirectory": "node_modules",
   "solidity.compileUsingRemoteVersion": "v0.8.13",
   "search.exclude": { "lib": true }
 }


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description
Since we're still using Hardhat, the default dir for dependencies should be `node_modules`. Foundry libs are configured via `remappings.txt` at the moment.

## Checklist

- [x] New Contracts have been tested
- [x] Lint has been run
- [x] I have checked my code and corrected any misspellings
