### PR TITLE
Fix: fork tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,7 @@ jobs:
   foundry-base:
     runs-on: ubuntu-latest
     env:
-      FOUNDRY_FUZZ_RUNS: 64
+      FOUNDRY_FUZZ_RUNS: 2000
 
     steps:
       - uses: actions/checkout@v3

--- a/scripts/foundry-fork.sh
+++ b/scripts/foundry-fork.sh
@@ -2,22 +2,3 @@
 
 # Test contracts ending with exactly "TestFork" read env variables using cheatcodes
 forge test --match-contract "$1.*TestFork$" -vvv || exit 1
-
-#TODO: fork tests should read env variables using cheatcodes
-# Test contracts ending with exactly "TestAvax" require Avalanche RPC and block number: 2022-04-25
-forge test --match-contract "$1.*TestAvax$" --fork-url $AVAX_API --fork-block-number 13897000 -vvv || exit 1
-
-# Test contracts ending with exactly "TestEth" require Ethereum RPC and block number: 2022-04-24
-forge test --match-contract "$1.*TestEth$" --fork-url $ALCHEMY_API --fork-block-number 14650000 -vvv || exit 1
-
-# Test contracts ending with exactly "TestArb" require Arbitrum RPC and block number: 2022-04-26
-forge test --match-contract "$1.*TestArb$" --fork-url $ARBITRUM_API --fork-block-number 10600000 -vvv || exit 1
-
-# Test contracts ending with exactly "TestOpt" require Optimism RPC and block number: 2022-04-26
-forge test --match-contract "$1.*TestOpt$" --fork-url $OPTIMISM_API --fork-block-number 6600000 -vvv || exit 1
-
-# Test contracts ending with exactly "TestMovr" require Moonriver RPC and block number: 2022-04-21
-forge test --match-contract "$1.*TestMovr$" --fork-url $MOVR_API --fork-block-number 1730000 -vvv || exit 1
-
-# Test contracts ending with exactly "TestCanto" require Canto RPC and block number: 2022-12-02
-forge test --match-contract "$1.*TestCanto$" --fork-url $CANTO_API --fork-block-number 1894000 -vvv || exit 1

--- a/test/bridge/klaytn/KlaytnSynapseBridge.t.sol
+++ b/test/bridge/klaytn/KlaytnSynapseBridge.t.sol
@@ -69,9 +69,9 @@ contract KlaytnSynapseBridgeTestFork is Test {
     event TokenWithdraw(address indexed to, IERC20 token, uint256 amount, uint256 fee, bytes32 indexed kappa);
 
     function setUp() public {
-        string memory cantoRPC = vm.envString("KLAY_API");
+        string memory klayRPC = vm.envString("KLAY_API");
         // Fork Klaytn for Bridge tests
-        vm.createSelectFork(cantoRPC, TEST_BLOCK_NUMBER);
+        vm.createSelectFork(klayRPC, TEST_BLOCK_NUMBER);
         utils = new Utilities();
         // Deploy 0.6.12 contracts, needs to be done via deployCode from 0.8.17 test
         unwrapper = IWKlayUnwrapper(deployCode("WKlayUnwrapper.sol", abi.encode(GOV)));

--- a/test/bridge/wrappers/swap/CantoSwapWrapper.t.sol
+++ b/test/bridge/wrappers/swap/CantoSwapWrapper.t.sol
@@ -19,8 +19,11 @@ interface ISynapseTest is ISynapse {
 
 // solhint-disable func-name-mixedcase
 // solhint-disable not-rely-on-time
-contract NewSwapWrapperTestCanto is Test {
+contract NewCantoSwapWrapperTestFork is Test {
     using SafeERC20 for IERC20;
+
+    // 2022-12-02
+    uint256 public constant TEST_BLOCK_NUMBER = 1_894_000;
 
     address internal constant NUSD = 0xD8836aF2e565D3Befce7D906Af63ee45a57E8f80;
     address internal constant NOTE = 0x4e71A2E537B7f9D9413D3991D37958c0b5e1e503;
@@ -36,6 +39,10 @@ contract NewSwapWrapperTestCanto is Test {
     CantoSwapWrapper internal swap;
 
     function setUp() public {
+        string memory cantoRPC = vm.envString("CANTO_API");
+        // Fork Canto for SwapWrapper tests
+        vm.createSelectFork(cantoRPC, TEST_BLOCK_NUMBER);
+
         vm.label(NUSD, "nUSD");
         vm.label(NOTE, "NOTE");
         vm.label(USDC, "USDC");

--- a/test/bridge/wrappers/swap/LegacyCantoSwapWrapper.t.sol
+++ b/test/bridge/wrappers/swap/LegacyCantoSwapWrapper.t.sol
@@ -13,8 +13,11 @@ interface ISynapseTest is ISynapse {
 
 // solhint-disable func-name-mixedcase
 // solhint-disable not-rely-on-time
-contract LegacySwapWrapperTestCanto is Test {
+contract LegacyCantoSwapWrapperTestFork is Test {
     using SafeERC20 for IERC20;
+
+    // 2022-12-02
+    uint256 public constant TEST_BLOCK_NUMBER = 1_894_000;
 
     address internal constant NUSD = 0xD8836aF2e565D3Befce7D906Af63ee45a57E8f80;
     address internal constant NOTE = 0x4e71A2E537B7f9D9413D3991D37958c0b5e1e503;
@@ -30,6 +33,10 @@ contract LegacySwapWrapperTestCanto is Test {
     LegacyCantoSwapWrapper internal swap;
 
     function setUp() public {
+        string memory cantoRPC = vm.envString("CANTO_API");
+        // Fork Canto for SwapWrapper tests
+        vm.createSelectFork(cantoRPC, TEST_BLOCK_NUMBER);
+
         swap = new LegacyCantoSwapWrapper();
         for (uint8 i = 0; i < COINS; ++i) {
             swap.getToken(i).safeApprove(address(swap), type(uint256).max);


### PR DESCRIPTION
## Description

- Fork tests are adjusted to use `vm.createSelectFork()` instead of relying on RPC URL to be provided in `forge test` command.
- Foundry scripts are adjusted
- Amount of fuzz runs in base tests increased to 2000 (these are quick anyway).

## Checklist

- [x] New Contracts have been tested
- [x] Lint has been run
- [x] I have checked my code and corrected any misspellings
