### PR TITLE
Bonus rewarder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "solidity.packageDefaultDependenciesContractsDirectory": "",
   "solidity.packageDefaultDependenciesDirectory": "node_modules",
-  "solidity.compileUsingRemoteVersion": "v0.8.13",
   "search.exclude": { "lib": true }
 }

--- a/contracts/bridge/rewarder/BonusRewarder.sol
+++ b/contracts/bridge/rewarder/BonusRewarder.sol
@@ -154,7 +154,7 @@ contract BonusRewarder is IRewarder, BoringOwnable {
         uint256 pending;
         // Calculate pending user bonus token rewards, if user triggered {onSynapseReward} before.
         // Otherwise, this is considered a user "deposit" into BonusRewarder.
-        if (user.amount > 0) {
+        if (user.amount > 0 || user.unpaidRewards > 0) {
             // First, we calculate total accumulated rewards for `user.amount` LP tokens.
             // Then, we subtract the amount of accumulated rewards at the last user interaction.
             // That gives us the amount of token rewards earned since last interaction.

--- a/contracts/bridge/rewarder/BonusRewarder.sol
+++ b/contracts/bridge/rewarder/BonusRewarder.sol
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+import "../interfaces/IRewarder.sol";
+import "@boringcrypto/boring-solidity/contracts/libraries/BoringERC20.sol";
+import "@boringcrypto/boring-solidity/contracts/libraries/BoringMath.sol";
+import "@boringcrypto/boring-solidity/contracts/BoringOwnable.sol";
+import "../MasterChefV2.sol";
+
+/// @author @0xKeno
+contract BonusRewarder is IRewarder, BoringOwnable {
+    using BoringMath for uint256;
+    using BoringMath128 for uint128;
+    using BoringERC20 for IERC20;
+
+    IERC20 private immutable rewardToken;
+
+    /// @notice Info of each MCV2 user.
+    /// `amount` LP token amount the user has provided.
+    /// `rewardDebt` The amount of SUSHI entitled to the user.
+    struct UserInfo {
+        uint256 amount;
+        uint256 rewardDebt;
+        uint256 unpaidRewards;
+    }
+
+    /// @notice Info of each MCV2 pool.
+    /// `allocPoint` The amount of allocation points assigned to the pool.
+    /// Also known as the amount of SUSHI to distribute per block.
+    struct PoolInfo {
+        uint128 accSushiPerShare;
+        uint64 lastRewardTime;
+        uint64 allocPoint;
+    }
+
+    /// @notice Info of each pool.
+    mapping(uint256 => PoolInfo) public poolInfo;
+
+    uint256[] public poolIds;
+
+    /// @notice Info of each user that stakes LP tokens.
+    mapping(uint256 => mapping(address => UserInfo)) public userInfo;
+    /// @dev Total allocation points. Must be the sum of all allocation points in all pools.
+    uint256 totalAllocPoint;
+
+    uint256 public rewardPerSecond;
+    uint256 private constant ACC_TOKEN_PRECISION = 1e12;
+
+    address private immutable MASTERCHEF_V2;
+
+    uint256 internal unlocked;
+    modifier lock() {
+        require(unlocked == 1, "LOCKED");
+        unlocked = 2;
+        _;
+        unlocked = 1;
+    }
+
+    event LogOnReward(address indexed user, uint256 indexed pid, uint256 amount, address indexed to);
+    event LogPoolAddition(uint256 indexed pid, uint256 allocPoint);
+    event LogSetPool(uint256 indexed pid, uint256 allocPoint);
+    event LogUpdatePool(uint256 indexed pid, uint64 lastRewardTime, uint256 lpSupply, uint256 accSushiPerShare);
+    event LogRewardPerSecond(uint256 rewardPerSecond);
+    event LogInit();
+
+    constructor(
+        IERC20 _rewardToken,
+        uint256 _rewardPerSecond,
+        address _MASTERCHEF_V2
+    ) public {
+        rewardToken = _rewardToken;
+        rewardPerSecond = _rewardPerSecond;
+        MASTERCHEF_V2 = _MASTERCHEF_V2;
+        unlocked = 1;
+    }
+
+    function onSushiReward(
+        uint256 pid,
+        address _user,
+        address to,
+        uint256,
+        uint256 lpToken
+    ) external override onlyMCV2 lock {
+        PoolInfo memory pool = updatePool(pid);
+        UserInfo storage user = userInfo[pid][_user];
+        uint256 pending;
+        if (user.amount > 0) {
+            pending = (user.amount.mul(pool.accSushiPerShare) / ACC_TOKEN_PRECISION).sub(user.rewardDebt).add(
+                user.unpaidRewards
+            );
+            uint256 balance = rewardToken.balanceOf(address(this));
+            if (pending > balance) {
+                rewardToken.safeTransfer(to, balance);
+                user.unpaidRewards = pending - balance;
+            } else {
+                rewardToken.safeTransfer(to, pending);
+                user.unpaidRewards = 0;
+            }
+        }
+        user.amount = lpToken;
+        user.rewardDebt = lpToken.mul(pool.accSushiPerShare) / ACC_TOKEN_PRECISION;
+        emit LogOnReward(_user, pid, pending - user.unpaidRewards, to);
+    }
+
+    function pendingTokens(
+        uint256 pid,
+        address user,
+        uint256
+    ) external view override returns (IERC20[] memory rewardTokens, uint256[] memory rewardAmounts) {
+        IERC20[] memory _rewardTokens = new IERC20[](1);
+        _rewardTokens[0] = (rewardToken);
+        uint256[] memory _rewardAmounts = new uint256[](1);
+        _rewardAmounts[0] = pendingToken(pid, user);
+        return (_rewardTokens, _rewardAmounts);
+    }
+
+    /// @notice Sets the sushi per second to be distributed. Can only be called by the owner.
+    /// @param _rewardPerSecond The amount of Sushi to be distributed per second.
+    function setRewardPerSecond(uint256 _rewardPerSecond) public onlyOwner {
+        rewardPerSecond = _rewardPerSecond;
+        emit LogRewardPerSecond(_rewardPerSecond);
+    }
+
+    modifier onlyMCV2 {
+        require(msg.sender == MASTERCHEF_V2, "Only MCV2 can call this function.");
+        _;
+    }
+
+    /// @notice Returns the number of MCV2 pools.
+    function poolLength() public view returns (uint256 pools) {
+        pools = poolIds.length;
+    }
+
+    /// @notice Add a new LP to the pool. Can only be called by the owner.
+    /// DO NOT add the same LP token more than once. Rewards will be messed up if you do.
+    /// @param allocPoint AP of the new pool.
+    /// @param _pid Pid on MCV2
+    function add(uint256 allocPoint, uint256 _pid) public onlyOwner {
+        require(poolInfo[_pid].lastRewardTime == 0, "Pool already exists");
+        uint256 lastRewardTime = block.timestamp;
+        totalAllocPoint = totalAllocPoint.add(allocPoint);
+
+        poolInfo[_pid] = PoolInfo({
+            allocPoint: allocPoint.to64(),
+            lastRewardTime: lastRewardTime.to64(),
+            accSushiPerShare: 0
+        });
+        poolIds.push(_pid);
+        emit LogPoolAddition(_pid, allocPoint);
+    }
+
+    /// @notice Update the given pool's SUSHI allocation point and `IRewarder` contract. Can only be called by the owner.
+    /// @param _pid The index of the pool. See `poolInfo`.
+    /// @param _allocPoint New AP of the pool.
+    function set(uint256 _pid, uint256 _allocPoint) public onlyOwner {
+        totalAllocPoint = totalAllocPoint.sub(poolInfo[_pid].allocPoint).add(_allocPoint);
+        poolInfo[_pid].allocPoint = _allocPoint.to64();
+        emit LogSetPool(_pid, _allocPoint);
+    }
+
+    /// @notice Allows owner to reclaim/withdraw any tokens (including reward tokens) held by this contract
+    /// @param token Token to reclaim, use 0x00 for Ethereum
+    /// @param amount Amount of tokens to reclaim
+    /// @param to Receiver of the tokens, first of his name, rightful heir to the lost tokens,
+    /// reightful owner of the extra tokens, and ether, protector of mistaken transfers, mother of token reclaimers,
+    /// the Khaleesi of the Great Token Sea, the Unburnt, the Breaker of blockchains.
+    function reclaimTokens(
+        address token,
+        uint256 amount,
+        address payable to
+    ) public onlyOwner {
+        if (token == address(0)) {
+            to.transfer(amount);
+        } else {
+            IERC20(token).safeTransfer(to, amount);
+        }
+    }
+
+    /// @notice View function to see pending Token
+    /// @param _pid The index of the pool. See `poolInfo`.
+    /// @param _user Address of user.
+    /// @return pending SUSHI reward for a given user.
+    function pendingToken(uint256 _pid, address _user) public view returns (uint256 pending) {
+        PoolInfo memory pool = poolInfo[_pid];
+        UserInfo storage user = userInfo[_pid][_user];
+        uint256 accSushiPerShare = pool.accSushiPerShare;
+        uint256 lpSupply = MasterChefV2(MASTERCHEF_V2).lpToken(_pid).balanceOf(MASTERCHEF_V2);
+        if (block.timestamp > pool.lastRewardTime && lpSupply != 0) {
+            uint256 time = block.timestamp.sub(pool.lastRewardTime);
+            uint256 sushiReward = time.mul(rewardPerSecond).mul(pool.allocPoint) / totalAllocPoint;
+            accSushiPerShare = accSushiPerShare.add(sushiReward.mul(ACC_TOKEN_PRECISION) / lpSupply);
+        }
+        pending = (user.amount.mul(accSushiPerShare) / ACC_TOKEN_PRECISION).sub(user.rewardDebt).add(
+            user.unpaidRewards
+        );
+    }
+
+    /// @notice Update reward variables for all pools. Be careful of gas spending!
+    /// @param pids Pool IDs of all to be updated. Make sure to update all active pools.
+    function massUpdatePools(uint256[] calldata pids) external {
+        uint256 len = pids.length;
+        for (uint256 i = 0; i < len; ++i) {
+            updatePool(pids[i]);
+        }
+    }
+
+    /// @notice Update reward variables of the given pool.
+    /// @param pid The index of the pool. See `poolInfo`.
+    /// @return pool Returns the pool that was updated.
+    function updatePool(uint256 pid) public returns (PoolInfo memory pool) {
+        pool = poolInfo[pid];
+        if (block.timestamp > pool.lastRewardTime) {
+            uint256 lpSupply = MasterChefV2(MASTERCHEF_V2).lpToken(pid).balanceOf(MASTERCHEF_V2);
+
+            if (lpSupply > 0) {
+                uint256 time = block.timestamp.sub(pool.lastRewardTime);
+                uint256 sushiReward = time.mul(rewardPerSecond).mul(pool.allocPoint) / totalAllocPoint;
+                pool.accSushiPerShare = pool.accSushiPerShare.add(
+                    (sushiReward.mul(ACC_TOKEN_PRECISION) / lpSupply).to128()
+                );
+            }
+            pool.lastRewardTime = block.timestamp.to64();
+            poolInfo[pid] = pool;
+            emit LogUpdatePool(pid, pool.lastRewardTime, lpSupply, pool.accSushiPerShare);
+        }
+    }
+}

--- a/contracts/bridge/rewarder/BonusRewarder.sol
+++ b/contracts/bridge/rewarder/BonusRewarder.sol
@@ -35,9 +35,9 @@ contract BonusRewarder is IRewarder, BoringOwnable {
     ▏*║                        CONSTANTS & IMMUTABLES                        ║*▕
     \*╚══════════════════════════════════════════════════════════════════════╝*/
 
-    uint256 private constant ACC_TOKEN_PRECISION = 1e12;
+    uint256 internal constant ACC_TOKEN_PRECISION = 1e12;
 
-    address private immutable miniChefV2;
+    address public immutable miniChefV2;
 
     /// @notice Address of the bonus reward token
     IERC20 public immutable rewardToken;
@@ -54,7 +54,7 @@ contract BonusRewarder is IRewarder, BoringOwnable {
     /// @notice Info of each user that stakes LP tokens.
     mapping(uint256 => mapping(address => UserInfo)) public userInfo;
     /// @dev Total allocation points. Must be the sum of all allocation points in all pools.
-    uint256 totalAllocPoint;
+    uint256 public totalAllocPoint;
 
     uint256 public rewardPerSecond;
 
@@ -138,7 +138,7 @@ contract BonusRewarder is IRewarder, BoringOwnable {
     /// DO NOT add the same LP token more than once. Rewards will be messed up if you do.
     /// @param allocPoint AP of the new pool.
     /// @param _pid Pid on MCV2
-    function add(uint256 allocPoint, uint256 _pid) public onlyOwner {
+    function add(uint256 allocPoint, uint256 _pid) external onlyOwner {
         require(poolInfo[_pid].lastRewardTime == 0, "Pool already exists");
         uint256 lastRewardTime = block.timestamp;
         totalAllocPoint = totalAllocPoint.add(allocPoint);
@@ -155,7 +155,7 @@ contract BonusRewarder is IRewarder, BoringOwnable {
     /// @notice Update the given pool's rewardToken allocation point and `IRewarder` contract. Can only be called by the owner.
     /// @param _pid The index of the pool. See `poolInfo`.
     /// @param _allocPoint New AP of the pool.
-    function set(uint256 _pid, uint256 _allocPoint) public onlyOwner {
+    function set(uint256 _pid, uint256 _allocPoint) external onlyOwner {
         totalAllocPoint = totalAllocPoint.sub(poolInfo[_pid].allocPoint).add(_allocPoint);
         poolInfo[_pid].allocPoint = _allocPoint.to64();
         emit LogSetPool(_pid, _allocPoint);
@@ -171,7 +171,7 @@ contract BonusRewarder is IRewarder, BoringOwnable {
         address token,
         uint256 amount,
         address payable to
-    ) public onlyOwner {
+    ) external onlyOwner {
         if (token == address(0)) {
             to.transfer(amount);
         } else {
@@ -181,7 +181,7 @@ contract BonusRewarder is IRewarder, BoringOwnable {
 
     /// @notice Sets the rewardToken per second to be distributed. Can only be called by the owner.
     /// @param _rewardPerSecond The amount of rewardToken to be distributed per second.
-    function setRewardPerSecond(uint256 _rewardPerSecond) public onlyOwner {
+    function setRewardPerSecond(uint256 _rewardPerSecond) external onlyOwner {
         rewardPerSecond = _rewardPerSecond;
         emit LogRewardPerSecond(_rewardPerSecond);
     }
@@ -237,7 +237,7 @@ contract BonusRewarder is IRewarder, BoringOwnable {
     }
 
     /// @notice Returns the number of MCV2 pools.
-    function poolLength() public view returns (uint256 pools) {
+    function poolLength() external view returns (uint256 pools) {
         pools = poolIds.length;
     }
 

--- a/contracts/bridge/rewarder/BonusRewarder.sol
+++ b/contracts/bridge/rewarder/BonusRewarder.sol
@@ -6,7 +6,7 @@ import "../interfaces/IRewarder.sol";
 import "@boringcrypto/boring-solidity/contracts/libraries/BoringERC20.sol";
 import "@boringcrypto/boring-solidity/contracts/libraries/BoringMath.sol";
 import "@boringcrypto/boring-solidity/contracts/BoringOwnable.sol";
-import "../MasterChefV2.sol";
+import "../MiniChefV2.sol";
 
 /// @author @0xKeno
 contract BonusRewarder is IRewarder, BoringOwnable {
@@ -47,7 +47,7 @@ contract BonusRewarder is IRewarder, BoringOwnable {
     uint256 public rewardPerSecond;
     uint256 private constant ACC_TOKEN_PRECISION = 1e12;
 
-    address private immutable MASTERCHEF_V2;
+    address private immutable miniChefV2;
 
     uint256 internal unlocked;
     modifier lock() {
@@ -67,11 +67,11 @@ contract BonusRewarder is IRewarder, BoringOwnable {
     constructor(
         IERC20 _rewardToken,
         uint256 _rewardPerSecond,
-        address _MASTERCHEF_V2
+        address _miniChefV2
     ) public {
         rewardToken = _rewardToken;
         rewardPerSecond = _rewardPerSecond;
-        MASTERCHEF_V2 = _MASTERCHEF_V2;
+        miniChefV2 = _miniChefV2;
         unlocked = 1;
     }
 
@@ -122,8 +122,8 @@ contract BonusRewarder is IRewarder, BoringOwnable {
         emit LogRewardPerSecond(_rewardPerSecond);
     }
 
-    modifier onlyMCV2 {
-        require(msg.sender == MASTERCHEF_V2, "Only MCV2 can call this function.");
+    modifier onlyMCV2() {
+        require(msg.sender == miniChefV2, "Only MCV2 can call this function");
         _;
     }
 
@@ -185,7 +185,7 @@ contract BonusRewarder is IRewarder, BoringOwnable {
         PoolInfo memory pool = poolInfo[_pid];
         UserInfo storage user = userInfo[_pid][_user];
         uint256 accSushiPerShare = pool.accSushiPerShare;
-        uint256 lpSupply = MasterChefV2(MASTERCHEF_V2).lpToken(_pid).balanceOf(MASTERCHEF_V2);
+        uint256 lpSupply = MiniChefV2(miniChefV2).lpToken(_pid).balanceOf(miniChefV2);
         if (block.timestamp > pool.lastRewardTime && lpSupply != 0) {
             uint256 time = block.timestamp.sub(pool.lastRewardTime);
             uint256 sushiReward = time.mul(rewardPerSecond).mul(pool.allocPoint) / totalAllocPoint;
@@ -211,7 +211,7 @@ contract BonusRewarder is IRewarder, BoringOwnable {
     function updatePool(uint256 pid) public returns (PoolInfo memory pool) {
         pool = poolInfo[pid];
         if (block.timestamp > pool.lastRewardTime) {
-            uint256 lpSupply = MasterChefV2(MASTERCHEF_V2).lpToken(pid).balanceOf(MASTERCHEF_V2);
+            uint256 lpSupply = MiniChefV2(miniChefV2).lpToken(pid).balanceOf(miniChefV2);
 
             if (lpSupply > 0) {
                 uint256 time = block.timestamp.sub(pool.lastRewardTime);

--- a/contracts/bridge/rewarder/BonusRewarder.sol
+++ b/contracts/bridge/rewarder/BonusRewarder.sol
@@ -262,11 +262,10 @@ contract BonusRewarder is IRewarder, BoringOwnable {
         address user,
         uint256
     ) external view override returns (IERC20[] memory rewardTokens, uint256[] memory rewardAmounts) {
-        IERC20[] memory _rewardTokens = new IERC20[](1);
-        _rewardTokens[0] = (rewardToken);
-        uint256[] memory _rewardAmounts = new uint256[](1);
-        _rewardAmounts[0] = pendingToken(pid, user);
-        return (_rewardTokens, _rewardAmounts);
+        rewardTokens = new IERC20[](1);
+        rewardTokens[0] = (rewardToken);
+        rewardAmounts = new uint256[](1);
+        rewardAmounts[0] = pendingToken(pid, user);
     }
 
     /// @notice Returns the number of MCV2 pools.

--- a/contracts/bridge/rewarder/BonusRewarder.sol
+++ b/contracts/bridge/rewarder/BonusRewarder.sol
@@ -67,6 +67,8 @@ contract BonusRewarder is IRewarder, BoringOwnable {
     uint256 public totalAllocPoint;
     /// @notice Amount of rewardToken emitted per second
     uint256 public rewardPerSecond;
+    /// @notice Timestamp when the bonus rewards will be stopped
+    uint256 public rewardDeadline;
     /// @dev Flag indicating that a lock-protected function is entered.
     uint256 internal unlocked;
 
@@ -79,6 +81,7 @@ contract BonusRewarder is IRewarder, BoringOwnable {
     event LogSetPool(uint256 indexed pid, uint256 allocPoint);
     event LogUpdatePool(uint256 indexed pid, uint64 lastRewardTime, uint256 lpSupply, uint256 accRewardsPerShare);
     event LogRewardPerSecond(uint256 rewardPerSecond);
+    event LogRewardDeadline(uint256 rewardDeadline);
     event LogInit();
 
     /*╔══════════════════════════════════════════════════════════════════════╗*\
@@ -93,6 +96,8 @@ contract BonusRewarder is IRewarder, BoringOwnable {
         rewardToken = _rewardToken;
         rewardPerSecond = _rewardPerSecond;
         miniChefV2 = _miniChefV2;
+        // Bonus rewards are not time limited by default
+        rewardDeadline = type(uint256).max;
         unlocked = 1;
     }
 
@@ -218,6 +223,11 @@ contract BonusRewarder is IRewarder, BoringOwnable {
     function setRewardPerSecond(uint256 _rewardPerSecond) external onlyOwner {
         rewardPerSecond = _rewardPerSecond;
         emit LogRewardPerSecond(_rewardPerSecond);
+    }
+
+    function setRewardDeadline(uint256 _rewardDeadline) external onlyOwner {
+        rewardDeadline = _rewardDeadline;
+        emit LogRewardDeadline(_rewardDeadline);
     }
 
     /*╔══════════════════════════════════════════════════════════════════════╗*\

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 optimizer = true
 optimizer_runs = 200
 auto_detect_solc = true
@@ -7,12 +7,12 @@ out = "artifacts"
 libs = ["node_modules"]
 
 ## set only when the `hardhat` profile is selected
-[hardhat]
+[profile.hardhat]
 src = "contracts"
 out = "artifacts"
 libs = ["node_modules"]
 
-[ci]
+[profile.ci]
 verbosity = 4
 
 # See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -163,6 +163,15 @@ let config: HardhatUserConfig = {
           },
         },
       },
+      {
+        version: "0.8.17",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 5000000, // see: https://github.com/ethereum/solidity/issues/5394#issue-379536332
+          },
+        },
+      },
     ],
   },
   namedAccounts: {


### PR DESCRIPTION
## Description

Adds `BonusRewarder`, a `MinChefV2` extension enabling double rewards for any of the pools present in `MiniChefV2`.

Every pool in MiniChef can be assigned allocation points for the bonus rewards. In order to opt in for the bonus rewards, user will have to interact with `MiniChefV2` after the bonus rewarder was added.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
