### PR TITLE
Bitmasks for valid swap "actions"

### DIFF
--- a/contracts/bridge/interfaces/ISwapQuoter.sol
+++ b/contracts/bridge/interfaces/ISwapQuoter.sol
@@ -6,7 +6,7 @@ import "../libraries/BridgeStructs.sol";
 
 interface ISwapQuoter {
     function getAmountOut(
-        address tokenIn,
+        LimitedToken memory tokenIn,
         address tokenOut,
         uint256 amountIn
     ) external view returns (SwapQuery memory query);

--- a/contracts/bridge/libraries/BridgeStructs.sol
+++ b/contracts/bridge/libraries/BridgeStructs.sol
@@ -16,6 +16,14 @@ enum Action {
     HandleEth
 }
 
+/// @notice Struct representing a token, and the available Actions for performing a swap.
+/// @param actionMask   Bitmask representing what actions (see ActionLib) are available for swapping a token
+/// @param token        Token address
+struct LimitedToken {
+    uint256 actionMask;
+    address token;
+}
+
 struct SynapseParams {
     Action action;
     address pool;
@@ -32,4 +40,30 @@ struct Pool {
     address pool;
     address lpToken;
     PoolToken[] tokens;
+}
+
+library ActionLib {
+    function allActions() internal pure returns (uint256 actionMask) {
+        actionMask = type(uint256).max;
+    }
+
+    function includes(uint256 actionMask, Action action) internal pure returns (bool) {
+        return actionMask & mask(action) != 0;
+    }
+
+    function mask(Action action) internal pure returns (uint256) {
+        return 1 << uint256(action);
+    }
+
+    function mask(Action a, Action b) internal pure returns (uint256) {
+        return mask(a) | mask(b);
+    }
+
+    function mask(
+        Action a,
+        Action b,
+        Action c
+    ) internal pure returns (uint256) {
+        return mask(a) | mask(b) | mask(c);
+    }
 }

--- a/contracts/bridge/libraries/BridgeStructs.sol
+++ b/contracts/bridge/libraries/BridgeStructs.sol
@@ -1,6 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 
+/// @notice Struct representing a request for SynapseRouter.
+/// @dev tokenIn is supplied separately.
+/// @param swapAdapter      Adapter address that will perform the swap.
+/// @param tokenOut         Token address to swap to.
+/// @param minAmountOut     Minimum amount of tokens to receive after the swap, or tx will be reverted.
+/// @param deadline         Latest timestamp for when the transaction needs to be executed, or tx will be reverted.
+/// @param rawParams        ABI-encoded params for the swap that will be passed to `swapAdapter`.
+///                         Should be SynapseParams for swaps via SynapseAdapter.
 struct SwapQuery {
     address swapAdapter;
     address tokenOut;
@@ -9,11 +17,12 @@ struct SwapQuery {
     bytes rawParams;
 }
 
+/// @notice All possible actions that SynapseAdapter could perform.
 enum Action {
-    Swap,
-    AddLiquidity,
-    RemoveLiquidity,
-    HandleEth
+    Swap, // swap between two pools tokens
+    AddLiquidity, // add liquidity in a form of a single pool token
+    RemoveLiquidity, // remove liquidity in a form of a single pool token
+    HandleEth // ETH <> WETH interaction
 }
 
 /// @notice Struct representing a token, and the available Actions for performing a swap.
@@ -24,6 +33,11 @@ struct LimitedToken {
     address token;
 }
 
+/// @notice Struct representing parameters for swapping via SynapseAdapter.
+/// @param action           Action that SynapseAdapter needs to perform.
+/// @param pool             Liquidity pool that will be used for Swap/AddLiquidity/RemoveLiquidity actions.
+/// @param tokenIndexFrom   Token index to swap from. Used for swap/addLiquidity actions.
+/// @param tokenIndexTo     Token index to swap to. Used for swap/removeLiquidity actions.
 struct SynapseParams {
     Action action;
     address pool;
@@ -31,39 +45,43 @@ struct SynapseParams {
     uint8 tokenIndexTo;
 }
 
+/// @notice Struct representing how pool tokens are stored by `SwapQuoter`.
+/// @param isWeth   Whether the token represents Wrapped ETH.
+/// @param token    Token address.
 struct PoolToken {
     bool isWeth;
     address token;
 }
 
+/// @notice Struct representing a liquidity pool. Used as the return value in view functions.
+/// @param pool         Pool address.
+/// @param lpToken      Address of pool's LP token.
+/// @param tokens       List of pool's tokens.
 struct Pool {
     address pool;
     address lpToken;
     PoolToken[] tokens;
 }
 
+/// @notice Library for dealing with bit masks, describing what Actions are available.
 library ActionLib {
+    /// @notice Returns a bitmask with all possible actions set to True.
     function allActions() internal pure returns (uint256 actionMask) {
         actionMask = type(uint256).max;
     }
 
+    /// @notice Returns whether the given action is set to True in the bitmask.
     function includes(uint256 actionMask, Action action) internal pure returns (bool) {
         return actionMask & mask(action) != 0;
     }
 
+    /// @notice Returns a bitmask with only the given action set to True.
     function mask(Action action) internal pure returns (uint256) {
         return 1 << uint256(action);
     }
 
+    /// @notice Returns a bitmask with only two given actions set to True.
     function mask(Action a, Action b) internal pure returns (uint256) {
         return mask(a) | mask(b);
-    }
-
-    function mask(
-        Action a,
-        Action b,
-        Action c
-    ) internal pure returns (uint256) {
-        return mask(a) | mask(b) | mask(c);
     }
 }

--- a/contracts/bridge/router/SwapCalculator.sol
+++ b/contracts/bridge/router/SwapCalculator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-
 pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
 
 import "../interfaces/ISwap.sol";
 import "../interfaces/ISwapQuoter.sol";

--- a/contracts/bridge/router/SynapseAdapter.sol
+++ b/contracts/bridge/router/SynapseAdapter.sol
@@ -11,7 +11,7 @@ import "../libraries/UniversalToken.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-abstract contract SynapseAdapter is Ownable, ISwapAdapter, ISwapQuoter {
+abstract contract SynapseAdapter is Ownable, ISwapAdapter {
     using SafeERC20 for IERC20;
     using UniversalToken for address;
 
@@ -152,8 +152,10 @@ abstract contract SynapseAdapter is Ownable, ISwapAdapter, ISwapQuoter {
         address tokenIn,
         address tokenOut,
         uint256 amountIn
-    ) external view override returns (SwapQuery memory) {
-        return swapQuoter.getAmountOut(tokenIn, tokenOut, amountIn);
+    ) external view returns (SwapQuery memory) {
+        // All actions are allowed by default
+        LimitedToken memory _tokenIn = LimitedToken(ActionLib.allActions(), tokenIn);
+        return swapQuoter.getAmountOut(_tokenIn, tokenOut, amountIn);
     }
 
     /**
@@ -165,7 +167,7 @@ abstract contract SynapseAdapter is Ownable, ISwapAdapter, ISwapQuoter {
      *                  If a token charges a fee on transfers, use the amount that gets transferred after the fee.
      * @return LP token amount the user will receive
      */
-    function calculateAddLiquidity(address pool, uint256[] memory amounts) external view override returns (uint256) {
+    function calculateAddLiquidity(address pool, uint256[] memory amounts) external view returns (uint256) {
         return swapQuoter.calculateAddLiquidity(pool, amounts);
     }
 
@@ -183,7 +185,7 @@ abstract contract SynapseAdapter is Ownable, ISwapAdapter, ISwapQuoter {
         uint8 tokenIndexFrom,
         uint8 tokenIndexTo,
         uint256 dx
-    ) external view override returns (uint256 amountOut) {
+    ) external view returns (uint256 amountOut) {
         amountOut = swapQuoter.calculateSwap(pool, tokenIndexFrom, tokenIndexTo, dx);
     }
 
@@ -196,7 +198,6 @@ abstract contract SynapseAdapter is Ownable, ISwapAdapter, ISwapQuoter {
     function calculateRemoveLiquidity(address pool, uint256 amount)
         external
         view
-        override
         returns (uint256[] memory amountsOut)
     {
         amountsOut = swapQuoter.calculateRemoveLiquidity(pool, amount);
@@ -213,7 +214,7 @@ abstract contract SynapseAdapter is Ownable, ISwapAdapter, ISwapQuoter {
         address pool,
         uint256 tokenAmount,
         uint8 tokenIndex
-    ) external view override returns (uint256 amountOut) {
+    ) external view returns (uint256 amountOut) {
         amountOut = swapQuoter.calculateWithdrawOneToken(pool, tokenAmount, tokenIndex);
     }
 
@@ -224,28 +225,28 @@ abstract contract SynapseAdapter is Ownable, ISwapAdapter, ISwapQuoter {
     /**
      * @notice Returns a list of all supported pools.
      */
-    function allPools() public view override returns (Pool[] memory pools) {
+    function allPools() public view returns (Pool[] memory pools) {
         pools = swapQuoter.allPools();
     }
 
     /**
      * @notice Returns the amount of tokens the given pool supports and the pool's LP token.
      */
-    function poolInfo(address pool) public view override returns (uint256, address) {
+    function poolInfo(address pool) public view returns (uint256, address) {
         return swapQuoter.poolInfo(pool);
     }
 
     /**
      * @notice Returns a list of pool tokens for the given pool.
      */
-    function poolTokens(address pool) public view override returns (PoolToken[] memory tokens) {
+    function poolTokens(address pool) public view returns (PoolToken[] memory tokens) {
         tokens = swapQuoter.poolTokens(pool);
     }
 
     /**
      * @notice Returns the amount of supported pools.
      */
-    function poolsAmount() public view override returns (uint256 amount) {
+    function poolsAmount() public view returns (uint256 amount) {
         amount = swapQuoter.poolsAmount();
     }
 

--- a/test/bridge/router/SwapCalculator.t.sol
+++ b/test/bridge/router/SwapCalculator.t.sol
@@ -12,7 +12,7 @@ contract SwapCalculatorHarness is SwapCalculator {
     }
 
     function getAmountOut(
-        address tokenIn,
+        LimitedToken memory tokenIn,
         address tokenOut,
         uint256 amountIn
     ) external view override returns (SwapQuery memory query) {}

--- a/test/bridge/router/SynapseRouterUnsupported.t.sol
+++ b/test/bridge/router/SynapseRouterUnsupported.t.sol
@@ -112,7 +112,7 @@ contract SynapseRouterUnsupportedTest is Utilities06 {
         // Make sure user has no WETH
         _unwrapUserWETH();
         uint256 amount = 10**18;
-        SwapQuery memory originQuery = quoter.getAmountOut(UniversalToken.ETH_ADDRESS, address(weth), amount);
+        SwapQuery memory originQuery = router.getAmountOut(UniversalToken.ETH_ADDRESS, address(weth), amount);
         SwapQuery memory emptyQuery;
         vm.expectRevert("Token not supported");
         vm.prank(USER);
@@ -150,7 +150,7 @@ contract SynapseRouterUnsupportedTest is Utilities06 {
 
     function test_sb_revert_fromTokenToUnsupported() public {
         uint256 amount = 10**18;
-        SwapQuery memory originQuery = quoter.getAmountOut(address(weth), address(neth), amount);
+        SwapQuery memory originQuery = router.getAmountOut(address(weth), address(neth), amount);
         SwapQuery memory emptyQuery;
         vm.expectRevert("Token not supported");
         vm.prank(USER);
@@ -169,7 +169,7 @@ contract SynapseRouterUnsupportedTest is Utilities06 {
         _unwrapUserWETH();
         uint256 amount = 10**18;
         SwapQuery memory emptyQuery;
-        SwapQuery memory originQuery = quoter.getAmountOut(UniversalToken.ETH_ADDRESS, address(neth), amount);
+        SwapQuery memory originQuery = router.getAmountOut(UniversalToken.ETH_ADDRESS, address(neth), amount);
         vm.expectRevert("Token not supported");
         vm.prank(USER);
         router.bridge{value: amount}({
@@ -186,7 +186,7 @@ contract SynapseRouterUnsupportedTest is Utilities06 {
         uint256 amount = 10**18;
         deal(USER, amount);
         _addRedeemToken(address(neth));
-        SwapQuery memory originQuery = quoter.getAmountOut(address(weth), address(neth), amount);
+        SwapQuery memory originQuery = router.getAmountOut(address(weth), address(neth), amount);
         SwapQuery memory emptyQuery;
         vm.expectRevert(bytes("!eth"));
         vm.prank(USER);
@@ -229,7 +229,7 @@ contract SynapseRouterUnsupportedTest is Utilities06 {
         // depositETHAndRemove() does not exist
         uint256 amount = 10**18;
         _addDepositToken(address(weth));
-        SwapQuery memory originQuery = quoter.getAmountOut(UniversalToken.ETH_ADDRESS, address(weth), amount);
+        SwapQuery memory originQuery = router.getAmountOut(UniversalToken.ETH_ADDRESS, address(weth), amount);
         SwapQuery memory destQuery = _mockQuery(Action.RemoveLiquidity);
         vm.expectRevert("Unsupported dest action");
         vm.prank(USER);
@@ -267,7 +267,7 @@ contract SynapseRouterUnsupportedTest is Utilities06 {
         // depositETHAndAdd() does not exist
         uint256 amount = 10**18;
         _addDepositToken(address(weth));
-        SwapQuery memory originQuery = quoter.getAmountOut(UniversalToken.ETH_ADDRESS, address(weth), amount);
+        SwapQuery memory originQuery = router.getAmountOut(UniversalToken.ETH_ADDRESS, address(weth), amount);
         SwapQuery memory destQuery = _mockQuery(Action.AddLiquidity);
         vm.expectRevert("Unsupported dest action");
         vm.prank(USER);


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

`SwapQuoter.getAmountOut()` is reworked to include `actionMask`: bitmask specifying what kind of actions should be considered when looking for a pool connecting `tokenIn` and `tokenOut`.

This is required because bridge swaps work differently on origin and destination chains:
- On origin chain, any swap is available. One could even swap through an external Swap Adapter.
- On destination chain only swap using the bridge token's "liquidity pool" is available. The set of actions is also limited:
  - For mintable tokens there's only `mint()` and `mintAndSwap()`
  - For withdrawable tokens there's only `withdraw` and `withdrawAndRemove()`

This PR takes it all into account to ensure that `getOriginAmountOut` + `getDestinationAmountOut` always gets a valid pair of `SwapQuery` structs for later use in `SynapseRouter`.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
