### PR TITLE
Remove block pinning in Canto tests

### DIFF
--- a/test/bridge/wrappers/swap/CantoSwapWrapper.t.sol
+++ b/test/bridge/wrappers/swap/CantoSwapWrapper.t.sol
@@ -22,9 +22,6 @@ interface ISynapseTest is ISynapse {
 contract NewCantoSwapWrapperTestFork is Test {
     using SafeERC20 for IERC20;
 
-    // 2022-12-02
-    uint256 public constant TEST_BLOCK_NUMBER = 1_894_000;
-
     address internal constant NUSD = 0xD8836aF2e565D3Befce7D906Af63ee45a57E8f80;
     address internal constant NOTE = 0x4e71A2E537B7f9D9413D3991D37958c0b5e1e503;
     address internal constant USDC = 0x80b5a32E4F032B2a058b4F29EC95EEfEEB87aDcd;
@@ -41,7 +38,7 @@ contract NewCantoSwapWrapperTestFork is Test {
     function setUp() public {
         string memory cantoRPC = vm.envString("CANTO_API");
         // Fork Canto for SwapWrapper tests
-        vm.createSelectFork(cantoRPC, TEST_BLOCK_NUMBER);
+        vm.createSelectFork(cantoRPC);
 
         vm.label(NUSD, "nUSD");
         vm.label(NOTE, "NOTE");

--- a/test/bridge/wrappers/swap/LegacyCantoSwapWrapper.t.sol
+++ b/test/bridge/wrappers/swap/LegacyCantoSwapWrapper.t.sol
@@ -16,9 +16,6 @@ interface ISynapseTest is ISynapse {
 contract LegacyCantoSwapWrapperTestFork is Test {
     using SafeERC20 for IERC20;
 
-    // 2022-12-02
-    uint256 public constant TEST_BLOCK_NUMBER = 1_894_000;
-
     address internal constant NUSD = 0xD8836aF2e565D3Befce7D906Af63ee45a57E8f80;
     address internal constant NOTE = 0x4e71A2E537B7f9D9413D3991D37958c0b5e1e503;
     address internal constant USDC = 0x80b5a32E4F032B2a058b4F29EC95EEfEEB87aDcd;
@@ -35,7 +32,7 @@ contract LegacyCantoSwapWrapperTestFork is Test {
     function setUp() public {
         string memory cantoRPC = vm.envString("CANTO_API");
         // Fork Canto for SwapWrapper tests
-        vm.createSelectFork(cantoRPC, TEST_BLOCK_NUMBER);
+        vm.createSelectFork(cantoRPC);
 
         swap = new LegacyCantoSwapWrapper();
         for (uint8 i = 0; i < COINS; ++i) {


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

Canto fork tests are no longer pinned to any block.
It looks as if the public Canto node we're using for tests (slingshot) does not handle the archive calls well,
thus removing the pin should lead to `foundry-fork` workflow to flake at a considerably lower rate.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
