### PR TITLE
MessageBus: immutable contracts

### DIFF
--- a/contracts/messaging/ContextChainId.sol
+++ b/contracts/messaging/ContextChainId.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+abstract contract ContextChainId {
+    uint256 internal immutable localChainId;
+
+    constructor() {
+        localChainId = _chainId();
+    }
+
+    function _chainId() internal view virtual returns (uint256) {
+        return block.chainid;
+    }
+}

--- a/contracts/messaging/HarmonyMessageBus.sol
+++ b/contracts/messaging/HarmonyMessageBus.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+import "./MessageBus.sol";
+
+contract HarmonyMessageBus is MessageBus {
+    uint256 private constant CHAIN_ID = 1666600000;
+
+    constructor(
+        IGasFeePricing _pricing,
+        IAuthVerifier _verifier,
+        IMessageExecutor _executor
+    ) MessageBus(_pricing, _verifier, _executor) {
+        this;
+    }
+
+    function _chainId() internal pure override returns (uint256) {
+        return CHAIN_ID;
+    }
+}

--- a/contracts/messaging/MessageBus.sol
+++ b/contracts/messaging/MessageBus.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+import "./MessageBusSender.sol";
+import "./MessageBusReceiver.sol";
+
+contract MessageBus is MessageBusSender, MessageBusReceiver {
+    constructor(
+        IGasFeePricing _pricing,
+        IAuthVerifier _verifier,
+        IMessageExecutor _executor
+    ) {
+        pricing = _pricing;
+        verifier = _verifier;
+        executor = _executor;
+    }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                               PAUSABLE                               ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+}

--- a/contracts/messaging/MessageBusReceiver.sol
+++ b/contracts/messaging/MessageBusReceiver.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+import "@openzeppelin/contracts-4.5.0/access/Ownable.sol";
+import "@openzeppelin/contracts-4.5.0/security/Pausable.sol";
+
+import "./interfaces/IAuthVerifier.sol";
+import "./interfaces/IMessageExecutor.sol";
+
+contract MessageBusReceiver is Ownable, Pausable {
+    enum TxStatus {
+        Null,
+        Success,
+        Fail
+    }
+
+    event Executed(
+        bytes32 indexed messageId,
+        TxStatus status,
+        address indexed dstAddress,
+        uint64 indexed srcChainId,
+        uint64 srcNonce
+    );
+
+    event CallReverted(string reason);
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                               STORAGE                                ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    /// @dev Contract used for authenticating validator address
+    IAuthVerifier public verifier;
+    /// @dev Contract used for executing received messages
+    IMessageExecutor public executor;
+    /// @dev Status of all executed messages
+    mapping(bytes32 => TxStatus) public executedMessages;
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                              ONLY OWNER                              ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function updateAuthVerifier(IAuthVerifier _verifier) external onlyOwner {
+        require(address(_verifier) != address(0), "Cannot set to 0");
+        verifier = _verifier;
+    }
+
+    function updateMessageExecutor(IMessageExecutor _executor) external onlyOwner {
+        require(address(_executor) != address(0), "Cannot set to 0");
+        executor = _executor;
+    }
+
+    // TODO: how useful is that, if contract is immutable?
+    function updateMessageStatus(bytes32 _messageId, TxStatus _status) external onlyOwner {
+        executedMessages[_messageId] = _status;
+    }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                           MESSAGING LOGIC                            ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    /**
+     * @notice Relayer executes messages through an authenticated method to the destination receiver
+     * based on the originating transaction on source chain
+     * @param _srcChainId Originating chain ID - typically a standard EVM chain ID,
+     * but may refer to a Synapse-specific chain ID on nonEVM chains
+     * @param _srcAddress Originating bytes32 address of the message sender on the srcChain
+     * @param _dstAddress Destination address that the arbitrary message will be passed to
+     * @param _message Arbitrary message payload to pass to the destination chain receiver
+     * @param _srcNonce Nonce of the message on the originating chain
+     * @param _options Versioned struct used to instruct message executor on how to proceed with gas limits,
+     * gas airdrop, etc
+     * @param _messageId Unique message identifier, computed when sending message on originating chain
+     * @param _proof Byte string containing proof that message was sent from originating chain
+     */
+    function executeMessage(
+        uint256 _srcChainId,
+        bytes32 _srcAddress,
+        address _dstAddress,
+        bytes calldata _message,
+        uint256 _srcNonce,
+        bytes calldata _options,
+        bytes32 _messageId,
+        bytes calldata _proof
+    ) external whenNotPaused {
+        // In order to guarantee that an individual message is only executed once, a messageId is passed
+        // enforce that this message ID hasn't already been tried ever
+        require(executedMessages[_messageId] == TxStatus.Null, "Message already executed");
+        // Authenticate executeMessage, will revert if not authenticated
+        IAuthVerifier(verifier).msgAuth(abi.encode(msg.sender, _messageId, _proof));
+
+        TxStatus status;
+        try executor.executeMessage(_srcChainId, _srcAddress, _dstAddress, _message, _options) {
+            // Assuming success state if no revert
+            status = TxStatus.Success;
+        } catch (bytes memory reason) {
+            // call hard reverted & failed
+            emit CallReverted(_getRevertMsg(reason));
+            status = TxStatus.Fail;
+        }
+
+        executedMessages[_messageId] = status;
+        emit Executed(_messageId, status, _dstAddress, uint64(_srcChainId), uint64(_srcNonce));
+    }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                           INTERNAL HELPERS                           ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    // https://ethereum.stackexchange.com/a/83577
+    // https://github.com/Uniswap/v3-periphery/blob/v1.0.0/contracts/base/Multicall.sol
+    function _getRevertMsg(bytes memory _returnData) internal pure returns (string memory) {
+        // If the _res length is less than 68, then the transaction failed silently (without a revert message)
+        if (_returnData.length < 68) return "Transaction reverted silently";
+        // solhint-disable-next-line
+        assembly {
+            // Slice the sighash.
+            _returnData := add(_returnData, 0x04)
+        }
+        return abi.decode(_returnData, (string)); // All that remains is the revert string
+    }
+}

--- a/contracts/messaging/MessageBusReceiver.sol
+++ b/contracts/messaging/MessageBusReceiver.sol
@@ -83,6 +83,7 @@ contract MessageBusReceiver is Ownable, Pausable {
         bytes32 _messageId,
         bytes calldata _proof
     ) external whenNotPaused {
+        /// @dev Sending messages is disabled, when {MessageBus} is paused.
         // In order to guarantee that an individual message is only executed once, a messageId is passed
         // enforce that this message ID hasn't already been tried ever
         require(executedMessages[_messageId] == TxStatus.Null, "Message already executed");

--- a/contracts/messaging/MessageBusReceiver.sol
+++ b/contracts/messaging/MessageBusReceiver.sol
@@ -83,12 +83,13 @@ contract MessageBusReceiver is Ownable, Pausable {
         bytes32 _messageId,
         bytes calldata _proof
     ) external whenNotPaused {
-        /// @dev Sending messages is disabled, when {MessageBus} is paused.
+        /// @dev Executing messages is disabled, when {MessageBus} is paused.
+
         // In order to guarantee that an individual message is only executed once, a messageId is passed
         // enforce that this message ID hasn't already been tried ever
         require(executedMessages[_messageId] == TxStatus.Null, "Message already executed");
         // Authenticate executeMessage, will revert if not authenticated
-        IAuthVerifier(verifier).msgAuth(abi.encode(msg.sender, _messageId, _proof));
+        verifier.msgAuth(abi.encode(msg.sender, _messageId, _proof));
 
         TxStatus status;
         try executor.executeMessage(_srcChainId, _srcAddress, _dstAddress, _message, _options) {

--- a/contracts/messaging/MessageBusReceiver.sol
+++ b/contracts/messaging/MessageBusReceiver.sol
@@ -19,8 +19,8 @@ contract MessageBusReceiver is Ownable, Pausable {
         bytes32 indexed messageId,
         TxStatus status,
         address indexed dstAddress,
-        uint64 indexed srcChainId,
-        uint64 srcNonce
+        uint256 indexed srcChainId,
+        uint256 srcNonce
     );
 
     event CallReverted(string reason);
@@ -102,7 +102,7 @@ contract MessageBusReceiver is Ownable, Pausable {
         }
 
         executedMessages[_messageId] = status;
-        emit Executed(_messageId, status, _dstAddress, uint64(_srcChainId), uint64(_srcNonce));
+        emit Executed(_messageId, status, _dstAddress, _srcChainId, _srcNonce);
     }
 
     /*╔══════════════════════════════════════════════════════════════════════╗*\

--- a/contracts/messaging/MessageBusSender.sol
+++ b/contracts/messaging/MessageBusSender.sol
@@ -91,7 +91,7 @@ contract MessageBusSender is Ownable, Pausable, ContextChainId {
      * @param _receiver The bytes32 address of the destination contract to be called
      * @param _dstChainId The destination chain ID - typically, standard EVM chain ID, but differs on nonEVM chains
      * @param _message The arbitrary payload to pass to the destination chain receiver
-     * @param _options Versioned struct used to instruct relayer on how to proceed with gas limits
+     * @param _options Versioned struct used to instruct message executor on how to proceed with gas limits
      */
     function sendMessage(
         bytes32 _receiver,
@@ -106,10 +106,12 @@ contract MessageBusSender is Ownable, Pausable, ContextChainId {
          * gas back, they should've specified themselves as a refund address.
          *
          * `tx.origin` is always an EOA that submitted the tx, and paid the gas fees,
-         * so returning overspent fees to it makes total sense.
+         * so returning overspent fees to it by default makes sense. This address is
+         * only going to be used for receiving unspent gas, so the usual
+         * "do not use tx.origin" approach can not be applied here.
          *
          * Also, some of the contracts interacting with {MessageBus} might have no way
-         * to receive gas, causing sendMessage to revert in case of overpayment,
+         * to receive gas, causing sendMessage to revert in case of overpayment, if
          * `msg.sender` was used by default.
          */
         // solhint-disable-next-line
@@ -123,7 +125,7 @@ contract MessageBusSender is Ownable, Pausable, ContextChainId {
      * @param _receiver The bytes32 address of the destination contract to be called
      * @param _dstChainId The destination chain ID - typically, standard EVM chain ID, but differs on nonEVM chains
      * @param _message The arbitrary payload to pass to the destination chain receiver
-     * @param _options Versioned struct used to instruct relayer on how to proceed with gas limits
+     * @param _options Versioned struct used to instruct message executor on how to proceed with gas limits
      * @param _refundAddress Address that will receive unspent gas fees
      */
     function sendMessage(

--- a/contracts/messaging/MessageBusSender.sol
+++ b/contracts/messaging/MessageBusSender.sol
@@ -15,7 +15,7 @@ contract MessageBusSender is Ownable, Pausable, ContextChainId {
         bytes32 receiver,
         uint256 indexed dstChainId,
         bytes message,
-        uint64 nonce,
+        uint256 nonce,
         bytes options,
         uint256 fee,
         bytes32 indexed messageId
@@ -28,7 +28,7 @@ contract MessageBusSender is Ownable, Pausable, ContextChainId {
     /// @dev Contract used for calculating fee for sending a message
     IGasFeePricing public pricing;
     /// @dev Nonce of the next send message (in other words, amount of messages sent)
-    uint64 public nonce;
+    uint256 public nonce;
     /// @dev Accrued messaging fees. Withdrawable by the owner.
     uint256 public fees;
 

--- a/contracts/messaging/MessageBusSender.sol
+++ b/contracts/messaging/MessageBusSender.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+import "./interfaces/IGasFeePricing.sol";
+import "./ContextChainId.sol";
+
+import "@openzeppelin/contracts-4.5.0/access/Ownable.sol";
+import "@openzeppelin/contracts-4.5.0/security/Pausable.sol";
+
+contract MessageBusSender is Ownable, Pausable, ContextChainId {
+    event MessageSent(
+        address indexed sender,
+        uint256 srcChainID,
+        bytes32 receiver,
+        uint256 indexed dstChainId,
+        bytes message,
+        uint64 nonce,
+        bytes options,
+        uint256 fee,
+        bytes32 indexed messageId
+    );
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                               STORAGE                                ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    /// @dev Contract used for calculating fee for sending a message
+    IGasFeePricing public pricing;
+    /// @dev Nonce of the next send message (in other words, amount of messages sent)
+    uint64 public nonce;
+    /// @dev Accrued messaging fees. Withdrawable by the owner.
+    uint256 public fees;
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                                VIEWS                                 ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function computeMessageId(
+        address _srcAddress,
+        uint256 _srcChainId,
+        bytes32 _dstAddress,
+        uint256 _dstChainId,
+        uint256 _srcNonce,
+        bytes calldata _message
+    ) public pure returns (bytes32) {
+        return keccak256(abi.encode(_srcAddress, _srcChainId, _dstAddress, _dstChainId, _srcNonce, _message));
+    }
+
+    function estimateFee(uint256 _dstChainId, bytes calldata _options) public returns (uint256) {
+        uint256 fee = pricing.estimateGasFee(_dstChainId, _options);
+        require(fee != 0, "Fee not set");
+        return fee;
+    }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                              ONLY OWNER                              ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    /**
+     * @notice Rescues any gas in contract, aside from fees
+     * @param to Address to which to rescue gas to
+     */
+    function rescueGas(address payable to) external onlyOwner {
+        uint256 withdrawAmount = address(this).balance - fees;
+        to.transfer(withdrawAmount);
+    }
+
+    /**
+     * @notice Withdraws accumulated fees in native gas token, based on fees variable.
+     * @param to Address to withdraw gas fees to, which can be specified in the event owner() can't receive native gas
+     */
+    function withdrawGasFees(address payable to) external onlyOwner {
+        to.transfer(fees);
+        delete fees;
+    }
+
+    function updateGasFeePricing(IGasFeePricing _pricing) external onlyOwner {
+        require(address(_pricing) != address(0), "Cannot set to 0");
+        pricing = _pricing;
+    }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                           MESSAGING LOGIC                            ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    /**
+     * @notice Sends a message to a receiving contract address on another chain.
+     * Sender must make sure that the message is unique and not a duplicate message.
+     * Unspent gas fees would be transferred back to tx.origin.
+     * @param _receiver The bytes32 address of the destination contract to be called
+     * @param _dstChainId The destination chain ID - typically, standard EVM chain ID, but differs on nonEVM chains
+     * @param _message The arbitrary payload to pass to the destination chain receiver
+     * @param _options Versioned struct used to instruct relayer on how to proceed with gas limits
+     */
+    function sendMessage(
+        bytes32 _receiver,
+        uint256 _dstChainId,
+        bytes calldata _message,
+        bytes calldata _options
+    ) external payable {
+        /**
+         * @dev We're using `tx.origin` instead of `msg.sender` here, because
+         * it's expected that the vast majority of interactions with {MessageBus}
+         * will be done by the smart contracts. If they truly wanted to receive unspent
+         * gas back, they should've specified themselves as a refund address.
+         *
+         * `tx.origin` is always an EOA that submitted the tx, and paid the gas fees,
+         * so returning overspent fees to it makes total sense.
+         *
+         * Also, some of the contracts interacting with {MessageBus} might have no way
+         * to receive gas, causing sendMessage to revert in case of overpayment,
+         * `msg.sender` was used by default.
+         */
+        // solhint-disable-next-line
+        _sendMessage(_receiver, _dstChainId, _message, _options, payable(tx.origin));
+    }
+
+    /**
+     * @notice Sends a message to a receiving contract address on another chain.
+     * Sender must make sure that the message is unique and not a duplicate message.
+     * Unspent gas fees will be refunded to specified address.
+     * @param _receiver The bytes32 address of the destination contract to be called
+     * @param _dstChainId The destination chain ID - typically, standard EVM chain ID, but differs on nonEVM chains
+     * @param _message The arbitrary payload to pass to the destination chain receiver
+     * @param _options Versioned struct used to instruct relayer on how to proceed with gas limits
+     * @param _refundAddress Address that will receive unspent gas fees
+     */
+    function sendMessage(
+        bytes32 _receiver,
+        uint256 _dstChainId,
+        bytes calldata _message,
+        bytes calldata _options,
+        address payable _refundAddress
+    ) external payable {
+        _sendMessage(_receiver, _dstChainId, _message, _options, _refundAddress);
+    }
+
+    /// @dev Sending messages is disabled, when {MessageBus} is paused.
+    function _sendMessage(
+        bytes32 _receiver,
+        uint256 _dstChainId,
+        bytes calldata _message,
+        bytes calldata _options,
+        address payable _refundAddress
+    ) internal whenNotPaused {
+        // Check that we're not sending to the local chain
+        require(_dstChainId != localChainId, "Invalid chainId");
+        // Check that messaging fee is fully covered
+        uint256 fee = estimateFee(_dstChainId, _options);
+        require(msg.value >= fee, "Insufficient gas fee");
+        // Compute individual message identifier
+        bytes32 msgId = computeMessageId(msg.sender, localChainId, _receiver, _dstChainId, nonce, _message);
+        emit MessageSent(msg.sender, localChainId, _receiver, _dstChainId, _message, nonce, _options, fee, msgId);
+        fees += fee;
+        ++nonce;
+        // refund gas fees in case of overpayment
+        if (msg.value > fee) {
+            _refundAddress.transfer(msg.value - fee);
+        }
+    }
+}

--- a/contracts/messaging/interfaces/IMessageExecutor.sol
+++ b/contracts/messaging/interfaces/IMessageExecutor.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+interface IMessageExecutor {
+    function executeMessage(
+        uint256 _srcChainId,
+        bytes32 _srcAddress,
+        address _dstAddress,
+        bytes calldata _message,
+        bytes calldata _options
+    ) external;
+}


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

This PR aims to provide an immutable `MessageBus`, which is supposed to serve as a backbone for the messaging infra on all the chains. All potential upgradeable logic is separated into separate contracts:

- `GasFeePricing` is responsible for calculating the fees for sending any type of message.
- `AuthVerifier` is responsible for verifying the submitted messages, which can be later upgraded to verifying messages using submitted proof.
- `MessageExecutor` is responsible for executing messages of any types.

`MessageBus` is responsible for:
- Sending messages:
  - Applying correct fee from `GasFeePricing`.
  - Emitting events, indicating that message was sent.
- Receiving messages:
  - Checking that every message can be executed only once.
  - Checking that message sender is authenticated by `AuthVerifier`.
  - Passing message correctly to have it executed by `MessageExecutor`.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
