### PR TITLE
DFK Hero Bridge - Upgrade to remove assisting auction check

### DIFF
--- a/contracts/messaging/dfk/bridge/HeroBridgeUpgradeable.sol
+++ b/contracts/messaging/dfk/bridge/HeroBridgeUpgradeable.sol
@@ -75,9 +75,6 @@ contract HeroBridgeUpgradeable is Initializable, SynMessagingReceiverUpgradeable
         // revert if the hero is on a quest
         require(heroToBridge.state.currentQuest == address(0), "hero is questing");
 
-        // revert if the hero is on auction
-        require((IAssistingAuction(assistingAuction).isOnAuction(heroId)) == false, "assisting auction");
-
         bytes32 receiver = trustedRemoteLookup[dstChainId];
         // _createMessage(heroId, dstUserAddress, Hero);
         // Only bridgeable directly to the caller of this contract


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

This a request to upgrade the HeroBridge contract to remove the check for heroes being listed for for hire, as there are a few heroes stuck in an error state and cannot bridge with this check in place.

Fixes # (issue)

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
