### PR TITLE
MessageBus: add custom block.chainid option

### DIFF
--- a/contracts/messaging/ContextChainIdUpgradeable.sol
+++ b/contracts/messaging/ContextChainIdUpgradeable.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+import "@openzeppelin/contracts-upgradeable-4.5.0/proxy/utils/Initializable.sol";
+
+abstract contract ContextChainIdUpgradeable is Initializable {
+    function __ContextChainId_init() internal onlyInitializing {}
+
+    function __ContextChainId_init_unchained() internal onlyInitializing {}
+
+    function _chainId() internal view virtual returns (uint256) {
+        return block.chainid;
+    }
+
+    /**
+     * This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[50] private __gap;
+}

--- a/contracts/messaging/HarmonyMessageBusUpgradeable.sol
+++ b/contracts/messaging/HarmonyMessageBusUpgradeable.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+import "./MessageBusSenderUpgradeable.sol";
+import "./MessageBusReceiverUpgradeable.sol";
+
+contract HarmonyMessageBusUpgradeable is MessageBusSenderUpgradeable, MessageBusReceiverUpgradeable {
+    uint256 private constant CHAIN_ID = 1666600000;
+
+    function initialize(address _gasFeePricing, address _authVerifier) external initializer {
+        __Ownable_init_unchained();
+        __Pausable_init_unchained();
+        __MessageBusSender_init_unchained(_gasFeePricing);
+        __MessageBusReceiver_init_unchained(_authVerifier);
+    }
+
+    function _chainId() internal pure override returns (uint256) {
+        return CHAIN_ID;
+    }
+
+    // PAUSABLE FUNCTIONS ***/
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+}

--- a/contracts/messaging/MessageBusSenderUpgradeable.sol
+++ b/contracts/messaging/MessageBusSenderUpgradeable.sol
@@ -6,8 +6,9 @@ import "@openzeppelin/contracts-upgradeable-4.5.0/access/OwnableUpgradeable.sol"
 import "@openzeppelin/contracts-upgradeable-4.5.0/security/PausableUpgradeable.sol";
 
 import "./interfaces/IGasFeePricing.sol";
+import "./ContextChainIdUpgradeable.sol";
 
-contract MessageBusSenderUpgradeable is OwnableUpgradeable, PausableUpgradeable {
+contract MessageBusSenderUpgradeable is OwnableUpgradeable, PausableUpgradeable, ContextChainIdUpgradeable {
     address public gasFeePricing;
     uint64 public nonce;
     uint256 public fees;
@@ -99,11 +100,12 @@ contract MessageBusSenderUpgradeable is OwnableUpgradeable, PausableUpgradeable 
         bytes calldata _options,
         address payable _refundAddress
     ) internal {
-        require(_dstChainId != block.chainid, "Invalid chainId");
+        uint256 srcChainId = _chainId();
+        require(_dstChainId != srcChainId, "Invalid chainId");
         uint256 fee = estimateFee(_dstChainId, _options);
         require(msg.value >= fee, "Insufficient gas fee");
-        bytes32 msgId = computeMessageId(msg.sender, block.chainid, _receiver, _dstChainId, nonce, _message);
-        emit MessageSent(msg.sender, block.chainid, _receiver, _dstChainId, _message, nonce, _options, fee, msgId);
+        bytes32 msgId = computeMessageId(msg.sender, srcChainId, _receiver, _dstChainId, nonce, _message);
+        emit MessageSent(msg.sender, srcChainId, _receiver, _dstChainId, _message, nonce, _options, fee, msgId);
         fees += fee;
         ++nonce;
         // refund gas fees in case of overpayment

--- a/test/messaging/HarmonyMessageBusUpgradeable.t.sol
+++ b/test/messaging/HarmonyMessageBusUpgradeable.t.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+import "forge-std/Test.sol";
+import "../../contracts/messaging/HarmonyMessageBusUpgradeable.sol";
+import "../../contracts/messaging/AuthVerifier.sol";
+import "./GasFeePricing.t.sol";
+
+import "@openzeppelin/contracts-4.5.0/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+// this is a temporary test file against Harmony until https://github.com/harmony-one/harmony/issues/4129
+// is merged. It runs tests we run on MessageBusUpgradeableTest and adds tests around custom chain ids.
+contract HarmonyMessageBusUpgradeableTest is Test {
+    HarmonyMessageBusUpgradeable public messageBus;
+    AuthVerifier public authVerifier;
+
+    GasFeePricing public gasFeePricing;
+    GasFeePricingTest public gasFeePricingTest;
+
+    event MessageSent(
+        address indexed sender,
+        uint256 srcChainID,
+        bytes32 receiver,
+        uint256 indexed dstChainId,
+        bytes message,
+        uint64 nonce,
+        bytes options,
+        uint256 fee,
+        bytes32 indexed messageId
+    );
+
+    function setUp() public {
+        // setup gas fee pricing contracts
+        gasFeePricing = new GasFeePricing();
+        gasFeePricingTest = new GasFeePricingTest();
+        gasFeePricing.setCostPerChain(
+            gasFeePricingTest.expectedDstChainId(),
+            gasFeePricingTest.expectedDstGasPrice(),
+            gasFeePricingTest.expectedGasTokenPriceRatio()
+        );
+
+        authVerifier = new AuthVerifier(address(1337));
+        HarmonyMessageBusUpgradeable impl = new HarmonyMessageBusUpgradeable();
+        // Setup proxy with needed logic and custom admin,
+        // we don't need to upgrade anything, so no need to setup ProxyAdmin
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(address(impl), address(420), bytes(""));
+        messageBus = HarmonyMessageBusUpgradeable(address(proxy));
+        messageBus.initialize(address(gasFeePricing), address(authVerifier));
+    }
+
+    function testUnauthorizedPauseUnpause() public {
+        // try pausing from unauthorized address
+        vm.prank(address(999));
+        vm.expectRevert("Ownable: caller is not the owner");
+        messageBus.pause();
+
+        // switch to authorized address, pause
+        vm.prank(address(this));
+        messageBus.pause();
+
+        // try pausing from unauthorized address
+        vm.prank(address(999));
+        vm.expectRevert("Ownable: caller is not the owner");
+        messageBus.unpause();
+
+        // try unpausing from correct address
+        vm.prank(address(this));
+        messageBus.unpause();
+    }
+
+    function testPausedMessageReceive() public {
+        // pause the contract
+        vm.prank(address(this));
+        messageBus.pause();
+
+        uint256 srcChainId = 1;
+        bytes32 srcAddress = addressToBytes32(address(1338));
+        address dstAddress = address(0x2796317b0fF8538F253012862c06787Adfb8cEb6);
+        uint256 nonce = 0;
+        bytes memory message = bytes("");
+        bytes32 messageId = keccak256("testMessageId");
+
+        vm.prank(address(999));
+        vm.expectRevert("Pausable: paused");
+
+        messageBus.executeMessage(srcChainId, srcAddress, dstAddress, 200000, nonce, message, messageId);
+    }
+
+    function testPausedMessageSend() public {
+        // pause the contract
+        vm.prank(address(this));
+        messageBus.pause();
+
+        vm.expectRevert("Pausable: paused");
+        bytes32 receiverAddress = addressToBytes32(address(1337));
+        messageBus.sendMessage{value: 4}(receiverAddress, 121, bytes(""), bytes(""));
+    }
+
+    function addressToBytes32(address _addr) public pure returns (bytes32) {
+        return bytes32(uint256(uint160(_addr)));
+    }
+
+    // use block.chainID. Should be rejected
+    function testSendMessagef() public {
+        uint256 estimatedFee = messageBus.estimateFee(gasFeePricingTest.expectedDstChainId(), bytes(""));
+        uint64 currentNonce = messageBus.nonce();
+        bytes32 receiverAddress = addressToBytes32(address(1337));
+
+        // TODO: Check data, so false should become true
+        vm.expectEmit(true, true, false, true);
+        emit MessageSent(
+            address(this),
+            1666600000,
+            receiverAddress,
+            gasFeePricingTest.expectedDstChainId(),
+            bytes(""),
+            currentNonce,
+            bytes(""),
+            estimatedFee,
+            messageBus.computeMessageId(
+                address(this),
+                1666600000,
+                receiverAddress,
+                gasFeePricingTest.expectedDstChainId(),
+                currentNonce,
+                bytes("")
+            )
+        );
+        messageBus.sendMessage{value: estimatedFee}(
+            receiverAddress,
+            gasFeePricingTest.expectedDstChainId(),
+            bytes(""),
+            bytes("")
+        );
+    }
+}


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

This PR allows an easy creation of `MessageBus` contract for a specific chain, failing to report `block.chainid` correctly. The implementation can be later upgraded to chain-agnostic version.

## Checklist

- [x] New Contracts have been tested
- [x] Lint has been run
- [x] I have checked my code and corrected any misspellings
