### PR TITLE
Feat: multicall view

### DIFF
--- a/contracts/bridge/router/SynapseRouter.sol
+++ b/contracts/bridge/router/SynapseRouter.sol
@@ -5,6 +5,7 @@ pragma experimental ABIEncoderV2;
 import "../interfaces/ISynapseBridge.sol";
 import "./LocalBridgeConfig.sol";
 import "./SynapseAdapter.sol";
+import "../utils/MulticallView.sol";
 
 /**
  * @notice SynapseRouter contract that can be used together with SynapseBridge on any chain.
@@ -30,7 +31,7 @@ import "./SynapseAdapter.sol";
  * // If tokenIn is WETH, do router.bridge{value: amount} to use native ETH instead of WETH.
  * Note: the transaction will be reverted, if `bridgeTokenO` is not set up in SynapseRouter.
  */
-contract SynapseRouter is LocalBridgeConfig, SynapseAdapter {
+contract SynapseRouter is LocalBridgeConfig, SynapseAdapter, MulticallView {
     // SynapseRouter is also the Adapter for the Synapse pools (this reduces the amount of token transfers).
     // SynapseRouter address will be used as swapAdapter in SwapQueries returned by a local SwapQuoter.
 

--- a/contracts/bridge/utils/MulticallView.sol
+++ b/contracts/bridge/utils/MulticallView.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+abstract contract MulticallView {
+    struct Result {
+        bool success;
+        bytes returnData;
+    }
+
+    /// @notice Aggregates a few static calls to this contract into one multicall.
+    /// Any of the calls could revert without having impact on other calls. That includes the scenario,
+    /// where a data for state modifying call was supplied, which would lead to one of the calls being reverted.
+    function multicallView(bytes[] memory data) external view returns (Result[] memory callResults) {
+        uint256 amount = data.length;
+        callResults = new Result[](amount);
+        for (uint256 i = 0; i < amount; ++i) {
+            (callResults[i].success, callResults[i].returnData) = address(this).staticcall(data[i]);
+        }
+    }
+}

--- a/contracts/bridge/utils/MulticallView.sol
+++ b/contracts/bridge/utils/MulticallView.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
+/// @notice Multicall utility for view/pure functions. Inspired by Multicall3:
+/// https://github.com/mds1/multicall/blob/master/src/Multicall3.sol
 abstract contract MulticallView {
     struct Result {
         bool success;
@@ -15,6 +17,10 @@ abstract contract MulticallView {
         uint256 amount = data.length;
         callResults = new Result[](amount);
         for (uint256 i = 0; i < amount; ++i) {
+            // We perform a static call to ourselves here. This will record `success` as false,
+            // should the static call be reverted. The other calls will still be performed regardless.
+            // Note: `success` will be set to false, if data for state modifying call was supplied.
+            // No data will be modified, as this is a view function.
             (callResults[i].success, callResults[i].returnData) = address(this).staticcall(data[i]);
         }
     }

--- a/test/bridge/utils/MulticallView.t.sol
+++ b/test/bridge/utils/MulticallView.t.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "../../utils/Utilities06.sol";
+import "../../../contracts/bridge/utils/MulticallView.sol";
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+contract MulticallHarness is MulticallView {
+    using SafeMath for uint256;
+
+    function add(uint256 a, uint256 b) external pure returns (uint256) {
+        return a.add(b);
+    }
+
+    function mul(uint256 a, uint256 b) external pure returns (uint256) {
+        return a.mul(b);
+    }
+}
+
+// solhint-disable func-name-mixedcase
+contract MulticallViewTest is Utilities06 {
+    MulticallHarness internal mc;
+
+    function setUp() public override {
+        super.setUp();
+        mc = new MulticallHarness();
+    }
+
+    function test_successCalls() public {
+        bytes[] memory calls = new bytes[](4);
+        calls[0] = _addCalldata(1, 2);
+        calls[1] = _mulCalldata(1, 2);
+        calls[2] = _addCalldata(21, 2);
+        calls[3] = _mulCalldata(4, 8);
+        MulticallView.Result[] memory results = mc.multicallView(calls);
+        assertEq(results.length, 4, "!length");
+        _checkResultSuccess(results[0], 1 + 2);
+        _checkResultSuccess(results[1], 1 * 2);
+        _checkResultSuccess(results[2], 21 + 2);
+        _checkResultSuccess(results[3], 4 * 8);
+    }
+
+    function test_failCalls() public {
+        bytes[] memory calls = new bytes[](4);
+        calls[0] = _addCalldata(type(uint256).max, type(uint256).max);
+        calls[1] = _addCalldata(60, 9);
+        calls[2] = _mulCalldata(type(uint256).max, type(uint256).max);
+        calls[3] = _mulCalldata(105, 4);
+        MulticallView.Result[] memory results = mc.multicallView(calls);
+        assertEq(results.length, 4, "!length");
+        _checkResultFail(results[0], "SafeMath: addition overflow");
+        _checkResultSuccess(results[1], 60 + 9);
+        _checkResultFail(results[2], "SafeMath: multiplication overflow");
+        _checkResultSuccess(results[3], 105 * 4);
+    }
+
+    function _checkResultFail(MulticallView.Result memory result, string memory revertMsg) internal {
+        assertFalse(result.success, "!fail");
+        assertEq(getRevertMsg(result.returnData), revertMsg, "!revertMessage");
+    }
+
+    function _checkResultSuccess(MulticallView.Result memory result, uint256 expectedValue) internal {
+        assertTrue(result.success, "!success");
+        // Should be exactly one uint256
+        assertEq(result.returnData.length, 32, "!returnData.length");
+        uint256 value = abi.decode(result.returnData, (uint256));
+        assertEq(value, expectedValue, "!returnData");
+    }
+
+    function _addCalldata(uint256 a, uint256 b) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(MulticallHarness.add.selector, a, b);
+    }
+
+    function _mulCalldata(uint256 a, uint256 b) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(MulticallHarness.mul.selector, a, b);
+    }
+}


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

Adds `multicallView()`: a function to aggregate view calls into one to save on RPC requests. Function being `view` makes it possible to use off-chain without using `.callStatic`

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
