### PR TITLE
Feat: cctp request library

### DIFF
--- a/contracts/cctp/libs/Errors.sol
+++ b/contracts/cctp/libs/Errors.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+error IndexOutOrRange();
+error SliceOverrun();

--- a/contracts/cctp/libs/Errors.sol
+++ b/contracts/cctp/libs/Errors.sol
@@ -3,3 +3,6 @@ pragma solidity 0.8.17;
 
 error IndexOutOrRange();
 error SliceOverrun();
+
+error IncorrectRequestLength();
+error UnknownRequestVersion();

--- a/contracts/cctp/libs/Request.sol
+++ b/contracts/cctp/libs/Request.sol
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IncorrectRequestLength, UnknownRequestVersion} from "./Errors.sol";
+import {BytesArray, SlicerLib} from "./Slicer.sol";
+
+type Request is uint256;
+
+using RequestLib for Request global;
+
+/// # Memory layout of common Request fields for versions [REQUEST_BASE, ...)
+/// > - (originDomain, nonce, originBurnToken) are optimized for storage in a single slot.
+///
+/// | Position   | Field           | Type    | Bytes | Description                                        |
+/// | ---------- | --------------- | ------- | ----- | -------------------------------------------------- |
+/// | [000..004) | originDomain    | uint32  | 4     | Domain of the origin chain                         |
+/// | [004..012) | nonce           | uint64  | 8     | Nonce of the CCTP message on origin domain         |
+/// | [012..032) | originBurnToken | address | 20    | Circle token that was burned on origin domain      |
+/// | [032..064) | amount          | uint256 | 32    | Amount of tokens to burn                           |
+/// | [064..084) | recipient       | address | 20    | Recipient of the tokens on destination domain      |
+///
+/// # Memory layout of common Request fields for versions [REQUEST_SWAP, ...)
+/// > - (pool, tokenIndexFrom, tokenIndexTo, deadline) are optimized for storage in a single slot.
+/// > - deadline is stored as uint80, which is enough to store timestamps until year 3*10^16.
+/// > - If a swap fails due to deadline or minAmountOut check, the recipient will receive the minted Circle token.
+///
+/// | Position   | Field           | Type    | Bytes | Description                                        |
+/// | ---------- | --------------- | ------- | ----- | -------------------------------------------------- |
+/// | [084..104) | pool            | address | 20    | Liquidity pool for swapping Circle token           |
+/// | [104..105) | tokenIndexFrom  | uint8   | 1     | Index of the minted Circle token in the pool       |
+/// | [105..106) | tokenIndexTo    | uint8   | 1     | Index of the final token in the pool               |
+/// | [106..116) | deadline        | uint80  | 10    | Latest timestamp to execute the swap               |
+/// | [116..148) | minAmountOut    | uint256 | 32    | Minimum amount of tokens to receive from the swap  |
+library RequestLib {
+    uint32 internal constant REQUEST_BASE = 0;
+    uint32 internal constant REQUEST_SWAP = 1;
+
+    uint256 private constant OFFSET_ORIGIN_DATA = 0;
+    uint256 private constant OFFSET_AMOUNT = OFFSET_ORIGIN_DATA + 32;
+    uint256 private constant OFFSET_RECIPIENT = OFFSET_AMOUNT + 32;
+    uint256 private constant REQUEST_BASE_LENGTH = OFFSET_RECIPIENT + 20;
+
+    uint256 private constant OFFSET_SWAP_PARAMS = REQUEST_BASE_LENGTH;
+    uint256 private constant OFFSET_MIN_AMOUNT_OUT = OFFSET_SWAP_PARAMS + 32;
+    uint256 private constant REQUEST_SWAP_LENGTH = OFFSET_MIN_AMOUNT_OUT + 32;
+    uint256 private constant SWAP_PARAMS_LENGTH = REQUEST_SWAP_LENGTH - REQUEST_BASE_LENGTH;
+
+    /// @notice Formats the base request into a bytes array.
+    /// @param originDomain_        Domain of the origin chain
+    /// @param nonce_               Nonce of the CCTP message on origin domain
+    /// @param originBurnToken_     Circle token that was burned on origin domain
+    /// @param amount_              Amount of tokens to burn
+    /// @param recipient_           Recipient of the tokens on destination domain
+    /// @return formattedRequest    Properly formatted base request
+    function formatBaseRequest(
+        uint32 originDomain_,
+        uint64 nonce_,
+        address originBurnToken_,
+        uint256 amount_,
+        address recipient_
+    ) internal pure returns (bytes memory formattedRequest) {
+        formattedRequest = abi.encodePacked(originDomain_, nonce_, originBurnToken_, amount_, recipient_);
+    }
+
+    /// @notice Formats the swap parameters part of the swap request into a bytes array.
+    /// @param pool_                Liquidity pool for swapping Circle token
+    /// @param tokenIndexFrom_      Index of the minted Circle token in the pool
+    /// @param tokenIndexTo_        Index of the final token in the pool
+    /// @param deadline_            Latest timestamp to execute the swap
+    /// @param minAmountOut_        Minimum amount of tokens to receive from the swap
+    /// @return formattedSwapParams Properly formatted swap parameters
+    function formatSwapParams(
+        address pool_,
+        uint8 tokenIndexFrom_,
+        uint8 tokenIndexTo_,
+        uint80 deadline_,
+        uint256 minAmountOut_
+    ) internal pure returns (bytes memory formattedSwapParams) {
+        formattedSwapParams = abi.encodePacked(pool_, tokenIndexFrom_, tokenIndexTo_, deadline_, minAmountOut_);
+    }
+
+    /// @notice Formats the request into a bytes array.
+    /// @dev Will revert if the either of these is true:
+    /// - Request version is unknown.
+    /// - Base request is not properly formatted.
+    /// - Swap parameters are specified for a base request.
+    /// - Swap parameters are not properly formatted.
+    /// @param requestVersion       Version of the request format
+    /// @param baseRequest_         Formatted base request
+    /// @param swapParams_          Formatted swap parameters
+    /// @return formattedRequest    Properly formatted swap request
+    function formatRequest(
+        uint32 requestVersion,
+        bytes memory baseRequest_,
+        bytes memory swapParams_
+    ) internal pure returns (bytes memory formattedRequest) {
+        if (requestVersion > REQUEST_SWAP) revert UnknownRequestVersion();
+        if (baseRequest_.length != REQUEST_BASE_LENGTH) revert IncorrectRequestLength();
+        if (requestVersion == REQUEST_BASE && swapParams_.length != 0) revert IncorrectRequestLength();
+        if (requestVersion == REQUEST_SWAP && swapParams_.length != SWAP_PARAMS_LENGTH) revert IncorrectRequestLength();
+        formattedRequest = abi.encodePacked(baseRequest_, swapParams_);
+    }
+
+    /// @notice Wraps the memory representation of a Request into a Request type.
+    function wrapRequest(uint32 requestVersion, bytes memory request) internal pure returns (Request) {
+        if (requestVersion > REQUEST_SWAP) revert UnknownRequestVersion();
+        if (requestVersion == REQUEST_BASE && request.length != REQUEST_BASE_LENGTH) {
+            revert IncorrectRequestLength();
+        }
+        if (requestVersion == REQUEST_SWAP && request.length != REQUEST_SWAP_LENGTH) {
+            revert IncorrectRequestLength();
+        }
+        // Wrap the BytesArray into Request type
+        return Request.wrap(BytesArray.unwrap(SlicerLib.wrapBytesArray(request)));
+    }
+
+    /// @notice Convenience shortcut for unwrapping a Request into a BytesArray.
+    function unwrap(Request request) internal pure returns (BytesArray) {
+        return BytesArray.wrap(Request.unwrap(request));
+    }
+
+    // ═══════════════════════════════════════════ REQUEST SLICING: BASE ═══════════════════════════════════════════════
+
+    /// @notice Extracts the data related to the origin domain.
+    /// @param request          Request to slice
+    /// @return originDomain    Domain of the origin chain
+    /// @return nonce           Nonce of the CCTP message on origin domain
+    /// @return originBurnToken Circle token that was burned on origin domain
+    function originData(Request request)
+        internal
+        pure
+        returns (
+            uint32 originDomain,
+            uint64 nonce,
+            address originBurnToken,
+            uint256 amount
+        )
+    {
+        bytes32 data = request.unwrap().sliceBytes32(OFFSET_ORIGIN_DATA);
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // To get originDomain, we need to shift the data by 256-32=224 bits
+            originDomain := shr(224, data)
+            // To get nonce, we need to shift the data by 256-96=160 bits, then mask the result with 0xFFFFFFFFFFFFFFFF
+            nonce := and(shr(160, data), 0xFFFFFFFFFFFFFFFF)
+            // To get originBurnToken, we need to mask the data with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+            originBurnToken := and(data, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+        }
+        // Read as bytes32 and then cast to uint256
+        amount = uint256(request.unwrap().sliceBytes32(OFFSET_AMOUNT));
+    }
+
+    /// @notice Extracts the recipient of the tokens on destination domain.
+    /// @param request      Request to slice
+    /// @return Recipient of the tokens on destination domain
+    function recipient(Request request) internal pure returns (address) {
+        return request.unwrap().sliceAddress(OFFSET_RECIPIENT);
+    }
+
+    // ═══════════════════════════════════════════ REQUEST SLICING: SWAP ═══════════════════════════════════════════════
+
+    /// @notice Extracts the swap parameters of the request
+    /// @param request          Request to slice
+    /// @return pool            Liquidity pool for swapping Circle token
+    /// @return tokenIndexFrom  Index of the minted Circle token in the pool
+    /// @return tokenIndexTo    Index of the final token in the pool
+    /// @return deadline        Latest timestamp to execute the swap
+    /// @return minAmountOut    Minimum amount of tokens to receive from the swap
+    function swapParams(Request request)
+        internal
+        pure
+        returns (
+            address pool,
+            uint8 tokenIndexFrom,
+            uint8 tokenIndexTo,
+            uint80 deadline,
+            uint256 minAmountOut
+        )
+    {
+        bytes32 data = request.unwrap().sliceBytes32(OFFSET_SWAP_PARAMS);
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // To get pool, we need to shift the data by 256-160=96 bits
+            pool := shr(96, data)
+            // To get tokenIndexFrom, we need to shift the data by 256-168=88 bits, then mask the result with 0xFF
+            tokenIndexFrom := and(shr(88, data), 0xFF)
+            // To get tokenIndexTo, we need to shift the data by 256-176=80 bits, then mask the result with 0xFF
+            tokenIndexTo := and(shr(80, data), 0xFF)
+            // To get deadline, we need to mask the data with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+            deadline := and(data, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+        }
+        // Read as bytes32 and then cast to uint256
+        minAmountOut = uint256(request.unwrap().sliceBytes32(OFFSET_MIN_AMOUNT_OUT));
+    }
+}

--- a/contracts/cctp/libs/Slicer.sol
+++ b/contracts/cctp/libs/Slicer.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IndexOutOrRange, SliceOverrun} from "./Errors.sol";
+
+/// `BytesArray` is a custom type for storing a memory reference to a bytes array.
+type BytesArray is uint256;
+
+using SlicerLib for BytesArray global;
+
+/// Library for slicing bytes arrays.
+/// # BytesArray stack layout (from highest bits to lowest)
+///
+/// | Position   | Field | Type    | Bytes | Description                              |
+/// | ---------- | ----- | ------- | ----- | ---------------------------------------- |
+/// | (032..016] | loc   | uint128 | 16    | Memory address of underlying bytes array |
+/// | (016..000] | len   | uint128 | 16    | Length of underlying bytes array         |
+library SlicerLib {
+    /// @notice Wrap a bytes array into a `BytesArray` custom type.
+    function wrapBytesArray(bytes memory arr) internal pure returns (BytesArray) {
+        // `bytes arr` is stored in memory in the following way
+        // 1. First, uint256 arr.length is stored. That requires 32 bytes (0x20).
+        // 2. Then, the array data is stored.
+        uint256 loc;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // We add 0x20 to get the locations where the array data starts
+            loc := add(arr, 0x20)
+        }
+        uint256 len = arr.length;
+        // There is no scenario where loc or len would overflow uint128, so we omit this check.
+        // We use the highest 128 bits to encode the location and the lowest 128 bits to encode the length.
+        return BytesArray.wrap((loc << 128) | len);
+    }
+
+    /// @notice Slices 32 bytes from the underlying bytes array starting from the given index.
+    function sliceBytes32(BytesArray arr, uint256 index) internal pure returns (bytes32 slice) {
+        (uint256 loc, uint256 len) = _unwrap(arr);
+        unchecked {
+            if (index >= len) revert IndexOutOrRange();
+            // len fits into uint128, so index+32 never overflows
+            if (index + 32 > len) revert SliceOverrun();
+        }
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // We need to load 32 bytes starting from loc + index
+            slice := mload(add(loc, index))
+        }
+    }
+
+    /// @notice Slices 20 bytes from the underlying bytes array starting from the given index,
+    /// and returns it as an address.
+    function sliceAddress(BytesArray arr, uint256 index) internal pure returns (address slice) {
+        (uint256 loc, uint256 len) = _unwrap(arr);
+        unchecked {
+            if (index >= len) revert IndexOutOrRange();
+            // len fits into uint128, so index+20 never overflows
+            if (index + 20 > len) revert SliceOverrun();
+        }
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // To slice the address we need to do two steps:
+            // 1. Load 32 bytes starting from loc + index: this gets the address in the highest 20 bytes
+            // 2. Shift the result to the right by 12 bytes (96 bits): this clears the dirty lowest 12 bytes
+            slice := shr(96, mload(add(loc, index)))
+        }
+    }
+
+    // ══════════════════════════════════════════════ PRIVATE HELPERS ══════════════════════════════════════════════════
+
+    function _unwrap(BytesArray arr) private pure returns (uint256 loc, uint256 len) {
+        // loc is stored in the highest 16 bytes of the underlying uint256
+        loc = BytesArray.unwrap(arr) >> 128;
+        // len is stored in the lowest 16 bytes of the underlying uint256
+        len = uint128(BytesArray.unwrap(arr));
+    }
+}

--- a/test/cctp/harnesses/RequestLibHarness.sol
+++ b/test/cctp/harnesses/RequestLibHarness.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {Request, RequestLib} from "../../../contracts/cctp/libs/Request.sol";
+
+contract RequestLibHarness {
+    function formatBaseRequest(
+        uint32 originDomain_,
+        uint64 nonce_,
+        address originBurnToken_,
+        uint256 amount_,
+        address recipient_
+    ) public pure returns (bytes memory formattedRequest) {
+        formattedRequest = RequestLib.formatBaseRequest(originDomain_, nonce_, originBurnToken_, amount_, recipient_);
+    }
+
+    function formatSwapParams(
+        address pool_,
+        uint8 tokenIndexFrom_,
+        uint8 tokenIndexTo_,
+        uint80 deadline_,
+        uint256 minAmountOut_
+    ) public pure returns (bytes memory formattedSwapParams) {
+        formattedSwapParams = RequestLib.formatSwapParams(
+            pool_,
+            tokenIndexFrom_,
+            tokenIndexTo_,
+            deadline_,
+            minAmountOut_
+        );
+    }
+
+    function formatRequest(
+        uint32 requestVersion,
+        bytes memory baseRequest_,
+        bytes memory swapParams_
+    ) public pure returns (bytes memory formattedRequest) {
+        formattedRequest = RequestLib.formatRequest(requestVersion, baseRequest_, swapParams_);
+    }
+
+    function wrapRequest(uint32 requestVersion, bytes memory request) public pure {
+        RequestLib.wrapRequest(requestVersion, request);
+    }
+
+    function originData(uint32 requestVersion, bytes memory formattedRequest)
+        public
+        pure
+        returns (
+            uint32 originDomain,
+            uint64 nonce,
+            address originBurnToken,
+            uint256 amount
+        )
+    {
+        Request request = RequestLib.wrapRequest(requestVersion, formattedRequest);
+        return request.originData();
+    }
+
+    function recipient(uint32 requestVersion, bytes memory formattedRequest) public pure returns (address) {
+        Request request = RequestLib.wrapRequest(requestVersion, formattedRequest);
+        return request.recipient();
+    }
+
+    function swapParams(uint32 requestVersion, bytes memory formattedRequest)
+        public
+        pure
+        returns (
+            address pool,
+            uint8 tokenIndexFrom,
+            uint8 tokenIndexTo,
+            uint80 deadline,
+            uint256 minAmountOut
+        )
+    {
+        Request request = RequestLib.wrapRequest(requestVersion, formattedRequest);
+        return request.swapParams();
+    }
+}

--- a/test/cctp/harnesses/SlicerLibHarness.sol
+++ b/test/cctp/harnesses/SlicerLibHarness.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {BytesArray, SlicerLib} from "../../../contracts/cctp/libs/Slicer.sol";
+
+contract SlicerLibHarness {
+    function sliceBytes32(bytes memory arr, uint256 index) public pure returns (bytes32) {
+        BytesArray bytesArray = SlicerLib.wrapBytesArray(arr);
+        return bytesArray.sliceBytes32(index);
+    }
+
+    function sliceAddress(bytes memory arr, uint256 index) public pure returns (address) {
+        BytesArray bytesArray = SlicerLib.wrapBytesArray(arr);
+        return bytesArray.sliceAddress(index);
+    }
+}

--- a/test/cctp/libs/Request.t.sol
+++ b/test/cctp/libs/Request.t.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IncorrectRequestLength, UnknownRequestVersion} from "../../../contracts/cctp/libs/Errors.sol";
+import {RequestLibHarness, RequestLib} from "../harnesses/RequestLibHarness.sol";
+import {Test} from "forge-std/Test.sol";
+
+contract RequestLibraryTest is Test {
+    // TODO: move outside of this contract
+    struct RawBaseRequest {
+        uint32 originDomain;
+        uint64 nonce;
+        address originBurnToken;
+        uint256 amount;
+        address recipient;
+    }
+
+    struct RawSwapRequest {
+        address pool;
+        uint8 tokenIndexFrom;
+        uint8 tokenIndexTo;
+        uint80 deadline;
+        uint256 minAmountOut;
+    }
+
+    RequestLibHarness public libHarness;
+
+    uint256 public constant EXPECTED_BASE_REQUEST_LENGTH = 84;
+    uint256 public constant EXPECTED_SWAP_PARAMS_LENGTH = 64;
+    uint256 public constant EXPECTED_SWAP_REQUEST_LENGTH = 148;
+
+    function setUp() public {
+        libHarness = new RequestLibHarness();
+    }
+
+    function testFormatBaseRequest(RawBaseRequest memory rbr) public {
+        bytes memory formattedRequest = libHarness.formatBaseRequest(
+            rbr.originDomain,
+            rbr.nonce,
+            rbr.originBurnToken,
+            rbr.amount,
+            rbr.recipient
+        );
+        assertEq(
+            formattedRequest,
+            abi.encodePacked(rbr.originDomain, rbr.nonce, rbr.originBurnToken, rbr.amount, rbr.recipient)
+        );
+        assertEq(formattedRequest, libHarness.formatRequest(RequestLib.REQUEST_BASE, formattedRequest, ""));
+        (uint32 originDomain, uint64 nonce, address originBurnToken, uint256 amount) = libHarness.originData(
+            0,
+            formattedRequest
+        );
+        assertEq(originDomain, rbr.originDomain);
+        assertEq(nonce, rbr.nonce);
+        assertEq(originBurnToken, rbr.originBurnToken);
+        assertEq(amount, rbr.amount);
+        assertEq(libHarness.recipient(0, formattedRequest), rbr.recipient);
+    }
+
+    function testFormatSwapRequest(RawBaseRequest memory rbr, RawSwapRequest memory rsr) public {
+        bytes memory formattedBaseRequest = libHarness.formatBaseRequest(
+            rbr.originDomain,
+            rbr.nonce,
+            rbr.originBurnToken,
+            rbr.amount,
+            rbr.recipient
+        );
+        bytes memory formattedSwapParams = libHarness.formatSwapParams(
+            rsr.pool,
+            rsr.tokenIndexFrom,
+            rsr.tokenIndexTo,
+            rsr.deadline,
+            rsr.minAmountOut
+        );
+        bytes memory formattedRequest = libHarness.formatRequest(
+            RequestLib.REQUEST_SWAP,
+            formattedBaseRequest,
+            formattedSwapParams
+        );
+        assertEq(
+            formattedSwapParams,
+            abi.encodePacked(rsr.pool, rsr.tokenIndexFrom, rsr.tokenIndexTo, rsr.deadline, rsr.minAmountOut)
+        );
+        assertEq(
+            formattedRequest,
+            abi.encodePacked(
+                rbr.originDomain,
+                rbr.nonce,
+                rbr.originBurnToken,
+                rbr.amount,
+                rbr.recipient,
+                rsr.pool,
+                rsr.tokenIndexFrom,
+                rsr.tokenIndexTo,
+                rsr.deadline,
+                rsr.minAmountOut
+            )
+        );
+        (uint32 originDomain, uint64 nonce, address originBurnToken, uint256 amount) = libHarness.originData(
+            1,
+            formattedRequest
+        );
+        assertEq(originDomain, rbr.originDomain);
+        assertEq(nonce, rbr.nonce);
+        assertEq(originBurnToken, rbr.originBurnToken);
+        assertEq(amount, rbr.amount);
+        assertEq(libHarness.recipient(1, formattedRequest), rbr.recipient);
+        (address pool, uint8 tokenIndexFrom, uint8 tokenIndexTo, uint80 deadline, uint256 minAmountOut) = libHarness
+            .swapParams(1, formattedRequest);
+        assertEq(pool, rsr.pool);
+        assertEq(tokenIndexFrom, rsr.tokenIndexFrom);
+        assertEq(tokenIndexTo, rsr.tokenIndexTo);
+        assertEq(deadline, rsr.deadline);
+        assertEq(minAmountOut, rsr.minAmountOut);
+    }
+
+    function testFormatBaseRequestIncorrectBaseRequestLength(uint8 length) public {
+        vm.assume(length != EXPECTED_BASE_REQUEST_LENGTH); // See RequestLib.sol
+        bytes memory baseRequest = new bytes(length);
+        vm.expectRevert(IncorrectRequestLength.selector);
+        libHarness.formatRequest(0, baseRequest, "");
+    }
+
+    function testFormatSwapRequestIncorrectBaseRequestLength(uint8 length) public {
+        vm.assume(length != EXPECTED_BASE_REQUEST_LENGTH); // See RequestLib.sol
+        bytes memory baseRequest = new bytes(length);
+        bytes memory swapParams = new bytes(64);
+        vm.expectRevert(IncorrectRequestLength.selector);
+        libHarness.formatRequest(1, baseRequest, swapParams);
+    }
+
+    function testFormatBaseRequestIncorrectSwapParamsLength(uint8 length) public {
+        vm.assume(length != 0);
+        bytes memory baseRequest = new bytes(EXPECTED_BASE_REQUEST_LENGTH);
+        bytes memory swapParams = new bytes(length);
+        vm.expectRevert(IncorrectRequestLength.selector);
+        libHarness.formatRequest(0, baseRequest, swapParams);
+    }
+
+    function testFormatSwapRequestIncorrectSwapParamsLength(uint8 length) public {
+        vm.assume(length != EXPECTED_SWAP_PARAMS_LENGTH);
+        bytes memory baseRequest = new bytes(EXPECTED_BASE_REQUEST_LENGTH);
+        bytes memory swapParams = new bytes(length);
+        vm.expectRevert(IncorrectRequestLength.selector);
+        libHarness.formatRequest(1, baseRequest, swapParams);
+    }
+
+    function testFormatRequestIncorrectVersion(uint32 version) public {
+        vm.assume(version > RequestLib.REQUEST_SWAP);
+        bytes memory baseRequest = new bytes(EXPECTED_BASE_REQUEST_LENGTH);
+        bytes memory swapParams = new bytes(EXPECTED_SWAP_PARAMS_LENGTH);
+        vm.expectRevert(UnknownRequestVersion.selector);
+        libHarness.formatRequest(version, baseRequest, swapParams);
+    }
+
+    function testWrapBaseRequestIncorrectLength(uint8 length) public {
+        vm.assume(length != EXPECTED_BASE_REQUEST_LENGTH); // See RequestLib.sol
+        bytes memory request = new bytes(length);
+        vm.expectRevert(IncorrectRequestLength.selector);
+        libHarness.wrapRequest(RequestLib.REQUEST_BASE, request);
+    }
+
+    function testWrapSwapRequestIncorrectLength(uint8 length) public {
+        vm.assume(length != EXPECTED_SWAP_REQUEST_LENGTH); // See RequestLib.sol
+        bytes memory request = new bytes(length);
+        vm.expectRevert(IncorrectRequestLength.selector);
+        libHarness.wrapRequest(RequestLib.REQUEST_SWAP, request);
+    }
+
+    function testWrapRequestUnknownVersion(uint32 version) public {
+        vm.assume(version > RequestLib.REQUEST_SWAP);
+        bytes memory request = new bytes(EXPECTED_BASE_REQUEST_LENGTH);
+        vm.expectRevert(UnknownRequestVersion.selector);
+        libHarness.wrapRequest(version, request);
+    }
+}

--- a/test/cctp/libs/Slicer.t.sol
+++ b/test/cctp/libs/Slicer.t.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IndexOutOrRange, SliceOverrun} from "../../../contracts/cctp/libs/Errors.sol";
+import {SlicerLibHarness} from "../harnesses/SlicerLibHarness.sol";
+import {Test} from "forge-std/Test.sol";
+
+contract SlicerLibraryTest is Test {
+    SlicerLibHarness public libHarness;
+    bytes public testBytes;
+
+    function setUp() public {
+        libHarness = new SlicerLibHarness();
+        for (uint256 i = 0; i <= type(uint8).max; ++i) {
+            testBytes.push(bytes1(uint8(i)));
+        }
+    }
+
+    function testSliceBytes32() public {
+        uint256 maxIndex = testBytes.length - 32;
+        for (uint256 i = 0; i <= maxIndex; ++i) {
+            assertEq(libHarness.sliceBytes32(testBytes, i), dumbSliceBytes32(i));
+        }
+    }
+
+    function testSliceAddress() public {
+        uint256 maxIndex = testBytes.length - 20;
+        for (uint256 i = 0; i <= maxIndex; ++i) {
+            assertEq(libHarness.sliceAddress(testBytes, i), dumbSliceAddress(i));
+        }
+    }
+
+    function testSliceBytes32IndexOutOfRange(uint256 index) public {
+        index = bound(index, testBytes.length, type(uint256).max);
+        vm.expectRevert(IndexOutOrRange.selector);
+        libHarness.sliceBytes32(testBytes, index);
+    }
+
+    function testSliceBytes32SliceOverrun() public {
+        uint256 maxIndex = testBytes.length - 32;
+        for (uint256 i = maxIndex + 1; i < testBytes.length; ++i) {
+            vm.expectRevert(SliceOverrun.selector);
+            libHarness.sliceBytes32(testBytes, i);
+        }
+    }
+
+    function testSliceBytes32SliceOverrunShortArray() public {
+        bytes memory arr = new bytes(16);
+        for (uint256 i = 0; i < arr.length; ++i) {
+            vm.expectRevert(SliceOverrun.selector);
+            libHarness.sliceBytes32(arr, i);
+        }
+    }
+
+    function testSliceAddressIndexOutOfRange(uint256 index) public {
+        index = bound(index, testBytes.length, type(uint256).max);
+        vm.expectRevert(IndexOutOrRange.selector);
+        libHarness.sliceAddress(testBytes, index);
+    }
+
+    function testSliceAddressSliceOverrun() public {
+        uint256 maxIndex = testBytes.length - 20;
+        for (uint256 i = maxIndex + 1; i < testBytes.length; ++i) {
+            vm.expectRevert(SliceOverrun.selector);
+            libHarness.sliceAddress(testBytes, i);
+        }
+    }
+
+    function testSliceAddressSliceOverrunShortArray() public {
+        bytes memory arr = new bytes(16);
+        for (uint256 i = 0; i < arr.length; ++i) {
+            vm.expectRevert(SliceOverrun.selector);
+            libHarness.sliceAddress(arr, i);
+        }
+    }
+
+    function dumbSliceAddress(uint256 index) public view returns (address) {
+        bytes memory arr = new bytes(32);
+        for (uint256 i = 0; i < 20; ++i) {
+            arr[12 + i] = testBytes[index + i];
+        }
+        return abi.decode(arr, (address));
+    }
+
+    function dumbSliceBytes32(uint256 index) public view returns (bytes32) {
+        bytes memory arr = new bytes(32);
+        for (uint256 i = 0; i < 32; ++i) {
+            arr[i] = testBytes[index + i];
+        }
+        return abi.decode(arr, (bytes32));
+    }
+}


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

This PR adds support for encoding/decoding the requests associated with bridging Circle tokens using CCTP. The request fields are tight packed and use a custom `Slicer` library to slice the fields out of raw payload.

Currently two types of requests are supported:
- Base requests. These encode the information about the bridged token, as well as the recipient address on destination chain.
- Swap requests. These extend the base requests by having additional fields to describe a swap that needs to be performed after the Circle tokens are minted.

The request payloads will be generated by `SynapseCCTP` contracts based on:
- Information about the bridged burnt token on origin chain (constructed&verified by `SynapseCCTP`).
- User inputs:
  - Recipient address on destination chain.
  - Swap params for destination chain, if needed.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
