### PR TITLE
Always populate tokenOut field

### DIFF
--- a/test/bridge/router/SwapQuoter.t.sol
+++ b/test/bridge/router/SwapQuoter.t.sol
@@ -281,6 +281,7 @@ contract SwapQuoterTest is Utilities06 {
     ) internal {
         SwapQuery memory query = quoter.getAmountOut(LimitedToken(actionMask, tokenIn), tokenOut, amountIn);
         SwapQuery memory emptyQuery;
+        emptyQuery.tokenOut = tokenOut;
         _compareQueries(query, emptyQuery);
         assertEq(query.rawParams, new bytes(0), "empty: !rawParams");
     }
@@ -293,7 +294,9 @@ contract SwapQuoterTest is Utilities06 {
     ) internal {
         SwapQuery memory query = quoter.getAmountOut(LimitedToken(actionMask, tokenIn), tokenOut, amountIn);
         SwapQuery memory sameTokenQuery;
-        (sameTokenQuery.tokenOut, sameTokenQuery.minAmountOut) = (tokenIn, amountIn);
+        sameTokenQuery.tokenOut = tokenIn;
+        sameTokenQuery.minAmountOut = amountIn;
+        sameTokenQuery.deadline = type(uint256).max;
         _compareQueries(query, sameTokenQuery);
         assertEq(query.rawParams, new bytes(0), "sameToken: !rawParams");
     }


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

`SwapQuoter` is updated to always populate `tokenOut` field in the struct returned by `getAmountOut()`. This subtle change enables following:

https://github.com/synapsecns/synapse-contracts/blob/7ece713039e26d2a27416ecde74eea8e8b9afad7/test/bridge/router/SynapseRouterSuite.t.sol#L396-L409

Before the change, `getOriginAmountOut()` would return an empty struct with `tokenOut = address(0)` for every bridge token that is not connected to `tokenIn` on origin chain.
After the change, it would still return an empty struct for these tokens, but with a correct `tokenOut` address. This address could be used to find an alternative path between `tokenIn` and a bridge token, using an off-chain Quoter in a combination with an alternative Swap Adapter to perform the swap.

In fact, as it is guaranteed that token symbols returned by `destination.router.getConnectedBridgeTokens()` could complete the bridge transaction, one could adjust the quoting algorithm this way:
```solidity
  // Step 1: perform a call to origin SynapseRouter
  SwapQuery[] memory originQueries = origin.router.getOriginAmountOut(address(tokenIn), symbols, amountIn);
  // Step 1a: perform a call to off-chain API to find alternative paths between `tokenIn` and `symbols`
  for (uint256 i = 0; i < originQueries.length; ++i) {
    // Perform an off-chain call to API to find a path between `tokenIn` and a bridge token returned above
    SwapQuery memory altQuery = api.findPath(address(tokenIn), originQueries[i].tokenOut, amountIn);
  }
```

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
