### PR TITLE
Router: end to end tests

### DIFF
--- a/test/bridge/router/SynapseRouterEndToEndEdgeCases.t.sol
+++ b/test/bridge/router/SynapseRouterEndToEndEdgeCases.t.sol
@@ -186,4 +186,130 @@ contract SynapseRouterEndToEndEdgeCasesTest is SynapseRouterSuite {
         // Validator completes the transaction on destination chain
         checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
     }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                       KLAYTN USDC -> ETH USDT                        ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function test_klaytnToEthereum_inUSDC_outUSDT() public {
+        ChainSetup memory origin = chains[KLAY_CHAINID];
+        // Step 1: nUSD is available as intermediate token
+        klaytnToEthereum_inUSDC_outUSDT();
+
+        // Step2: no options are available for bridging
+        // Remove nUSD from list of valid origin tokens
+        origin.router.removeToken(address(origin.nusd));
+        vm.expectRevert("No path found on origin");
+        // Doing an external call to catch the revert from the test suite
+        this.klaytnToEthereum_inUSDC_outUSDT();
+    }
+
+    function klaytnToEthereum_inUSDC_outUSDT() public {
+        // Prepare test parameters: Klaytn USDC -> Ethereum USDT
+        ChainSetup memory origin = chains[KLAY_CHAINID];
+        ChainSetup memory destination = chains[ETH_CHAINID];
+        IERC20 tokenIn = origin.usdc;
+        IERC20 tokenOut = destination.usdt;
+        uint256 amountIn = 10**uint256(ERC20(address(tokenIn)).decimals());
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Could use only nUSD
+        address bridgeTokenOrigin = address(origin.nusd);
+        address bridgeTokenDest = address(destination.nusd);
+        // Klaytn: USDC -> nUSD; Ethereum: nUSD -> USDT
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenRedeemAndRemove({
+            to: TO,
+            chainId: ETH_CHAINID,
+            token: bridgeTokenOrigin,
+            amount: originQuery.minAmountOut,
+            swapTokenIndex: 2, // USDT index is 2
+            swapMinAmount: destQuery.minAmountOut,
+            swapDeadline: destQuery.deadline
+        });
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                       KLAYTN NUSD -> ETH USDC                        ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function test_klaytnToEthereum_inNUSD_outUSDC() public {
+        ChainSetup memory origin = chains[ETH_CHAINID];
+        ChainSetup memory destination = chains[KLAY_CHAINID];
+
+        // Step 1: both nUSD and USDC are available as intermediate token
+        klaytnToEthereum_inNUSD_outUSDC({checkNUSD: false, checkUSDC: false});
+
+        // Step 2: only USDC is available  as intermediate token
+        // Remove nUSD pool on origin from the list of pools
+        origin.quoter.removePool(origin.nUsdPool);
+        klaytnToEthereum_inNUSD_outUSDC({checkNUSD: false, checkUSDC: true});
+
+        // Step 3: no tokens are available
+        // Remove USDC as bridge asset from destination router
+        destination.router.removeToken(address(destination.usdc));
+        vm.expectRevert("No path found on origin");
+        // Doing an external call to catch the revert from the test suite
+        this.klaytnToEthereum_inNUSD_outUSDC({checkNUSD: false, checkUSDC: false});
+
+        // Step 4: only nUSD is available  as intermediate token
+        // Add nUSD pool on origin back to the list of pools
+        origin.quoter.addPool(origin.nUsdPool);
+        klaytnToEthereum_inNUSD_outUSDC({checkNUSD: true, checkUSDC: false});
+    }
+
+    function klaytnToEthereum_inNUSD_outUSDC(bool checkNUSD, bool checkUSDC) public {
+        // Prepare test parameters: Klaytn nUSD -> Ethereum USDC
+        ChainSetup memory origin = chains[KLAY_CHAINID];
+        ChainSetup memory destination = chains[ETH_CHAINID];
+        IERC20 tokenIn = origin.nusd;
+        IERC20 tokenOut = destination.usdc;
+        uint256 amountIn = 10**uint256(ERC20(address(tokenIn)).decimals());
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Could use either nUSD or USDC as the bridge token on Klaytn
+        address bridgeTokenOrigin = originQuery.tokenOut;
+        if (checkUSDC) require(bridgeTokenOrigin == address(origin.usdc), "!USDC");
+        if (checkNUSD) require(bridgeTokenOrigin == address(origin.nusd), "!NUSD");
+        address bridgeTokenDest;
+        if (bridgeTokenOrigin == address(origin.usdc)) {
+            // Klaytn: nUSD -> USDC; Ethereum: USDC -> USDC
+            // Expect Bridge event to be emitted
+            vm.expectEmit(true, true, true, true);
+            emit TokenRedeem(TO, ETH_CHAINID, bridgeTokenOrigin, originQuery.minAmountOut);
+            bridgeTokenDest = address(destination.usdc);
+        } else {
+            // Klaytn: nUSD -> nUSD; Ethereum: nUSD -> USDC
+            vm.expectEmit(true, true, true, true);
+            emit TokenRedeemAndRemove({
+                to: TO,
+                chainId: ETH_CHAINID,
+                token: bridgeTokenOrigin,
+                amount: originQuery.minAmountOut,
+                swapTokenIndex: 1, // USDC index is 1
+                swapMinAmount: destQuery.minAmountOut,
+                swapDeadline: destQuery.deadline
+            });
+            bridgeTokenDest = address(destination.nusd);
+        }
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
 }

--- a/test/bridge/router/SynapseRouterEndToEndEdgeCases.t.sol
+++ b/test/bridge/router/SynapseRouterEndToEndEdgeCases.t.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./SynapseRouterSuite.t.sol";
+
+// solhint-disable func-name-mixedcase
+contract SynapseRouterEndToEndEdgeCasesTest is SynapseRouterSuite {
+    uint256 internal constant KLAY_CHAINID = 8217;
+
+    function setUp() public override {
+        super.setUp();
+        chains[KLAY_CHAINID] = deployTestKlaytn();
+    }
+
+    function deployTestKlaytn() public virtual returns (ChainSetup memory chain) {
+        deployChainBasics({chain: chain, name: "KLAY", gasName: "KLAY", chainId: KLAY_CHAINID});
+        deployChainBridge(chain);
+        deployChainRouter(chain);
+        chain.dai = deploySynapseERC20(chain, "DAI", 18);
+        chain.usdc = deploySynapseERC20(chain, "USDC", 6);
+        chain.usdt = deploySynapseERC20(chain, "USDT", 6);
+        // Deploy nETH pool: nETH + WETH
+        chain.nEthPool = deployPool(chain, castToArray(chain.neth, chain.weth), 100);
+        // Deploy nUSD pool: nUSD + USDC
+        chain.nUsdPool = deployPool(chain, castToArray(chain.nusd, chain.usdc), 10_000);
+        // Set up Swap Quoter
+        chain.quoter.addPool(chain.nEthPool);
+        chain.quoter.addPool(chain.nUsdPool);
+    }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                       ETH -> KLAYTN, OUT: DAI                        ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function test_ethereumToKlaytn_inDAI_outDAI() public {
+        ethereumToKlaytn_outDAI_fullTest(chains[ETH_CHAINID].dai);
+    }
+
+    function test_ethereumToKlaytn_inNUSD_outDAI() public {
+        ethereumToKlaytn_outDAI_fullTest(chains[ETH_CHAINID].nusd);
+    }
+
+    function test_ethereumToKlaytn_inUSDC_outDAI() public {
+        ethereumToKlaytn_outDAI_fullTest(chains[ETH_CHAINID].usdc);
+    }
+
+    function test_ethereumToKlaytn_inUSDT_outDAI() public {
+        ethereumToKlaytn_outDAI_fullTest(chains[ETH_CHAINID].usdt);
+    }
+
+    function ethereumToKlaytn_outDAI_fullTest(IERC20 tokenIn) public {
+        ChainSetup memory origin = chains[ETH_CHAINID];
+
+        // Step 1: only DAI is available as option
+        ethereumToKlaytn_outDAI(tokenIn);
+
+        // Step 2: remove nUSD pool on origin. This will cause next test to fail unless tokenIn is DAI
+        origin.quoter.removePool(origin.nUsdPool);
+        if (tokenIn != origin.dai) vm.expectRevert("No path found on origin");
+        // Doing an external call to catch the revert from the test suite
+        this.ethereumToKlaytn_outDAI(tokenIn);
+
+        // Step 3: add back the pool, remove DAI from bridge tokens on origin. Next test is going to fail
+        origin.quoter.addPool(origin.nUsdPool);
+        origin.router.removeToken(address(origin.dai));
+        vm.expectRevert("No path found on origin");
+        // Doing an external call to catch the revert from the test suite
+        this.ethereumToKlaytn_outDAI(tokenIn);
+    }
+
+    function ethereumToKlaytn_outDAI(IERC20 tokenIn) public {
+        // Prepare test parameters: Ethereum tokenIn -> Klaytn DAI
+        ChainSetup memory origin = chains[ETH_CHAINID];
+        ChainSetup memory destination = chains[KLAY_CHAINID];
+        IERC20 tokenOut = destination.dai;
+        uint256 amountIn = 10**uint256(ERC20(address(tokenIn)).decimals());
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Only DAI could be used on origin chain
+        address bridgeTokenOrigin = address(origin.dai);
+        address bridgeTokenDest = address(destination.dai);
+        vm.expectEmit(true, true, true, true);
+        emit TokenDeposit(TO, KLAY_CHAINID, bridgeTokenOrigin, originQuery.minAmountOut);
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                       ETH -> KLAYTN, OUT: USDC                       ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function test_ethereumToKlaytn_inDAI_outUSDC() public {
+        ethereumToKlaytn_outUSDC_fullTest(chains[ETH_CHAINID].dai);
+    }
+
+    function test_ethereumToKlaytn_inNUSD_outUSDC() public {
+        ethereumToKlaytn_outUSDC_fullTest(chains[ETH_CHAINID].nusd);
+    }
+
+    function test_ethereumToKlaytn_inUSDC_outUSDC() public {
+        ethereumToKlaytn_outUSDC_fullTest(chains[ETH_CHAINID].usdc);
+    }
+
+    function test_ethereumToKlaytn_inUSDT_outUSDC() public {
+        ethereumToKlaytn_outUSDC_fullTest(chains[ETH_CHAINID].usdt);
+    }
+
+    function ethereumToKlaytn_outUSDC_fullTest(IERC20 tokenIn) public {
+        ChainSetup memory origin = chains[ETH_CHAINID];
+        ChainSetup memory destination = chains[KLAY_CHAINID];
+
+        // Step 1: both nUSD and USDC are available as intermediate token
+        ethereumToKlaytn_outUSDC({tokenIn: tokenIn, checkUSDC: false, checkNUSD: false});
+
+        // Step 2: only USDC are available as intermediate token
+        // Remove nUSD pool on Klaytn, this will make the transaction go through USDC
+        destination.quoter.removePool(destination.nUsdPool);
+        ethereumToKlaytn_outUSDC({tokenIn: tokenIn, checkUSDC: true, checkNUSD: false});
+
+        // Step 3: no options are available for bridging
+        // Remove USDC from list of valid origin tokens
+        origin.router.removeToken(address(origin.usdc));
+        vm.expectRevert("No path found on origin");
+        // Doing an external call to catch the revert from the test suite
+        this.ethereumToKlaytn_outUSDC({tokenIn: tokenIn, checkUSDC: false, checkNUSD: false});
+
+        // Step 4: only nUSD are available as intermediate token
+        // Add back nUSD pool on Klaytn, this will route tx through nUSD
+        destination.quoter.addPool(destination.nUsdPool);
+        ethereumToKlaytn_outUSDC({tokenIn: tokenIn, checkUSDC: false, checkNUSD: true});
+    }
+
+    function ethereumToKlaytn_outUSDC(
+        IERC20 tokenIn,
+        bool checkUSDC,
+        bool checkNUSD
+    ) public {
+        // Prepare test parameters: Ethereum tokenIn -> Klaytn USDC
+        ChainSetup memory origin = chains[ETH_CHAINID];
+        ChainSetup memory destination = chains[KLAY_CHAINID];
+        IERC20 tokenOut = destination.usdc;
+        uint256 amountIn = 10**uint256(ERC20(address(tokenIn)).decimals());
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Could use either nUSD or USDC as the bridge token on Ethereum
+        address bridgeTokenOrigin = originQuery.tokenOut;
+        if (checkUSDC) require(bridgeTokenOrigin == address(origin.usdc), "!USDC");
+        if (checkNUSD) require(bridgeTokenOrigin == address(origin.nusd), "!NUSD");
+        address bridgeTokenDest;
+        if (bridgeTokenOrigin == address(origin.usdc)) {
+            // Ethereum: tokenIn -> USDC; Klaytn: USDC -> USDC
+            // Expect Bridge event to be emitted
+            vm.expectEmit(true, true, true, true);
+            emit TokenDeposit(TO, KLAY_CHAINID, bridgeTokenOrigin, originQuery.minAmountOut);
+            bridgeTokenDest = address(destination.usdc);
+        } else {
+            // Ethereum: tokenIn -> nUSD; Klaytn: nUSD -> USDC
+            vm.expectEmit(true, true, true, true);
+            emit TokenDepositAndSwap({
+                to: TO,
+                chainId: KLAY_CHAINID,
+                token: bridgeTokenOrigin,
+                amount: originQuery.minAmountOut,
+                tokenIndexFrom: 0,
+                tokenIndexTo: 1,
+                minDy: destQuery.minAmountOut,
+                deadline: destQuery.deadline
+            });
+            bridgeTokenDest = address(destination.nusd);
+        }
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+}

--- a/test/bridge/router/SynapseRouterEndToEndGMX.t.sol
+++ b/test/bridge/router/SynapseRouterEndToEndGMX.t.sol
@@ -24,6 +24,10 @@ contract GMX is ERC20 {
     function setMinter(address _minter) external {
         minter = _minter;
     }
+
+    function setupDecimals(uint8 decimals_) external {
+        _setupDecimals(decimals_);
+    }
 }
 
 // solhint-disable func-name-mixedcase
@@ -59,6 +63,7 @@ contract SynapseRouterEndToEndGMXTest is SynapseRouterSuite {
         {
             // Deploy contract to copy the "mock" bytecode to GMX address
             vm.etch(address(avaGMX), codeAt(address(new GMX())));
+            avaGMX.setupDecimals(18);
         }
         // GMX Bridge Wrapper is set as minter for GMX
         avaGMX.setMinter(address(avaGmxWrapper));

--- a/test/bridge/router/SynapseRouterEndToEndJewel.t.sol
+++ b/test/bridge/router/SynapseRouterEndToEndJewel.t.sol
@@ -18,23 +18,19 @@ contract SynapseRouterEndToEndJewelTest is SynapseRouterSuite {
 
     function deployTestAvalanche() public virtual override returns (ChainSetup memory chain) {
         chain = super.deployTestAvalanche();
-        avaJewel = deploySynapseERC20(chain, "AVA JEWEL");
-        // Add JEWEL to Router config
-        _addRedeemToken(chain.router, SYMBOL_JEWEL, address(avaJewel));
+        avaJewel = deploySynapseERC20(chain, SYMBOL_JEWEL, 18);
     }
 
     function deployTestDFK() public virtual override returns (ChainSetup memory chain) {
         chain = super.deployTestDFK();
         // Add JEWEL to Router config
-        _addDepositToken(chain.router, SYMBOL_JEWEL, address(chain.wgas));
-        // Setup initial WJEWEL locked in Bridge
-        dealToken(chain, address(chain.bridge), chain.wgas, 10**24);
+        _addDepositToken(chain, SYMBOL_JEWEL, address(chain.wgas));
     }
 
     function deployTestHarmony() public virtual override returns (ChainSetup memory chain) {
         chain = super.deployTestHarmony();
-        harJewel = deploySynapseERC20(chain, "HAR JEWEL");
-        harLegacyJewel = deployERC20("HAR LEGACY JEWEL", 18);
+        harJewel = deploySynapseERC20(chain, SYMBOL_JEWEL, 18);
+        harLegacyJewel = deployERC20(chain, "LEGACY JEWEL", 18);
         harmonyJewelSwap = new JewelBridgeSwap(harLegacyJewel, harJewel);
         // JewelSwap should have a minter role
         {
@@ -42,10 +38,8 @@ contract SynapseRouterEndToEndJewelTest is SynapseRouterSuite {
             _harJewel.grantRole(_harJewel.MINTER_ROLE(), address(harmonyJewelSwap));
         }
         chain.quoter.addPool(address(harmonyJewelSwap));
-        // Add JEWEL to Router config
-        _addRedeemToken(chain.router, SYMBOL_JEWEL, address(harJewel));
         // Setup initial Legacy Jewel balance for JewelBridgeSwap
-        dealToken(chain, address(harmonyJewelSwap), harLegacyJewel, 10**24);
+        mintInitialTestTokens(chain, address(harmonyJewelSwap), address(harLegacyJewel), 10**24);
     }
 
     /*╔══════════════════════════════════════════════════════════════════════╗*\

--- a/test/bridge/router/SynapseRouterEndToEndNETH.t.sol
+++ b/test/bridge/router/SynapseRouterEndToEndNETH.t.sol
@@ -3,10 +3,38 @@ pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./SynapseRouterSuite.t.sol";
+import {LendingPoolMock} from "./mocks/AaveMock.t.sol";
+import {AaveSwapWrapper} from "./mocks/AaveMock.t.sol";
 
 // solhint-disable func-name-mixedcase
 // solhint-disable not-rely-on-time
 contract SynapseRouterEndToEndNETHTest is SynapseRouterSuite {
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                         OVERRIDES: AAVE POOL                         ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function deployPool(
+        ChainSetup memory chain,
+        IERC20[] memory tokens,
+        uint256 seedAmount
+    ) public virtual override returns (address pool) {
+        if (!equals(chain.name, "AVA") || tokens[0] != chain.neth) {
+            return super.deployPool(chain, tokens, seedAmount);
+        }
+        LendingPoolMock lendingPool = new LendingPoolMock();
+        IERC20 aWETH = deployERC20("AVA aWETH", 18);
+        Ownable(address(aWETH)).transferOwnership(address(lendingPool));
+        lendingPool.addToken(address(aWETH), address(chain.weth));
+        tokens[1] = aWETH;
+        // Deploy nETH + aWETH pool
+        address aavePool = super.deployPool(chain, tokens, seedAmount);
+        dealToken(chain, address(lendingPool), chain.weth, aWETH.balanceOf(aavePool));
+        tokens[1] = chain.weth;
+        // Deploy Aave Swap Wrapper and use it as the pool for SwapQuoter
+        AaveSwapWrapper _pool = new AaveSwapWrapper(Swap(aavePool), tokens, address(lendingPool), address(this));
+        pool = address(_pool);
+    }
+
     /*╔══════════════════════════════════════════════════════════════════════╗*\
     ▏*║                     TESTS: ETH -> L2 (FROM ETH)                      ║*▕
     \*╚══════════════════════════════════════════════════════════════════════╝*/
@@ -613,6 +641,115 @@ contract SynapseRouterEndToEndNETHTest is SynapseRouterSuite {
             to: TO,
             chainId: ARB_CHAINID,
             token: address(origin.neth),
+            amount: originQuery.minAmountOut,
+            tokenIndexFrom: 0,
+            tokenIndexTo: 1,
+            minDy: destQuery.minAmountOut,
+            deadline: destQuery.deadline
+        });
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                      TESTS: AVALANCHE AAVE WETH                      ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function test_avalancheToEthereum_inNETH_outETH() public {
+        // Prepare test parameters: Avalanche nETH -> Ethereum ETH
+        ChainSetup memory origin = chains[AVA_CHAINID];
+        ChainSetup memory destination = chains[ETH_CHAINID];
+        IERC20 tokenIn = origin.neth;
+        IERC20 tokenOut = destination.gas;
+        uint256 amountIn = 10**18;
+        address bridgeTokenDest = address(destination.weth);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenRedeem(TO, ETH_CHAINID, address(origin.neth), originQuery.minAmountOut);
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    function test_avalancheToEthereum_inWETH_outETH() public {
+        // Prepare test parameters: Avalanche WETH -> Ethereum ETH
+        ChainSetup memory origin = chains[AVA_CHAINID];
+        ChainSetup memory destination = chains[ETH_CHAINID];
+        IERC20 tokenIn = origin.weth;
+        IERC20 tokenOut = destination.gas;
+        uint256 amountIn = 10**18;
+        address bridgeTokenDest = address(destination.weth);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenRedeem(TO, ETH_CHAINID, address(origin.neth), originQuery.minAmountOut);
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    function test_ethereumToAvalanche_inETH_outNETH() public {
+        // Prepare test parameters: Ethereum ETH -> Avalanche nETH
+        ChainSetup memory origin = chains[ETH_CHAINID];
+        ChainSetup memory destination = chains[AVA_CHAINID];
+        IERC20 tokenIn = origin.gas;
+        IERC20 tokenOut = destination.neth;
+        uint256 amountIn = 10**18;
+        address bridgeTokenDest = address(destination.neth);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenDeposit(TO, AVA_CHAINID, address(origin.weth), originQuery.minAmountOut);
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    function test_ethereumToAvalanche_inETH_outWETH() public {
+        // Prepare test parameters: Ethereum ETH -> Avalanche WETH
+        ChainSetup memory origin = chains[ETH_CHAINID];
+        ChainSetup memory destination = chains[AVA_CHAINID];
+        IERC20 tokenIn = origin.gas;
+        IERC20 tokenOut = destination.weth;
+        uint256 amountIn = 10**18;
+        address bridgeTokenDest = address(destination.neth);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenDepositAndSwap({
+            to: TO,
+            chainId: AVA_CHAINID,
+            token: address(origin.weth),
             amount: originQuery.minAmountOut,
             tokenIndexFrom: 0,
             tokenIndexTo: 1,

--- a/test/bridge/router/SynapseRouterEndToEndNETH.t.sol
+++ b/test/bridge/router/SynapseRouterEndToEndNETH.t.sol
@@ -22,13 +22,13 @@ contract SynapseRouterEndToEndNETHTest is SynapseRouterSuite {
             return super.deployPool(chain, tokens, seedAmount);
         }
         LendingPoolMock lendingPool = new LendingPoolMock();
-        IERC20 aWETH = deployERC20("AVA aWETH", 18);
+        IERC20 aWETH = deployERC20(chain, "aWETH", 18);
+        mintInitialTestTokens(chain, address(lendingPool), address(chain.weth), aWETH.totalSupply());
         Ownable(address(aWETH)).transferOwnership(address(lendingPool));
         lendingPool.addToken(address(aWETH), address(chain.weth));
         tokens[1] = aWETH;
         // Deploy nETH + aWETH pool
         address aavePool = super.deployPool(chain, tokens, seedAmount);
-        dealToken(chain, address(lendingPool), chain.weth, aWETH.balanceOf(aavePool));
         tokens[1] = chain.weth;
         // Deploy Aave Swap Wrapper and use it as the pool for SwapQuoter
         AaveSwapWrapper _pool = new AaveSwapWrapper(Swap(aavePool), tokens, address(lendingPool), address(this));

--- a/test/bridge/router/SynapseRouterEndToEndNUSD.t.sol
+++ b/test/bridge/router/SynapseRouterEndToEndNUSD.t.sol
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./SynapseRouterSuite.t.sol";
+
+// solhint-disable func-name-mixedcase
+contract SynapseRouterEndToEndNUSDTest is SynapseRouterSuite {
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                           TESTS: ETH -> L2                           ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function test_ethereumToOptimism_inNUSD_outNUSD() public {
+        // Prepare test parameters: Ethereum nUSD -> Optimism nUSD
+        ChainSetup memory origin = chains[ETH_CHAINID];
+        ChainSetup memory destination = chains[OPT_CHAINID];
+        IERC20 tokenIn = origin.nusd;
+        IERC20 tokenOut = destination.nusd;
+        uint256 amountIn = 10**18;
+        address bridgeTokenDest = address(destination.nusd);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenDeposit(TO, OPT_CHAINID, address(origin.nusd), originQuery.minAmountOut);
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    function test_ethereumToOptimism_inNUSD_outUSDC() public {
+        // Prepare test parameters: Ethereum nUSD -> Optimism USDC
+        ChainSetup memory origin = chains[ETH_CHAINID];
+        ChainSetup memory destination = chains[OPT_CHAINID];
+        IERC20 tokenIn = origin.nusd;
+        IERC20 tokenOut = destination.usdc;
+        uint256 amountIn = 10**18;
+        address bridgeTokenDest = address(destination.nusd);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenDepositAndSwap({
+            to: TO,
+            chainId: OPT_CHAINID,
+            token: address(origin.nusd),
+            amount: originQuery.minAmountOut,
+            tokenIndexFrom: 0,
+            tokenIndexTo: 1,
+            minDy: destQuery.minAmountOut,
+            deadline: destQuery.deadline
+        });
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    function test_ethereumToOptimism_inUSDC_outNUSD() public {
+        // Prepare test parameters: Ethereum USDC -> Optimism nUSD
+        ChainSetup memory origin = chains[ETH_CHAINID];
+        ChainSetup memory destination = chains[OPT_CHAINID];
+        IERC20 tokenIn = origin.usdc;
+        IERC20 tokenOut = destination.nusd;
+        uint256 amountIn = 10**6;
+        address bridgeTokenDest = address(destination.nusd);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenDeposit(TO, OPT_CHAINID, address(origin.nusd), originQuery.minAmountOut);
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    function test_ethereumToOptimism_inUSDC_outUSDC() public {
+        // Prepare test parameters: Ethereum USDC -> Optimism USDC
+        ChainSetup memory origin = chains[ETH_CHAINID];
+        ChainSetup memory destination = chains[OPT_CHAINID];
+        IERC20 tokenIn = origin.usdc;
+        IERC20 tokenOut = destination.usdc;
+        uint256 amountIn = 10**6;
+        address bridgeTokenDest = address(destination.nusd);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenDepositAndSwap({
+            to: TO,
+            chainId: OPT_CHAINID,
+            token: address(origin.nusd),
+            amount: originQuery.minAmountOut,
+            tokenIndexFrom: 0,
+            tokenIndexTo: 1,
+            minDy: destQuery.minAmountOut,
+            deadline: destQuery.deadline
+        });
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                        TESTS: L2 -> ETHEREUM                         ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function test_optimismToEthereum_inNUSD_outNUSD() public {
+        // Prepare test parameters: Optimism nUSD -> Ethereum nUSD
+        ChainSetup memory origin = chains[OPT_CHAINID];
+        ChainSetup memory destination = chains[ETH_CHAINID];
+        IERC20 tokenIn = origin.nusd;
+        IERC20 tokenOut = destination.nusd;
+        uint256 amountIn = 10**18;
+        address bridgeTokenDest = address(destination.nusd);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenRedeem(TO, ETH_CHAINID, address(origin.nusd), originQuery.minAmountOut);
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    function test_optimismToEthereum_inNUSD_outUSDC() public {
+        // Prepare test parameters: Optimism nUSD -> Ethereum nUSD
+        ChainSetup memory origin = chains[OPT_CHAINID];
+        ChainSetup memory destination = chains[ETH_CHAINID];
+        IERC20 tokenIn = origin.nusd;
+        IERC20 tokenOut = destination.usdc;
+        uint256 amountIn = 10**18;
+        address bridgeTokenDest = address(destination.nusd);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenRedeemAndRemove({
+            to: TO,
+            chainId: ETH_CHAINID,
+            token: address(origin.nusd),
+            amount: originQuery.minAmountOut,
+            swapTokenIndex: 1,
+            swapMinAmount: destQuery.minAmountOut,
+            swapDeadline: destQuery.deadline
+        });
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    function test_optimismToEthereum_inUSDC_outNUSD() public {
+        // Prepare test parameters: Optimism USDC -> Ethereum nUSD
+        ChainSetup memory origin = chains[OPT_CHAINID];
+        ChainSetup memory destination = chains[ETH_CHAINID];
+        IERC20 tokenIn = origin.usdc;
+        IERC20 tokenOut = destination.nusd;
+        uint256 amountIn = 10**6;
+        address bridgeTokenDest = address(destination.nusd);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenRedeem(TO, ETH_CHAINID, address(origin.nusd), originQuery.minAmountOut);
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    function test_optimismToEthereum_inUSDC_outUSDC() public {
+        // Prepare test parameters: Optimism USDC -> Ethereum nUSD
+        ChainSetup memory origin = chains[OPT_CHAINID];
+        ChainSetup memory destination = chains[ETH_CHAINID];
+        IERC20 tokenIn = origin.usdc;
+        IERC20 tokenOut = destination.usdc;
+        uint256 amountIn = 10**6;
+        address bridgeTokenDest = address(destination.nusd);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenRedeemAndRemove({
+            to: TO,
+            chainId: ETH_CHAINID,
+            token: address(origin.nusd),
+            amount: originQuery.minAmountOut,
+            swapTokenIndex: 1,
+            swapMinAmount: destQuery.minAmountOut,
+            swapDeadline: destQuery.deadline
+        });
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    /*╔══════════════════════════════════════════════════════════════════════╗*\
+    ▏*║                           TESTS: L2 <> L2                            ║*▕
+    \*╚══════════════════════════════════════════════════════════════════════╝*/
+
+    function test_optimismToArbitrum_inNUSD_outNUSD() public {
+        // Prepare test parameters: Optimism nUSD -> Arbitrum nUSD
+        ChainSetup memory origin = chains[OPT_CHAINID];
+        ChainSetup memory destination = chains[ARB_CHAINID];
+        IERC20 tokenIn = origin.nusd;
+        IERC20 tokenOut = destination.nusd;
+        uint256 amountIn = 10**18;
+        address bridgeTokenDest = address(destination.nusd);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenRedeem(TO, ARB_CHAINID, address(origin.nusd), originQuery.minAmountOut);
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    function test_optimismToArbitrum_inNUSD_outUSDC() public {
+        // Prepare test parameters: Optimism nUSD -> Arbitrum USDC
+        ChainSetup memory origin = chains[OPT_CHAINID];
+        ChainSetup memory destination = chains[ARB_CHAINID];
+        IERC20 tokenIn = origin.nusd;
+        IERC20 tokenOut = destination.usdc;
+        uint256 amountIn = 10**18;
+        address bridgeTokenDest = address(destination.nusd);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenRedeemAndSwap({
+            to: TO,
+            chainId: ARB_CHAINID,
+            token: address(origin.nusd),
+            amount: originQuery.minAmountOut,
+            tokenIndexFrom: 0,
+            tokenIndexTo: 1,
+            minDy: destQuery.minAmountOut,
+            deadline: destQuery.deadline
+        });
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    function test_optimismToArbitrum_inUSDC_outNUSD() public {
+        // Prepare test parameters: Optimism USDC -> Arbitrum nUSD
+        ChainSetup memory origin = chains[OPT_CHAINID];
+        ChainSetup memory destination = chains[ARB_CHAINID];
+        IERC20 tokenIn = origin.usdc;
+        IERC20 tokenOut = destination.nusd;
+        uint256 amountIn = 10**6;
+        address bridgeTokenDest = address(destination.nusd);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenRedeem(TO, ARB_CHAINID, address(origin.nusd), originQuery.minAmountOut);
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+
+    function test_optimismToArbitrum_inUSDC_outUSDC() public {
+        // Prepare test parameters: Optimism USDC -> Arbitrum USDC
+        ChainSetup memory origin = chains[OPT_CHAINID];
+        ChainSetup memory destination = chains[ARB_CHAINID];
+        IERC20 tokenIn = origin.usdc;
+        IERC20 tokenOut = destination.usdc;
+        uint256 amountIn = 10**6;
+        address bridgeTokenDest = address(destination.nusd);
+        (SwapQuery memory originQuery, SwapQuery memory destQuery) = performQuoteCalls(
+            origin,
+            destination,
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        // Expect Bridge event to be emitted
+        vm.expectEmit(true, true, true, true);
+        emit TokenRedeemAndSwap({
+            to: TO,
+            chainId: ARB_CHAINID,
+            token: address(origin.nusd),
+            amount: originQuery.minAmountOut,
+            tokenIndexFrom: 0,
+            tokenIndexTo: 1,
+            minDy: destQuery.minAmountOut,
+            deadline: destQuery.deadline
+        });
+        // User interacts with the SynapseRouter on origin chain
+        initiateBridgeTx(origin, destination, tokenIn, tokenOut, amountIn);
+        // Validator completes the transaction on destination chain
+        checkCompletedBridgeTx(destination, bridgeTokenDest, originQuery, destQuery);
+    }
+}

--- a/test/bridge/router/SynapseRouterSuite.t.sol
+++ b/test/bridge/router/SynapseRouterSuite.t.sol
@@ -106,6 +106,10 @@ abstract contract SynapseRouterSuite is Utilities06 {
     string internal constant SYMBOL_GMX = "GMX";
     string internal constant SYMBOL_JEWEL = "JEWEL";
 
+    string internal constant SYMBOL_DAI = "DAI";
+    string internal constant SYMBOL_USDC = "USDC";
+    string internal constant SYMBOL_USDT = "USDT";
+
     ValidatorMock internal validator;
 
     struct ChainSetup {
@@ -204,9 +208,15 @@ abstract contract SynapseRouterSuite is Utilities06 {
         // Setup bridge tokens for Mainnet
         _addDepositToken(chain.router, SYMBOL_NETH, address(chain.weth));
         _addDepositToken(chain.router, SYMBOL_NUSD, address(chain.nusd));
-        // Setup initial WETH, nUSD Bridge deposits
-        dealToken(chain, address(chain.bridge), chain.weth, 10**20);
+        _addDepositToken(chain.router, SYMBOL_DAI, address(chain.dai));
+        _addDepositToken(chain.router, SYMBOL_USDC, address(chain.usdc));
+        _addDepositToken(chain.router, SYMBOL_USDT, address(chain.usdt));
+        // Setup initial WETH, nUSD, DAI, USDC, USDT Bridge deposits
+        dealToken(chain, address(chain.bridge), chain.weth, 10**24);
         chain.nusd.transfer(address(chain.bridge), chain.nusd.balanceOf(address(this)));
+        dealToken(chain, address(chain.bridge), chain.dai, 10**24);
+        dealToken(chain, address(chain.bridge), chain.usdc, 10**12);
+        dealToken(chain, address(chain.bridge), chain.usdt, 10**12);
     }
 
     function deployTestArbitrum() public virtual returns (ChainSetup memory chain) {

--- a/test/bridge/router/SynapseRouterSuite.t.sol
+++ b/test/bridge/router/SynapseRouterSuite.t.sol
@@ -280,7 +280,7 @@ abstract contract SynapseRouterSuite is Utilities06 {
         ChainSetup memory chain,
         IERC20[] memory tokens,
         uint256 seedAmount
-    ) internal returns (address pool) {
+    ) public virtual returns (address pool) {
         uint256[] memory amounts = new uint256[](tokens.length);
         pool = deployPool(tokens);
         for (uint256 i = 0; i < tokens.length; ++i) {
@@ -438,7 +438,7 @@ abstract contract SynapseRouterSuite is Utilities06 {
     }
 
     function getRecipientBalance(ChainSetup memory chain, address token) public view returns (uint256) {
-        if (token == address(chain.weth) || token == UniversalToken.ETH_ADDRESS) {
+        if (token == address(chain.wgas) || token == address(chain.gas)) {
             return TO.balance;
         } else {
             return IERC20(token).balanceOf(TO);

--- a/test/bridge/router/SynapseRouterSuite.t.sol
+++ b/test/bridge/router/SynapseRouterSuite.t.sol
@@ -441,9 +441,8 @@ abstract contract SynapseRouterSuite is Utilities06 {
         // Step 3: perform a call to destination SynapseRouter
         SwapQuery[] memory destQueries = destination.router.getDestinationAmountOut(requests, address(tokenOut));
         // Step 4: find the best query (in practice, we could return them all)
-        uint256 maxAmountOut = 0;
         for (uint256 i = 0; i < tokens.length; ++i) {
-            if (destQueries[i].minAmountOut > maxAmountOut) {
+            if (destQueries[i].minAmountOut > destQuery.minAmountOut) {
                 originQuery = originQueries[i];
                 destQuery = destQueries[i];
             }

--- a/test/bridge/router/SynapseRouterSwap.t.sol
+++ b/test/bridge/router/SynapseRouterSwap.t.sol
@@ -36,7 +36,7 @@ contract SynapseRouterSwapTest is Utilities06 {
         super.setUp();
 
         weth = deployWETH();
-        neth = deploySynapseERC20("neth");
+        neth = deploySynapseERC20("neth", 18);
 
         {
             uint256[] memory amounts = new uint256[](2);

--- a/test/bridge/router/SynapseRouterUnsupported.t.sol
+++ b/test/bridge/router/SynapseRouterUnsupported.t.sol
@@ -30,7 +30,7 @@ contract SynapseRouterUnsupportedTest is Utilities06 {
         super.setUp();
 
         weth = deployWETH();
-        neth = deploySynapseERC20("neth");
+        neth = deploySynapseERC20("neth", 18);
 
         {
             uint256[] memory amounts = new uint256[](2);

--- a/test/bridge/router/mocks/AaveMock.t.sol
+++ b/test/bridge/router/mocks/AaveMock.t.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.12;
+
+import "../../../../contracts/amm/AaveSwapWrapper.sol";
+
+interface BurnMintToken {
+    function burnFrom(address to, uint256 amount) external;
+
+    function mint(address to, uint256 amount) external;
+}
+
+contract LendingPoolMock is ILendingPool {
+    using SafeERC20 for IERC20;
+
+    mapping(address => address) internal underlyingTokenMap;
+    mapping(address => address) internal aTokenMap;
+
+    function addToken(address _aToken, address _underlyingToken) external {
+        underlyingTokenMap[_aToken] = _underlyingToken;
+        aTokenMap[_underlyingToken] = _aToken;
+    }
+
+    /**
+     * @dev Deposits an `amount` of underlying asset into the reserve, receiving in return overlying aTokens.
+     * - E.g. User deposits 100 USDC and gets in return 100 aUSDC
+     * @param asset The address of the underlying asset to deposit
+     * @param amount The amount to be deposited
+     * @param onBehalfOf The address that will receive the aTokens, same as msg.sender if the user
+     *   wants to receive them on his own wallet, or a different address if the beneficiary of aTokens
+     *   is a different wallet
+     **/
+    function deposit(
+        address asset,
+        uint256 amount,
+        address onBehalfOf,
+        uint16
+    ) external override {
+        address aToken = aTokenMap[asset];
+        require(aToken != address(0), "Unknown asset");
+        IERC20(asset).safeTransferFrom(onBehalfOf, address(this), amount);
+        BurnMintToken(aToken).mint(onBehalfOf, amount);
+    }
+
+    /**
+     * @dev Withdraws an `amount` of underlying asset from the reserve, burning the equivalent aTokens owned
+     * E.g. User has 100 aUSDC, calls withdraw() and receives 100 USDC, burning the 100 aUSDC
+     * @param asset The address of the underlying asset to withdraw
+     * @param amount The underlying amount to be withdrawn
+     *   - Send the value type(uint256).max in order to withdraw the whole aToken balance
+     * @param to Address that will receive the underlying, same as msg.sender if the user
+     *   wants to receive it on his own wallet, or a different address if the beneficiary is a
+     *   different wallet
+     * @return The final amount withdrawn
+     **/
+    function withdraw(
+        address asset,
+        uint256 amount,
+        address to
+    ) external override returns (uint256) {
+        address aToken = aTokenMap[asset];
+        require(aToken != address(0), "Unknown asset");
+        uint256 amountOut = amount == type(uint256).max ? IERC20(aToken).balanceOf(msg.sender) : amount;
+        BurnMintToken(aToken).burnFrom(msg.sender, amountOut);
+        IERC20(asset).safeTransfer(to, amountOut);
+    }
+}

--- a/test/utils/Utilities06.sol
+++ b/test/utils/Utilities06.sol
@@ -12,11 +12,24 @@ import {SynapseERC20} from "../../contracts/bridge/SynapseERC20.sol";
 import {ISwap} from "../../contracts/bridge/interfaces/ISwap.sol";
 import {IWETH9} from "../../contracts/bridge/interfaces/IWETH9.sol";
 
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-contract ERC20Decimals is ERC20 {
+contract ERC20Mock is ERC20, Ownable {
     constructor(string memory name_, uint8 decimals_) public ERC20(name_, name_) {
         _setupDecimals(decimals_);
+    }
+
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+
+    function burnFrom(address from, uint256 amount) external onlyOwner {
+        _burn(from, amount);
     }
 }
 
@@ -120,7 +133,7 @@ contract Utilities06 is Test {
      * @notice Deploys and labels an ERC20 mock.
      */
     function deployERC20(string memory name, uint8 decimals) public returns (ERC20 token) {
-        token = new ERC20Decimals(name, decimals);
+        token = new ERC20Mock(name, decimals);
         vm.label(address(token), name);
     }
 

--- a/test/utils/Utilities06.sol
+++ b/test/utils/Utilities06.sol
@@ -140,9 +140,9 @@ contract Utilities06 is Test {
     /**
      * @notice Deploys and labels a SynapseERC20 token.
      */
-    function deploySynapseERC20(string memory name) public returns (SynapseERC20 token) {
+    function deploySynapseERC20(string memory name, uint8 decimals) public returns (SynapseERC20 token) {
         token = new SynapseERC20();
-        token.initialize(name, name, 18, address(this));
+        token.initialize(name, name, decimals, address(this));
         vm.label(address(token), name);
     }
 


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

A bunch of end-to-end tests covering bridging of following tokens have been added:
- `nUSD` and its connected stablecoins
- `nETH`, `WETH`, native `ETH` and Avalanche's `aWETH`
- `JEWEL`, including DFK where it is a gas token
- `GMX`

Also, e945a2b2bac1f63507608a06f179eb61f5a558e7 fixed the incorrect "find best path" algorithm, used in the test suite. A test to ensure the quote matches the one obtained straightforward way was also added.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
