### PR TITLE
Mock swap

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "solidity.packageDefaultDependenciesContractsDirectory": "",
   "solidity.packageDefaultDependenciesDirectory": "node_modules",
-  "solidity.compileUsingRemoteVersion": "v0.8.13",
   "search.exclude": { "lib": true }
 }

--- a/contracts/bridge/wrappers/swap/MockSwap.sol
+++ b/contracts/bridge/wrappers/swap/MockSwap.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+contract MockSwap {
+    function calculateSwap(
+        uint8,
+        uint8,
+        uint256
+    ) external pure returns (uint256) {
+        return 0;
+    }
+
+    function swap(
+        uint8,
+        uint8,
+        uint256,
+        uint256,
+        uint256
+    ) external payable returns (uint256) {
+        // Using payable saves a bit of gas here
+        // We always revert, so this will not lead to locked ether
+        revert("");
+    }
+}

--- a/deploy/100_deploy_MockSwap.ts
+++ b/deploy/100_deploy_MockSwap.ts
@@ -1,0 +1,21 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { CHAIN_ID } from "../utils/network";
+import { includes } from "lodash";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre;
+  const { deploy, get, execute } = deployments;
+  const { deployer } = await getNamedAccounts();
+
+  if (includes([CHAIN_ID.FANTOM, CHAIN_ID.KLATYN], await getChainId())) {
+    await deploy("MockSwap", {
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    });
+  }
+};
+
+export default func;
+func.tags = ["MockSwap"];

--- a/deployments/fantom/MockSwap.json
+++ b/deployments/fantom/MockSwap.json
@@ -1,0 +1,108 @@
+{
+  "address": "0xFD7FD973010EBA29108049aAc9A8Ff297A1B7e58",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "calculateSwap",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "swap",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0x1622e646df346f2f3e1311e3fda5873642de0c87fe7916526301de39187358c5",
+  "receipt": {
+    "to": null,
+    "from": "0xb104bCbFe8B143804d8cfE92e9f100a3270D1E55",
+    "contractAddress": "0xFD7FD973010EBA29108049aAc9A8Ff297A1B7e58",
+    "transactionIndex": 36,
+    "gasUsed": "118999",
+    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "blockHash": "0x0002b0a600000455ddf20b18f3dee93ea0977627244f3c786f80acc9d543fe53",
+    "transactionHash": "0x1622e646df346f2f3e1311e3fda5873642de0c87fe7916526301de39187358c5",
+    "logs": [],
+    "blockNumber": 52029806,
+    "cumulativeGasUsed": "3824392",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [],
+  "solcInputHash": "758096ecd3d06e06616ed8b113dfbf80",
+  "metadata": "{\"compiler\":{\"version\":\"0.6.12+commit.27d51765\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"calculateSwap\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"swap\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"payable\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/bridge/wrappers/swap/MockSwap.sol\":\"MockSwap\"},\"evmVersion\":\"istanbul\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":10000},\"remappings\":[]},\"sources\":{\"contracts/bridge/wrappers/swap/MockSwap.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity 0.6.12;\\n\\ncontract MockSwap {\\n    function calculateSwap(\\n        uint8,\\n        uint8,\\n        uint256\\n    ) external pure returns (uint256) {\\n        return 0;\\n    }\\n\\n    function swap(\\n        uint8,\\n        uint8,\\n        uint256,\\n        uint256,\\n        uint256\\n    ) external payable returns (uint256) {\\n        // Using payable saves a bit of gas here\\n        // We always revert, so this will not lead to locked ether\\n        revert(\\\"\\\");\\n    }\\n}\\n\",\"keccak256\":\"0xdf90f5b3819480aaf287c72cbb2ecb0506b1c4ec163e2ba1005adbb3fe65b319\",\"license\":\"MIT\"}},\"version\":1}",
+  "bytecode": "0x608060405234801561001057600080fd5b50610131806100206000396000f3fe60806040526004361060265760003560e01c80639169558614602b578063a95b089f146076575b600080fd5b6064600480360360a0811015603f57600080fd5b5060ff81358116916020810135909116906040810135906060810135906080013560af565b60408051918252519081900360200190f35b348015608157600080fd5b50606460048036036060811015609657600080fd5b5060ff81358116916020810135909116906040013560f2565b604080517f08c379a00000000000000000000000000000000000000000000000000000000081526020600482015260006024820181905291519081900360640190fd5b6000939250505056fea26469706673582212203e9babea9ee5d1c0b25685288489501736e4c992e7346893236352828c95eaa564736f6c634300060c0033",
+  "deployedBytecode": "0x60806040526004361060265760003560e01c80639169558614602b578063a95b089f146076575b600080fd5b6064600480360360a0811015603f57600080fd5b5060ff81358116916020810135909116906040810135906060810135906080013560af565b60408051918252519081900360200190f35b348015608157600080fd5b50606460048036036060811015609657600080fd5b5060ff81358116916020810135909116906040013560f2565b604080517f08c379a00000000000000000000000000000000000000000000000000000000081526020600482015260006024820181905291519081900360640190fd5b6000939250505056fea26469706673582212203e9babea9ee5d1c0b25685288489501736e4c992e7346893236352828c95eaa564736f6c634300060c0033",
+  "devdoc": {
+    "kind": "dev",
+    "methods": {},
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {},
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [],
+    "types": null
+  }
+}

--- a/deployments/fantom/solcInputs/758096ecd3d06e06616ed8b113dfbf80.json
+++ b/deployments/fantom/solcInputs/758096ecd3d06e06616ed8b113dfbf80.json
@@ -1,0 +1,37 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "contracts/bridge/wrappers/swap/MockSwap.sol": {
+      "content": "// SPDX-License-Identifier: MIT\n\npragma solidity 0.6.12;\n\ncontract MockSwap {\n    function calculateSwap(\n        uint8,\n        uint8,\n        uint256\n    ) external pure returns (uint256) {\n        return 0;\n    }\n\n    function swap(\n        uint8,\n        uint8,\n        uint256,\n        uint256,\n        uint256\n    ) external payable returns (uint256) {\n        // Using payable saves a bit of gas here\n        // We always revert, so this will not lead to locked ether\n        revert(\"\");\n    }\n}\n"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "enabled": true,
+      "runs": 10000
+    },
+    "outputSelection": {
+      "*": {
+        "*": [
+          "abi",
+          "evm.bytecode",
+          "evm.deployedBytecode",
+          "evm.methodIdentifiers",
+          "metadata",
+          "devdoc",
+          "userdoc",
+          "storageLayout",
+          "evm.gasEstimates",
+          "devdoc",
+          "userdoc"
+        ],
+        "": [
+          "ast"
+        ]
+      }
+    },
+    "metadata": {
+      "useLiteralContent": true
+    }
+  }
+}

--- a/deployments/klatyn/MockSwap.json
+++ b/deployments/klatyn/MockSwap.json
@@ -1,0 +1,108 @@
+{
+  "address": "0x0150E4bb98422f3b38aE8524E0cE0B7E734923eB",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "calculateSwap",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "swap",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0x31d53f227f54d4b2cd1c2db3a10a2bc39883597cd199ca858f1591f8cfd33722",
+  "receipt": {
+    "to": null,
+    "from": "0xb104bCbFe8B143804d8cfE92e9f100a3270D1E55",
+    "contractAddress": "0x0150E4bb98422f3b38aE8524E0cE0B7E734923eB",
+    "transactionIndex": 5,
+    "gasUsed": "147811",
+    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "blockHash": "0x74420db3103eff5195e8dad7c0a63cb16ce0a5b149141a806e62f363425703ec",
+    "transactionHash": "0x31d53f227f54d4b2cd1c2db3a10a2bc39883597cd199ca858f1591f8cfd33722",
+    "logs": [],
+    "blockNumber": 108605481,
+    "cumulativeGasUsed": "1556601",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [],
+  "solcInputHash": "758096ecd3d06e06616ed8b113dfbf80",
+  "metadata": "{\"compiler\":{\"version\":\"0.6.12+commit.27d51765\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"calculateSwap\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"swap\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"payable\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/bridge/wrappers/swap/MockSwap.sol\":\"MockSwap\"},\"evmVersion\":\"istanbul\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":10000},\"remappings\":[]},\"sources\":{\"contracts/bridge/wrappers/swap/MockSwap.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity 0.6.12;\\n\\ncontract MockSwap {\\n    function calculateSwap(\\n        uint8,\\n        uint8,\\n        uint256\\n    ) external pure returns (uint256) {\\n        return 0;\\n    }\\n\\n    function swap(\\n        uint8,\\n        uint8,\\n        uint256,\\n        uint256,\\n        uint256\\n    ) external payable returns (uint256) {\\n        // Using payable saves a bit of gas here\\n        // We always revert, so this will not lead to locked ether\\n        revert(\\\"\\\");\\n    }\\n}\\n\",\"keccak256\":\"0xdf90f5b3819480aaf287c72cbb2ecb0506b1c4ec163e2ba1005adbb3fe65b319\",\"license\":\"MIT\"}},\"version\":1}",
+  "bytecode": "0x608060405234801561001057600080fd5b50610131806100206000396000f3fe60806040526004361060265760003560e01c80639169558614602b578063a95b089f146076575b600080fd5b6064600480360360a0811015603f57600080fd5b5060ff81358116916020810135909116906040810135906060810135906080013560af565b60408051918252519081900360200190f35b348015608157600080fd5b50606460048036036060811015609657600080fd5b5060ff81358116916020810135909116906040013560f2565b604080517f08c379a00000000000000000000000000000000000000000000000000000000081526020600482015260006024820181905291519081900360640190fd5b6000939250505056fea26469706673582212203e9babea9ee5d1c0b25685288489501736e4c992e7346893236352828c95eaa564736f6c634300060c0033",
+  "deployedBytecode": "0x60806040526004361060265760003560e01c80639169558614602b578063a95b089f146076575b600080fd5b6064600480360360a0811015603f57600080fd5b5060ff81358116916020810135909116906040810135906060810135906080013560af565b60408051918252519081900360200190f35b348015608157600080fd5b50606460048036036060811015609657600080fd5b5060ff81358116916020810135909116906040013560f2565b604080517f08c379a00000000000000000000000000000000000000000000000000000000081526020600482015260006024820181905291519081900360640190fd5b6000939250505056fea26469706673582212203e9babea9ee5d1c0b25685288489501736e4c992e7346893236352828c95eaa564736f6c634300060c0033",
+  "devdoc": {
+    "kind": "dev",
+    "methods": {},
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {},
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [],
+    "types": null
+  }
+}

--- a/deployments/klatyn/solcInputs/758096ecd3d06e06616ed8b113dfbf80.json
+++ b/deployments/klatyn/solcInputs/758096ecd3d06e06616ed8b113dfbf80.json
@@ -1,0 +1,37 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "contracts/bridge/wrappers/swap/MockSwap.sol": {
+      "content": "// SPDX-License-Identifier: MIT\n\npragma solidity 0.6.12;\n\ncontract MockSwap {\n    function calculateSwap(\n        uint8,\n        uint8,\n        uint256\n    ) external pure returns (uint256) {\n        return 0;\n    }\n\n    function swap(\n        uint8,\n        uint8,\n        uint256,\n        uint256,\n        uint256\n    ) external payable returns (uint256) {\n        // Using payable saves a bit of gas here\n        // We always revert, so this will not lead to locked ether\n        revert(\"\");\n    }\n}\n"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "enabled": true,
+      "runs": 10000
+    },
+    "outputSelection": {
+      "*": {
+        "*": [
+          "abi",
+          "evm.bytecode",
+          "evm.deployedBytecode",
+          "evm.methodIdentifiers",
+          "metadata",
+          "devdoc",
+          "userdoc",
+          "storageLayout",
+          "evm.gasEstimates",
+          "devdoc",
+          "userdoc"
+        ],
+        "": [
+          "ast"
+        ]
+      }
+    },
+    "metadata": {
+      "useLiteralContent": true
+    }
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 optimizer = true
 optimizer_runs = 200
 auto_detect_solc = true
@@ -7,12 +7,12 @@ out = "artifacts"
 libs = ["node_modules"]
 
 ## set only when the `hardhat` profile is selected
-[hardhat]
+[profile.hardhat]
 src = "contracts"
 out = "artifacts"
 libs = ["node_modules"]
 
-[ci]
+[profile.ci]
 verbosity = 4
 
 # See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/test/bridge/wrappers/MockSwap.t.sol
+++ b/test/bridge/wrappers/MockSwap.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+import "forge-std/Test.sol";
+
+import "../../../contracts/bridge/wrappers/swap/MockSwap.sol";
+import "../../../contracts/bridge/SynapseBridge.sol";
+import "../../../contracts/bridge/SynapseERC20.sol";
+
+//solhint-disable func-name-mixedcase
+contract MockSwapTest is Test {
+    MockSwap internal mockSwap;
+    SynapseBridge internal bridge;
+    SynapseERC20 internal token;
+
+    address payable internal constant USER = address(123456);
+
+    function setUp() public {
+        mockSwap = new MockSwap();
+        bridge = new SynapseBridge();
+        bridge.initialize();
+        bridge.grantRole(bridge.NODEGROUP_ROLE(), address(this));
+
+        token = new SynapseERC20();
+        token.initialize("TOKEN", "TOKEN", 18, address(this));
+        token.grantRole(token.MINTER_ROLE(), address(bridge));
+    }
+
+    function test_calculateSwap(
+        uint8 a,
+        uint8 b,
+        uint256 c
+    ) public {
+        assertEq(mockSwap.calculateSwap(a, b, c), 0);
+    }
+
+    function test_swap(
+        uint8 a,
+        uint8 b,
+        uint256 c,
+        uint256 d,
+        uint256 e
+    ) public {
+        vm.expectRevert(bytes(""));
+        mockSwap.swap(a, b, c, d, e);
+    }
+
+    function test_mintAndSwap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 minDy,
+        uint256 deadline,
+        bytes32 kappa
+    ) public {
+        uint256 amount = 10**18;
+        uint256 fee = 10**15;
+        // Should work with any values for the fuzzed params
+        bridge.mintAndSwap(
+            USER,
+            IERC20Mintable(address(token)),
+            amount,
+            fee,
+            ISwap(address(mockSwap)),
+            tokenIndexFrom,
+            tokenIndexTo,
+            minDy,
+            deadline,
+            kappa
+        );
+        assertTrue(bridge.kappaExists(kappa), "!kappaExists");
+        assertEq(bridge.getFeeBalance(address(token)), fee, "!fees");
+        assertEq(token.balanceOf(USER), amount - fee, "!user balance");
+    }
+}


### PR DESCRIPTION
## Description

Setting `MockSwap` as the liquidity pool for a bridge token will allow to resolve all transactions with incorrect swap parameters. Could be deployed once per chain, and be reused for any of the bridged tokens on that chain.

A slight rework of 74dad49edfcc315c55fc38bb1e013b31e4df439b:
- More appropriate universal name
- Consumes a bit less gas
- Comes with a Foundry test :)

## Checklist

- [x] New Contracts have been tested
- [x] Lint has been run
- [x] I have checked my code and corrected any misspellings
