### PR TITLE
Owner transfership in constructor

### DIFF
--- a/contracts/bridge/router/SwapQuoter.sol
+++ b/contracts/bridge/router/SwapQuoter.sol
@@ -31,9 +31,14 @@ contract SwapQuoter is SwapCalculator, Ownable {
 
     uint256 private constant PATH_FOUND = 1;
 
-    constructor(address _synapseRouter, address _weth) public {
+    constructor(
+        address _synapseRouter,
+        address _weth,
+        address owner_
+    ) public {
         synapseRouter = _synapseRouter;
         weth = _weth;
+        transferOwnership(owner_);
     }
 
     /*╔══════════════════════════════════════════════════════════════════════╗*\

--- a/contracts/bridge/router/SynapseRouter.sol
+++ b/contracts/bridge/router/SynapseRouter.sol
@@ -53,8 +53,9 @@ contract SynapseRouter is LocalBridgeConfig, SynapseAdapter, MulticallView {
      * @dev Redeploy an implementation with different values, if an update is required.
      * Upgrading the proxy implementation then will effectively "update the immutables".
      */
-    constructor(address _synapseBridge) public {
+    constructor(address _synapseBridge, address owner_) public {
         synapseBridge = ISynapseBridge(_synapseBridge);
+        transferOwnership(owner_);
     }
 
     /*╔══════════════════════════════════════════════════════════════════════╗*\

--- a/test/bridge/router/SwapQuoter.t.sol
+++ b/test/bridge/router/SwapQuoter.t.sol
@@ -30,7 +30,7 @@ contract SwapQuoterTest is Utilities06 {
         // Deploy ETH tokens
         neth = deployERC20("nETH", 18);
         weth = deployERC20("WETH", 18);
-        quoter = new SwapQuoter(ROUTER_MOCK, address(weth));
+        quoter = new SwapQuoter(ROUTER_MOCK, address(weth), OWNER);
         // Deploy USD tokens
         nusd = deployERC20("nUSD", 18);
         dai = deployERC20("DAI", 18);
@@ -59,8 +59,6 @@ contract SwapQuoterTest is Utilities06 {
             nUsdPool = deployPoolWithLiquidity(nUsdTokens, amounts);
             vm.label(nUsdPool, "nUSD Pool");
         }
-
-        quoter.transferOwnership(OWNER);
     }
 
     function test_setUp() public {

--- a/test/bridge/router/SynapseRouterSuite.t.sol
+++ b/test/bridge/router/SynapseRouterSuite.t.sol
@@ -174,8 +174,9 @@ abstract contract SynapseRouterSuite is Utilities06 {
     }
 
     function deployChainRouter(ChainSetup memory chain) public virtual {
-        chain.router = new SynapseRouter(address(chain.bridge));
-        chain.quoter = new SwapQuoter(address(chain.router), address(chain.wgas));
+        // We're using this contract as owner for testing suite deployments
+        chain.router = new SynapseRouter(address(chain.bridge), address(this));
+        chain.quoter = new SwapQuoter(address(chain.router), address(chain.wgas), address(this));
         chain.router.setSwapQuoter(chain.quoter);
 
         vm.label(address(chain.bridge), concat(chain.name, " Bridge"));

--- a/test/bridge/router/SynapseRouterSwap.t.sol
+++ b/test/bridge/router/SynapseRouterSwap.t.sol
@@ -48,14 +48,16 @@ contract SynapseRouterSwapTest is Utilities06 {
         }
 
         // Bridge address is not required for swap testing
-        router = new SynapseRouter(address(0));
-        quoter = new SwapQuoter(address(router), address(weth));
+        // We're using this contract as owner for testing suite deployments
+        router = new SynapseRouter(address(0), address(this));
+        quoter = new SwapQuoter(address(router), address(weth), address(this));
         quoter.addPool(nEthPool);
         router.setSwapQuoter(quoter);
 
         // Deploy "external" router/quoter
-        routerExt = new SynapseRouter(address(0));
-        quoterExt = new SwapQuoter(address(routerExt), address(weth));
+        // We're using this contract as owner for testing suite deployments
+        routerExt = new SynapseRouter(address(0), address(this));
+        quoterExt = new SwapQuoter(address(routerExt), address(weth), address(this));
         quoterExt.addPool(nEthPool);
         routerExt.setSwapQuoter(quoterExt);
 

--- a/test/bridge/router/SynapseRouterUnsupported.t.sol
+++ b/test/bridge/router/SynapseRouterUnsupported.t.sol
@@ -42,8 +42,9 @@ contract SynapseRouterUnsupportedTest is Utilities06 {
         }
 
         bridge = deployBridge();
-        router = new SynapseRouter(address(bridge));
-        quoter = new SwapQuoter(address(router), address(weth));
+        // We're using this contract as owner for testing suite deployments
+        router = new SynapseRouter(address(bridge), address(this));
+        quoter = new SwapQuoter(address(router), address(weth), address(this));
 
         quoter.addPool(nEthPool);
         router.setSwapQuoter(quoter);

--- a/test/bridge/router/SynapseRouterViews.t.sol
+++ b/test/bridge/router/SynapseRouterViews.t.sol
@@ -59,8 +59,9 @@ contract SynapseRouterViewsTest is Utilities06 {
         nexusNusd = ERC20(_lpToken);
 
         bridge = deployBridge();
-        router = new SynapseRouter(address(bridge));
-        quoter = new SwapQuoter(address(router), address(weth));
+        // We're using this contract as owner for testing suite deployments
+        router = new SynapseRouter(address(bridge), address(this));
+        quoter = new SwapQuoter(address(router), address(weth), address(this));
 
         quoter.addPool(nEthPool);
         quoter.addPool(nUsdPool);


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

A small PR to enable contract deployments from a factory. As the deployer won't be the `msg.sender`, an extra `owner` argument is required in the constructor.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
