### PR TITLE
Optimism Swap Wrapper: DAI, sUSD, USDT support

### DIFF
--- a/contracts/bridge/wrappers/OptimismSwapWrapper.sol
+++ b/contracts/bridge/wrappers/OptimismSwapWrapper.sol
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+import {IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/utils/SafeERC20.sol";
+
+// solhint-disable func-name-mixedcase
+interface ICurve {
+    // Imagine using signed integers for indexes
+    function get_dy(
+        int128 i,
+        int128 j,
+        uint256 dx
+    ) external view returns (uint256);
+
+    function exchange(
+        int128 i,
+        int128 j,
+        uint256 dx,
+        uint256 minDy,
+        address receiver
+    ) external returns (uint256);
+}
+
+interface ISynapse {
+    function calculateSwap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx
+    ) external view returns (uint256);
+
+    function swap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx,
+        uint256 minDy,
+        uint256 deadline
+    ) external returns (uint256);
+}
+
+interface IVelodrome {
+    function getAmountOut(uint256 amountIn, address tokenIn) external view returns (uint256);
+
+    // this low-level function should be called from a contract which performs important safety checks
+    function swap(
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address to,
+        bytes calldata data
+    ) external;
+}
+
+/**
+ * @notice Contract mimicking Saddle swap interface to connect following pools:
+ * - Synapse nUSD/USDC
+ * - Velodrome USDC/DAI
+ * - Velodrome USDC/sUSD
+ * - Curve DAI/USDC/USDT
+ * Swaps between "disconnected" coins are routed through USDC.
+ */
+contract OptimismSwapWrapper {
+    using SafeERC20 for IERC20;
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                              CONSTANTS                               ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    /**
+     * @notice Token ordering is nUSD, USDC (for backwards compatibility),
+     * then all remaining tokens sorted alphabetically.
+     * (index: token)
+     * 0: nUSD
+     * 1: USDC
+     * 2: DAI
+     * 3: sUSD
+     * 4: USDT
+     */
+
+    IERC20 internal constant NUSD = IERC20(0x67C10C397dD0Ba417329543c1a40eb48AAa7cd00);
+    IERC20 internal constant USDC = IERC20(0x7F5c764cBc14f9669B88837ca1490cCa17c31607);
+    IERC20 internal constant DAI = IERC20(0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1);
+    IERC20 internal constant SUSD = IERC20(0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9);
+    IERC20 internal constant USDT = IERC20(0x94b008aA00579c1307B0EF2c499aD98a8ce58e58);
+
+    /// @notice USDC index, important because all multi swaps are routed through USDC
+    uint256 internal constant USDC_INDEX = 1;
+    uint256 internal constant COINS = 5;
+
+    /// @notice Synapse nUSD/USDC
+    address internal constant SYNAPSE_NUSD_POOL = 0xF44938b0125A6662f9536281aD2CD6c499F22004;
+    /// @notice Velodrome USDC/DAI
+    address internal constant VELODROME_DAI_POOL = 0x4F7ebc19844259386DBdDB7b2eB759eeFc6F8353;
+    /// @notice Velodrome USDC/SUSD
+    address internal constant VELODROME_SUSD_POOL = 0xd16232ad60188B68076a235c65d692090caba155;
+    /// @notice Curve DAI/USDC/USDT
+    address internal constant CURVE_USDT_POOL = 0x1337BedC9D22ecbe766dF105c9623922A27963EC;
+
+    uint256 internal constant MAX_UINT = type(uint256).max;
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                             CONSTRUCTOR                              ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    constructor() {
+        // Approve spending by Synapse Pool
+        NUSD.safeApprove(SYNAPSE_NUSD_POOL, MAX_UINT);
+        USDC.safeApprove(SYNAPSE_NUSD_POOL, MAX_UINT);
+        // Velodrome pools don't need approvals
+        // Approve Curve DAI/USDC/USDT Pool
+        // We don't need DAI approval, as we don't use Curve pool for DAI swaps
+        USDC.safeApprove(CURVE_USDT_POOL, MAX_UINT);
+        USDT.safeApprove(CURVE_USDT_POOL, MAX_UINT);
+    }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                          EXTERNAL FUNCTIONS                          ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function swap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx,
+        uint256 minDy,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
+        // solhint-disable-next-line not-rely-on-time
+        require(block.timestamp <= deadline, "Deadline not met");
+        require(tokenIndexFrom < COINS && tokenIndexTo < COINS && tokenIndexFrom != tokenIndexTo, "Swap not supported");
+        IERC20 tokenFrom = _getToken(tokenIndexFrom);
+        // Record balance before transfer
+        uint256 balanceBefore = tokenFrom.balanceOf(address(this));
+        // First, pull tokens from the user
+        tokenFrom.safeTransferFrom(msg.sender, address(this), dx);
+        // Use actual transferred amount for the swap
+        dx = tokenFrom.balanceOf(address(this)) - balanceBefore;
+        // Check if direct swap is possible
+        if (tokenIndexFrom == USDC_INDEX || tokenIndexTo == USDC_INDEX) {
+            amountOut = _directSwap(tokenIndexFrom, tokenIndexTo, dx, minDy, msg.sender);
+        } else {
+            // First, perform tokenFrom -> USDC swap, recipient is this contract
+            // Don't check minAmountOut
+            amountOut = _directSwap(tokenIndexFrom, USDC_INDEX, dx, 0, address(this));
+            // Then, perform USDC -> tokenTo swap, recipient is the user
+            // Check minAmountOut
+            amountOut = _directSwap(USDC_INDEX, tokenIndexTo, amountOut, minDy, msg.sender);
+        }
+    }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                                VIEWS                                 ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function calculateSwap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx
+    ) external view returns (uint256 amountOut) {
+        if (tokenIndexFrom == tokenIndexTo) return 0;
+        // Check if direct swap is possible
+        if (tokenIndexFrom == USDC_INDEX || tokenIndexTo == USDC_INDEX) {
+            amountOut = _getDirectAmountOut(tokenIndexFrom, tokenIndexTo, dx);
+        } else {
+            // First, get tokenFrom -> USDC quote
+            amountOut = _getDirectAmountOut(tokenIndexFrom, USDC_INDEX, dx);
+            // Then, get USDC -> tokenTo quote
+            amountOut = _getDirectAmountOut(USDC_INDEX, tokenIndexTo, amountOut);
+        }
+    }
+
+    function getToken(uint8 index) external pure returns (IERC20 token) {
+        token = _getToken(index);
+        require(address(token) != address(0), "Out of range");
+    }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                          INTERNAL FUNCTIONS                          ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function _directSwap(
+        uint256 _indexFrom,
+        uint256 _indexTo,
+        uint256 _amountIn,
+        uint256 _minAmountOut,
+        address _recipient
+    ) internal returns (uint256 amountOut) {
+        // Get swap pool for a direct trade
+        address pool = _getPoolAddress(_indexFrom, _indexTo);
+        require(pool != address(0), "Swap not supported");
+        if (pool == SYNAPSE_NUSD_POOL) {
+            // Indexes in Synapse pool match the indexes in SwapWrapper
+            // solhint-disable-next-line not-rely-on-time
+            amountOut = ISynapse(pool).swap(uint8(_indexFrom), uint8(_indexTo), _amountIn, 0, block.timestamp);
+            // Transfer tokens to recipient, if needed
+            if (_recipient != address(this)) {
+                _getToken(_indexTo).safeTransfer(_recipient, amountOut);
+            }
+        } else if (pool == CURVE_USDT_POOL) {
+            // Get corresponding Curve indexes and perform a swap
+            amountOut = ICurve(pool).exchange(
+                _getCurveIndex(_indexFrom),
+                _getCurveIndex(_indexTo),
+                _amountIn,
+                0,
+                _recipient
+            );
+        } else if (pool == VELODROME_DAI_POOL || pool == VELODROME_SUSD_POOL) {
+            // Get starting token
+            IERC20 tokenFrom = _getToken(_indexFrom);
+            // Get a quote
+            amountOut = IVelodrome(pool).getAmountOut(_amountIn, address(tokenFrom));
+            // Transfer starting token to Pair contract
+            tokenFrom.safeTransfer(address(pool), _amountIn);
+            // USDC is token0 in both USDC/DAI and USDC/sUSD pool,
+            // because USDC address is lexicographically smaller
+            (uint256 amount0Out, uint256 amount1Out) = (_indexFrom == USDC_INDEX)
+                ? (uint256(0), amountOut)
+                : (amountOut, uint256(0));
+            // Perform a swap
+            IVelodrome(pool).swap(amount0Out, amount1Out, _recipient, bytes(""));
+        } else {
+            // Sanity check: should never reach this
+            assert(false);
+        }
+        // Check output amount
+        require(amountOut >= _minAmountOut, "Swap didn't result in min tokens");
+    }
+
+    function _getDirectAmountOut(
+        uint256 _indexFrom,
+        uint256 _indexTo,
+        uint256 _amountIn
+    ) internal view returns (uint256 amountOut) {
+        // First, check input amount
+        if (_amountIn == 0) return 0;
+        // Then get swap pool for a direct trade
+        address pool = _getPoolAddress(_indexFrom, _indexTo);
+        if (pool == SYNAPSE_NUSD_POOL) {
+            // Indexes in Synapse pool match the indexes in SwapWrapper
+            amountOut = ISynapse(pool).calculateSwap(uint8(_indexFrom), uint8(_indexTo), _amountIn);
+        } else if (pool == CURVE_USDT_POOL) {
+            // Get corresponding Curve indexes and get a quote
+            amountOut = ICurve(pool).get_dy(_getCurveIndex(_indexFrom), _getCurveIndex(_indexTo), _amountIn);
+        } else if (pool == VELODROME_DAI_POOL || pool == VELODROME_SUSD_POOL) {
+            // Get starting token
+            IERC20 tokenFrom = _getToken(_indexFrom);
+            // Get a quote
+            amountOut = IVelodrome(pool).getAmountOut(_amountIn, address(tokenFrom));
+        }
+        /// @dev amountOut is 0 if direct swap is not supported
+    }
+
+    function _getCurveIndex(uint256 _tokenIndex) internal pure returns (int128 index) {
+        if (_tokenIndex == 2) {
+            // DAI
+            index = 0;
+        } else if (_tokenIndex == 1) {
+            // USDC
+            index = 1;
+        } else if (_tokenIndex == 4) {
+            // USDT
+            index = 2;
+        } else {
+            // return -1 for unsupported token index
+            index = -1;
+        }
+    }
+
+    /// @dev Gets pool address for direct swap between two tokens.
+    function _getPoolAddress(uint256 _indexFrom, uint256 _indexTo) internal pure returns (address pool) {
+        if (_indexFrom == USDC_INDEX) {
+            pool = _getTokenPoolAddress(_indexTo);
+        } else if (_indexTo == USDC_INDEX) {
+            pool = _getTokenPoolAddress(_indexFrom);
+        }
+        /// @dev pool is address(0) if neither of tokens is USDC.
+    }
+
+    function _getToken(uint256 _tokenIndex) internal pure returns (IERC20 token) {
+        if (_tokenIndex == 0) {
+            token = NUSD;
+        } else if (_tokenIndex == 1) {
+            token = USDC;
+        } else if (_tokenIndex == 2) {
+            token = DAI;
+        } else if (_tokenIndex == 3) {
+            token = SUSD;
+        } else if (_tokenIndex == 4) {
+            token = USDT;
+        }
+        /// @dev token is IERC20(address(0)) for unsupported indexes
+    }
+
+    /// @dev Gets pool address for direct swap between USDC and other token.
+    function _getTokenPoolAddress(uint256 _tokenIndex) internal pure returns (address pool) {
+        if (_tokenIndex == 0) {
+            pool = SYNAPSE_NUSD_POOL;
+        } else if (_tokenIndex == 2) {
+            pool = VELODROME_DAI_POOL;
+        } else if (_tokenIndex == 3) {
+            pool = VELODROME_SUSD_POOL;
+        } else if (_tokenIndex == 4) {
+            pool = CURVE_USDT_POOL;
+        }
+        /// @dev pool is address(0) if _tokenIndex is USDC, or out of range
+    }
+}

--- a/contracts/bridge/wrappers/OptimismSwapWrapper.sol
+++ b/contracts/bridge/wrappers/OptimismSwapWrapper.sol
@@ -83,8 +83,11 @@ contract OptimismSwapWrapper {
     IERC20 internal constant SUSD = IERC20(0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9);
     IERC20 internal constant USDT = IERC20(0x94b008aA00579c1307B0EF2c499aD98a8ce58e58);
 
-    /// @notice USDC index, important because all multi swaps are routed through USDC
+    uint256 internal constant NUSD_INDEX = 0;
     uint256 internal constant USDC_INDEX = 1;
+    uint256 internal constant DAI_INDEX = 2;
+    uint256 internal constant SUSD_INDEX = 3;
+    uint256 internal constant USDT_INDEX = 4;
     uint256 internal constant COINS = 5;
 
     /// @notice Synapse nUSD/USDC
@@ -251,14 +254,12 @@ contract OptimismSwapWrapper {
     }
 
     function _getCurveIndex(uint256 _tokenIndex) internal pure returns (int128 index) {
-        if (_tokenIndex == 2) {
-            // DAI
+        // Order of tokens in the Curve pool is DAI, USDC, USDT
+        if (_tokenIndex == DAI_INDEX) {
             index = 0;
-        } else if (_tokenIndex == 1) {
-            // USDC
+        } else if (_tokenIndex == USDC_INDEX) {
             index = 1;
-        } else if (_tokenIndex == 4) {
-            // USDT
+        } else if (_tokenIndex == USDT_INDEX) {
             index = 2;
         } else {
             // return -1 for unsupported token index
@@ -277,15 +278,15 @@ contract OptimismSwapWrapper {
     }
 
     function _getToken(uint256 _tokenIndex) internal pure returns (IERC20 token) {
-        if (_tokenIndex == 0) {
+        if (_tokenIndex == NUSD_INDEX) {
             token = NUSD;
-        } else if (_tokenIndex == 1) {
+        } else if (_tokenIndex == USDC_INDEX) {
             token = USDC;
-        } else if (_tokenIndex == 2) {
+        } else if (_tokenIndex == DAI_INDEX) {
             token = DAI;
-        } else if (_tokenIndex == 3) {
+        } else if (_tokenIndex == SUSD_INDEX) {
             token = SUSD;
-        } else if (_tokenIndex == 4) {
+        } else if (_tokenIndex == USDT_INDEX) {
             token = USDT;
         }
         /// @dev token is IERC20(address(0)) for unsupported indexes
@@ -293,13 +294,13 @@ contract OptimismSwapWrapper {
 
     /// @dev Gets pool address for direct swap between USDC and other token.
     function _getTokenPoolAddress(uint256 _tokenIndex) internal pure returns (address pool) {
-        if (_tokenIndex == 0) {
+        if (_tokenIndex == NUSD_INDEX) {
             pool = SYNAPSE_NUSD_POOL;
-        } else if (_tokenIndex == 2) {
+        } else if (_tokenIndex == DAI_INDEX) {
             pool = VELODROME_DAI_POOL;
-        } else if (_tokenIndex == 3) {
+        } else if (_tokenIndex == SUSD_INDEX) {
             pool = VELODROME_SUSD_POOL;
-        } else if (_tokenIndex == 4) {
+        } else if (_tokenIndex == USDT_INDEX) {
             pool = CURVE_USDT_POOL;
         }
         /// @dev pool is address(0) if _tokenIndex is USDC, or out of range

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 optimizer = true
 optimizer_runs = 200
 auto_detect_solc = true
@@ -7,12 +7,12 @@ out = "artifacts"
 libs = ["node_modules"]
 
 ## set only when the `hardhat` profile is selected
-[hardhat]
+[profile.hardhat]
 src = "contracts"
 out = "artifacts"
 libs = ["node_modules"]
 
-[ci]
+[profile.ci]
 verbosity = 4
 
 # See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/scripts/foundry.sh
+++ b/scripts/foundry.sh
@@ -12,8 +12,8 @@ forge test --match-contract "$1.*TestEth$" --fork-url $ALCHEMY_API --fork-block-
 # Test contracts ending with exactly "TestArb" require Arbitrum RPC and block number: 2022-04-26
 forge test --match-contract "$1.*TestArb$" --fork-url $ARBITRUM_API --fork-block-number 10600000 -vvv || exit 1
 
-# Test contracts ending with exactly "TestOpt" require Optimism RPC and block number: 2022-04-26
-forge test --match-contract "$1.*TestOpt$" --fork-url $OPTIMISM_API --fork-block-number 6600000 -vvv || exit 1
+# Test contracts ending with exactly "TestOpt" require Optimism RPC and block number: 2022-08-13
+forge test --match-contract "$1.*TestOpt$" --fork-url $OPTIMISM_API --fork-block-number 19000000 -vvv || exit 1
 
 # Test contracts ending with exactly "TestMovr" require Moonriver RPC and block number: 2022-04-21
 forge test --match-contract "$1.*TestMovr$" --fork-url $MOVR_API --fork-block-number 1730000 -vvv || exit 1

--- a/test/bridge/wrappers/OptimismSwapWrapper.t.sol
+++ b/test/bridge/wrappers/OptimismSwapWrapper.t.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+import "forge-std/Test.sol";
+
+import "../../../contracts/bridge/wrappers/OptimismSwapWrapper.sol";
+import {ERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/ERC20.sol";
+
+interface SynthUSD {
+    function target() external view returns (SynthUSD);
+
+    function tokenState() external view returns (TokenState);
+}
+
+interface TokenState {
+    function associatedContract() external view returns (address);
+
+    function setBalanceOf(address, uint256) external;
+}
+
+// solhint-disable func-name-mixedcase
+// solhint-disable not-rely-on-time
+contract SwapWrapperTestOpt is Test {
+    using SafeERC20 for IERC20;
+
+    address internal constant NUSD = 0x67C10C397dD0Ba417329543c1a40eb48AAa7cd00;
+    address internal constant USDC = 0x7F5c764cBc14f9669B88837ca1490cCa17c31607;
+    address internal constant DAI = 0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1;
+    address internal constant SUSD = 0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9;
+    address internal constant USDT = 0x94b008aA00579c1307B0EF2c499aD98a8ce58e58;
+
+    uint8 internal constant COINS = 5;
+
+    OptimismSwapWrapper internal swap;
+
+    function setUp() public {
+        swap = new OptimismSwapWrapper();
+        for (uint8 i = 0; i < COINS; ++i) {
+            swap.getToken(i).safeApprove(address(swap), type(uint256).max);
+        }
+        vm.label(NUSD, "nUSD");
+        vm.label(USDC, "USDC");
+        vm.label(DAI, "DAI");
+        vm.label(SUSD, "sUSD");
+        vm.label(USDT, "USDT");
+
+        vm.label(0xF44938b0125A6662f9536281aD2CD6c499F22004, "nUSD Pool");
+        vm.label(0x4F7ebc19844259386DBdDB7b2eB759eeFc6F8353, "DAI Pool");
+        vm.label(0xd16232ad60188B68076a235c65d692090caba155, "sUSD Pool");
+        vm.label(0x1337BedC9D22ecbe766dF105c9623922A27963EC, "USDT Pool");
+    }
+
+    function test_tokenNames() public {
+        // Sanity checks
+        assertEq(ERC20(NUSD).symbol(), "nUSD", "!nUSD token");
+        assertEq(ERC20(USDC).symbol(), "USDC", "!USC token");
+        assertEq(ERC20(DAI).symbol(), "DAI", "!DAI token");
+        assertEq(ERC20(SUSD).symbol(), "sUSD", "!sUSD token");
+        assertEq(ERC20(USDT).symbol(), "USDT", "!USDT token");
+    }
+
+    function test_getToken() public {
+        assertEq(address(swap.getToken(0)), NUSD, "!nUSD index");
+        assertEq(address(swap.getToken(1)), USDC, "!USDC index");
+        assertEq(address(swap.getToken(2)), DAI, "!DAI index");
+        assertEq(address(swap.getToken(3)), SUSD, "!sUSD index");
+        assertEq(address(swap.getToken(4)), USDT, "!USDT index");
+    }
+
+    function test_getToken_outOfRange() public {
+        vm.expectRevert("Out of range");
+        swap.getToken(COINS);
+    }
+
+    function test_calculateSwap_identicalIndex() public {
+        for (uint8 index = 0; index < COINS; ++index) {
+            assertEq(swap.calculateSwap(index, index, _getTestAmountIn(address(_getToken(index)))), 0);
+        }
+    }
+
+    function test_calculateSwap_unsupportedIndex() public {
+        uint256 amountIn = _getTestAmountIn(NUSD);
+        assertEq(swap.calculateSwap(0, COINS, amountIn), 0, "nUSD -> ????");
+        assertEq(swap.calculateSwap(COINS, 0, amountIn), 0, "???? -> nUSD");
+    }
+
+    function test_swap() public {
+        for (uint8 indexFrom = 0; indexFrom < COINS; ++indexFrom) {
+            for (uint8 indexTo = 0; indexTo < COINS; ++indexTo) {
+                if (indexFrom != indexTo) _checkSwap(indexFrom, indexTo);
+            }
+        }
+    }
+
+    function test_swap_identicalIndex() public {
+        for (uint8 indexFrom = 0; indexFrom < COINS; ++indexFrom) {
+            vm.expectRevert("Swap not supported");
+            swap.swap(indexFrom, indexFrom, 0, 0, type(uint256).max);
+        }
+    }
+
+    function test_swap_unsupportedIndex() public {
+        for (uint8 indexFrom = 0; indexFrom < COINS; ++indexFrom) {
+            vm.expectRevert("Swap not supported");
+            swap.swap(indexFrom, COINS, 0, 0, type(uint256).max);
+            vm.expectRevert("Swap not supported");
+            swap.swap(COINS, indexFrom, 0, 0, type(uint256).max);
+        }
+    }
+
+    function test_swap_deadlineFailed() public {
+        vm.expectRevert("Deadline not met");
+        swap.swap(0, 1, 0, 0, block.timestamp - 1);
+    }
+
+    function test_swap_amountOutTooLow() public {
+        for (uint8 indexFrom = 0; indexFrom < COINS; ++indexFrom) {
+            for (uint8 indexTo = 0; indexTo < COINS; ++indexTo) {
+                if (indexFrom != indexTo) {
+                    (, uint256 amountIn) = _prepareSwap(indexFrom, indexTo);
+                    uint256 quoteOut = swap.calculateSwap(indexFrom, indexTo, amountIn);
+                    assert(quoteOut != 0);
+                    vm.expectRevert("Swap didn't result in min tokens");
+                    swap.swap(indexFrom, indexTo, amountIn, 2 * quoteOut, block.timestamp);
+                }
+            }
+        }
+    }
+
+    function _checkSwap(uint8 _indexFrom, uint8 _indexTo) internal {
+        (, uint256 amountIn) = _prepareSwap(_indexFrom, _indexTo);
+        IERC20 tokenOut = _getToken(_indexTo);
+        // Get swap quote
+        uint256 quoteOut = swap.calculateSwap(_indexFrom, _indexTo, amountIn);
+        uint256 balanceBefore = tokenOut.balanceOf(address(this));
+        // Do the swap
+        uint256 amountOut = swap.swap(_indexFrom, _indexTo, amountIn, quoteOut, block.timestamp);
+        uint256 balanceAfter = tokenOut.balanceOf(address(this));
+        assertEq(amountOut, balanceAfter - balanceBefore, "Failed to report swapped amount");
+        assertEq(quoteOut, amountOut, "Failed to give accurate quote");
+    }
+
+    function _prepareSwap(uint8 _indexFrom, uint8 _indexTo) internal returns (IERC20 tokenIn, uint256 amountIn) {
+        assert(_indexFrom != _indexTo);
+        tokenIn = _getToken(_indexFrom);
+        amountIn = _getTestAmountIn(address(tokenIn));
+        // Mint test tokens
+        if (address(tokenIn) == SUSD) {
+            // Minting test sUSD is pure pain
+            TokenState state = SynthUSD(address(tokenIn)).target().tokenState();
+            vm.prank(state.associatedContract());
+            state.setBalanceOf(address(this), amountIn);
+        } else {
+            deal(address(tokenIn), address(this), amountIn);
+        }
+    }
+
+    function _getToken(uint8 _index) internal view returns (IERC20) {
+        return swap.getToken(_index);
+    }
+
+    function _getTestAmountIn(address _token) internal view returns (uint256) {
+        // $1000 in token's decimals
+        return 1000 * 10**ERC20(_token).decimals();
+    }
+}

--- a/test/bridge/wrappers/OptimismSwapWrapper.t.sol
+++ b/test/bridge/wrappers/OptimismSwapWrapper.t.sol
@@ -153,7 +153,7 @@ contract SwapWrapperTestOpt is Test {
         for (uint8 indexFrom = 0; indexFrom < COINS; ++indexFrom) {
             for (uint8 indexTo = 0; indexTo < COINS; ++indexTo) {
                 if (indexFrom != indexTo) {
-                    (, uint256 amountIn) = _prepareSwap(indexFrom, indexTo);
+                    uint256 amountIn = _prepareSwap(indexFrom, indexTo);
                     uint256 quoteOut = swap.calculateSwap(indexFrom, indexTo, amountIn);
                     assert(quoteOut != 0);
                     vm.expectRevert("Swap didn't result in min tokens");
@@ -164,7 +164,7 @@ contract SwapWrapperTestOpt is Test {
     }
 
     function _checkSwap(uint8 _indexFrom, uint8 _indexTo) internal {
-        (, uint256 amountIn) = _prepareSwap(_indexFrom, _indexTo);
+        uint256 amountIn = _prepareSwap(_indexFrom, _indexTo);
         IERC20 tokenOut = _getToken(_indexTo);
         // Get swap quote
         uint256 quoteOut = swap.calculateSwap(_indexFrom, _indexTo, amountIn);
@@ -205,18 +205,18 @@ contract SwapWrapperTestOpt is Test {
         assertEq(quoteOut, curveQuote, "Quote doesn't match Curve");
     }
 
-    function _prepareSwap(uint8 _indexFrom, uint8 _indexTo) internal returns (IERC20 tokenIn, uint256 amountIn) {
+    function _prepareSwap(uint8 _indexFrom, uint8 _indexTo) internal returns (uint256 amountIn) {
         assert(_indexFrom != _indexTo);
-        tokenIn = _getToken(_indexFrom);
-        amountIn = _getTestAmountIn(address(tokenIn));
+        address tokenIn = address(_getToken(_indexFrom));
+        amountIn = _getTestAmountIn(tokenIn);
         // Mint test tokens
-        if (address(tokenIn) == SUSD) {
+        if (tokenIn == SUSD) {
             // Minting test sUSD is pure pain
-            TokenState state = SynthUSD(address(tokenIn)).target().tokenState();
+            TokenState state = SynthUSD(tokenIn).target().tokenState();
             vm.prank(state.associatedContract());
             state.setBalanceOf(address(this), amountIn);
         } else {
-            deal(address(tokenIn), address(this), amountIn);
+            deal(tokenIn, address(this), amountIn);
         }
     }
 


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

`SwapWrapper` is a contract mimicking a Saddle swap pool. On Optimism it supports swaps between nUSD, USDC (via the Synapse pool), DAI, sUSD (via the USDC/DAI and USDC/sUSD Velodrome pools) and USDT (via the DAI/USDC/USDT Curve pool). Direct/multi-hop quotes and swaps (using USDC as the intermediate token) are available.

Things to consider _(updated, new thoughts are in italics)_:
- Reverting on `calculateSwap`, when swap isn't possible (invalid or equal token indexes) instead of returning 0. _Decided to leave as is._
- Enabling direct swap between DAI and USDT via Curve pool instead of `DAI<>USDC<>USDT` via Curve + Velodrome (only if the SwapWrapper is added to "Swap" page on the UI). _Done in [df14870](https://github.com/synapsecns/synapse-contracts/pull/176/commits/df14870f359508b6720a3239bd91d1e40c8c9b4b)._
- Reverting in internal view/pure functions instead of returning default "invalid" values. _Added `assert(false)` is the places that are supposed to be unreachable._

## Checklist

- [x] New Contracts have been tested
- [x] Lint has been run
- [x] I have checked my code and corrected any misspellings
