### PR TITLE
Feat: first draft for CCTP

### DIFF
--- a/contracts/cctp/SynapseCCTP.sol
+++ b/contracts/cctp/SynapseCCTP.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {SynapseCCTPEvents} from "./events/SynapseCCTPEvents.sol";
+import {IMessageTransmitter} from "./interfaces/IMessageTransmitter.sol";
+import {ISynapseCCTP} from "./interfaces/ISynapseCCTP.sol";
+import {ITokenMessenger} from "./interfaces/ITokenMessenger.sol";
+import {RequestLib} from "./libs/Request.sol";
+
+contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
+    // TODO: add setters for these (or make them immutable)
+    uint32 public localDomain;
+    IMessageTransmitter public messageTransmitter;
+    ITokenMessenger public tokenMessenger;
+    mapping(uint32 => bytes32) public remoteSynapseCCTP;
+
+    /// @inheritdoc ISynapseCCTP
+    function sendCircleToken(
+        address recipient,
+        uint32 destinationDomain,
+        address burnToken,
+        uint256 amount,
+        uint32 requestVersion,
+        bytes memory swapParams
+    ) external {
+        uint64 nonce = messageTransmitter.nextAvailableNonce();
+        // This will revert if the request version is not supported, or swap params are not properly formatted.
+        bytes memory formattedRequest = RequestLib.formatRequest(
+            requestVersion,
+            RequestLib.formatBaseRequest(localDomain, nonce, burnToken, amount, recipient),
+            swapParams
+        );
+        // Construct the request identifier to be used as salt later.
+        // Origin domain and nonce are already part of the request, so we only need to add the destination domain.
+        bytes32 kappa = _kappa(destinationDomain, requestVersion, formattedRequest);
+        tokenMessenger.depositForBurnWithCaller(
+            amount,
+            destinationDomain,
+            remoteSynapseCCTP[destinationDomain],
+            burnToken,
+            _destinationCaller(destinationDomain, kappa)
+        );
+        emit CircleRequestSent(destinationDomain, nonce, requestVersion, formattedRequest, kappa);
+    }
+
+    // TODO: guard this to be only callable by the validators?
+    /// @inheritdoc ISynapseCCTP
+    function receiveCircleToken(
+        bytes calldata message,
+        bytes calldata signature,
+        uint32 requestVersion,
+        bytes memory formattedRequest
+    ) external {
+        (bytes memory baseRequest, bytes memory swapParams) = RequestLib.decodeRequest(
+            requestVersion,
+            formattedRequest
+        );
+        (uint32 originDomain, , address originBurnToken, uint256 amount, address recipient) = RequestLib
+            .decodeBaseRequest(baseRequest);
+        bytes32 kappa = _kappa(localDomain, requestVersion, formattedRequest);
+        // Kindly ask the Circle Bridge to mint the tokens for us.
+        _mintCircleToken(message, signature, kappa);
+        address token = _getMintedToken(originDomain, originBurnToken);
+        uint256 fee;
+        // Apply the bridging fee. This will revert if amount <= fee.
+        (amount, fee) = _applyFee(token, amount);
+        // Fulfill the request: perform an optional swap and send the end tokens to the recipient.
+        _fulfillRequest(recipient, token, amount, swapParams);
+        emit CircleRequestFulfilled(recipient, token, amount, fee, kappa);
+    }
+
+    // ══════════════════════════════════════════════ INTERNAL LOGIC ═══════════════════════════════════════════════════
+
+    /// @dev Applies the bridging fee. Will revert if amount <= fee.
+    function _applyFee(address token, uint256 amount) internal returns (uint256 amountAfterFee, uint256 fee) {
+        // TODO: implement
+    }
+
+    /// @dev Mints the Circle token by sending the message and signature to the Circle Bridge.
+    function _mintCircleToken(
+        bytes calldata message,
+        bytes calldata signature,
+        bytes32 kappa
+    ) internal {
+        // TODO: implement
+    }
+
+    /// @dev Performs a swap, if was requested back on origin chain, and transfers the tokens to the recipient.
+    /// Should the swap fail, will transfer `token` to the recipient instead.
+    function _fulfillRequest(
+        address recipient,
+        address token,
+        uint256 amount,
+        bytes memory swapParams
+    ) internal {
+        // TODO: implement
+    }
+
+    // ══════════════════════════════════════════════ INTERNAL VIEWS ═══════════════════════════════════════════════════
+
+    /// @dev Predicts the address of the destination caller.
+    function _destinationCaller(uint32 destinationDomain, bytes32 kappa) internal view returns (bytes32) {
+        // TODO: implement
+    }
+
+    /// @dev Fetches the address and the amount of the minted Circle token.
+    function _getMintedToken(uint32 originDomain, address originBurnToken) internal view returns (address token) {
+        // TODO: implement
+    }
+
+    /// @dev Calculates the unique identifier of the request.
+    function _kappa(
+        uint32 destinationDomain,
+        uint32 requestVersion,
+        bytes memory request
+    ) internal pure returns (bytes32) {
+        // TODO: implement
+    }
+}

--- a/contracts/cctp/SynapseCCTP.sol
+++ b/contracts/cctp/SynapseCCTP.sol
@@ -31,7 +31,9 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
             swapParams
         );
         // Construct the request identifier to be used as salt later.
-        // Origin domain and nonce are already part of the request, so we only need to add the destination domain.
+        // The identifier (kappa) is unique for every single request on all the chains.
+        // This is done by including origin and destination domains as well as origin nonce in the hashed data.
+        // Origin domain and nonce are included in `formattedRequest`, so we only need to add the destination domain.
         bytes32 kappa = _kappa(destinationDomain, requestVersion, formattedRequest);
         tokenMessenger.depositForBurnWithCaller(
             amount,
@@ -57,6 +59,8 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
         );
         (uint32 originDomain, , address originBurnToken, uint256 amount, address recipient) = RequestLib
             .decodeBaseRequest(baseRequest);
+        // For kappa hashing we use origin and destination domains as well as origin nonce.
+        // This ensures that kappa is unique for each request, and that it is not possible to replay requests.
         bytes32 kappa = _kappa(localDomain, requestVersion, formattedRequest);
         // Kindly ask the Circle Bridge to mint the tokens for us.
         _mintCircleToken(message, signature, kappa);

--- a/contracts/cctp/events/MessageTransmitterEvents.sol
+++ b/contracts/cctp/events/MessageTransmitterEvents.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+abstract contract MessageTransmitterEvents {
+    /**
+     * @notice Emitted when a new message is dispatched
+     * @param message Raw bytes of message
+     */
+    event MessageSent(bytes message);
+
+    /**
+     * @notice Emitted when a new message is received
+     * @param caller Caller (msg.sender) on destination domain
+     * @param sourceDomain The source domain this message originated from
+     * @param nonce The nonce unique to this message
+     * @param sender The sender of this message
+     * @param messageBody message body bytes
+     */
+    event MessageReceived(
+        address indexed caller,
+        uint32 sourceDomain,
+        uint64 indexed nonce,
+        bytes32 sender,
+        bytes messageBody
+    );
+}

--- a/contracts/cctp/events/SynapseCCTPEvents.sol
+++ b/contracts/cctp/events/SynapseCCTPEvents.sol
@@ -7,17 +7,18 @@ abstract contract SynapseCCTPEvents {
     /// @notice Emitted when a Circle token is sent with an attached action request.
     /// @dev To fulfill the request, the validator needs to fetch `message` from `MessageSent` event
     /// emitted by Circle's MessageTransmitter in the same tx, then fetch `signature` for the message from Circle API.
-    /// All this data will need to be presented to SynapseCCTP on the destination domain.
+    /// This data will need to be presented to SynapseCCTP on the destination domain,
+    /// along with `requestVersion` and `formattedRequest` emitted in this event.
     /// @param destinationDomain    Domain of destination chain
     /// @param nonce                Nonce of the CCTP message on origin domain
     /// @param requestVersion       Version of the request format
-    /// @param request              Request for the action to take on the destination domain
+    /// @param formattedRequest     Formatted request for the action to take on the destination domain
     /// @param kappa                Unique identifier of the request
     event CircleRequestSent(
         uint32 destinationDomain,
         uint64 nonce,
         uint32 requestVersion,
-        bytes request,
+        bytes formattedRequest,
         bytes32 indexed kappa
     );
 

--- a/contracts/cctp/events/SynapseCCTPEvents.sol
+++ b/contracts/cctp/events/SynapseCCTPEvents.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+abstract contract SynapseCCTPEvents {
+    // TODO: figure out what we need to emit for the Explorer
+
+    /// @notice Emitted when a Circle token is sent with an attached action request.
+    /// @dev To fulfill the request, the validator needs to fetch `message` from `MessageSent` event
+    /// emitted by Circle's MessageTransmitter in the same tx, then fetch `signature` for the message from Circle API.
+    /// All this data will need to be presented to SynapseCCTP on the destination domain.
+    /// @param destinationDomain    Domain of destination chain
+    /// @param nonce                Nonce of the CCTP message on origin domain
+    /// @param requestVersion       Version of the request format
+    /// @param request              Request for the action to take on the destination domain
+    /// @param kappa                Unique identifier of the request
+    event CircleRequestSent(
+        uint32 destinationDomain,
+        uint64 nonce,
+        uint32 requestVersion,
+        bytes request,
+        bytes32 indexed kappa
+    );
+
+    /// @notice Emitted when a Circle token is received with an attached action request.
+    /// @param recipient            End recipient of the tokens on this domain
+    /// @param token                Address of Circle token received on this domain
+    /// @param amount               Amount of tokens received
+    /// @param fee                  Fee paid for fulfilling the request
+    /// @param kappa                Unique identifier of the request
+    event CircleRequestFulfilled(
+        address indexed recipient,
+        address token,
+        uint256 amount,
+        uint256 fee,
+        bytes32 indexed kappa
+    );
+}

--- a/contracts/cctp/events/TokenMessengerEvents.sol
+++ b/contracts/cctp/events/TokenMessengerEvents.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+abstract contract TokenMessengerEvents {
+    /**
+     * @notice Emitted when a DepositForBurn message is sent
+     * @param nonce unique nonce reserved by message
+     * @param burnToken address of token burnt on source domain
+     * @param amount deposit amount
+     * @param depositor address where deposit is transferred from
+     * @param mintRecipient address receiving minted tokens on destination domain as bytes32
+     * @param destinationDomain destination domain
+     * @param destinationTokenMessenger address of TokenMessenger on destination domain as bytes32
+     * @param destinationCaller authorized caller as bytes32 of receiveMessage() on destination domain, if not equal to bytes32(0).
+     * If equal to bytes32(0), any address can call receiveMessage().
+     */
+    event DepositForBurn(
+        uint64 indexed nonce,
+        address indexed burnToken,
+        uint256 amount,
+        address indexed depositor,
+        bytes32 mintRecipient,
+        uint32 destinationDomain,
+        bytes32 destinationTokenMessenger,
+        bytes32 destinationCaller
+    );
+
+    /**
+     * @notice Emitted when tokens are minted
+     * @param mintRecipient recipient address of minted tokens
+     * @param amount amount of minted tokens
+     * @param mintToken contract address of minted token
+     */
+    event MintAndWithdraw(address indexed mintRecipient, uint256 amount, address indexed mintToken);
+}

--- a/contracts/cctp/interfaces/IMessageTransmitter.sol
+++ b/contracts/cctp/interfaces/IMessageTransmitter.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface IMessageTransmitter {
+    /**
+     * @notice Receives an incoming message, validating the header and passing
+     * the body to application-specific handler.
+     * @param message The message raw bytes
+     * @param signature The message signature
+     * @return success bool, true if successful
+     */
+    function receiveMessage(bytes calldata message, bytes calldata signature) external returns (bool success);
+
+    /**
+     * @notice Sends an outgoing message from the source domain.
+     * @dev Increment nonce, format the message, and emit `MessageSent` event with message information.
+     * @param destinationDomain Domain of destination chain
+     * @param recipient Address of message recipient on destination domain as bytes32
+     * @param messageBody Raw bytes content of message
+     * @return nonce reserved by message
+     */
+    function sendMessage(
+        uint32 destinationDomain,
+        bytes32 recipient,
+        bytes calldata messageBody
+    ) external returns (uint64);
+
+    /**
+     * @notice Sends an outgoing message from the source domain, with a specified caller on the
+     * destination domain.
+     * @dev Increment nonce, format the message, and emit `MessageSent` event with message information.
+     * WARNING: if the `destinationCaller` does not represent a valid address as bytes32, then it will not be possible
+     * to broadcast the message on the destination domain. This is an advanced feature, and the standard
+     * sendMessage() should be preferred for use cases where a specific destination caller is not required.
+     * @param destinationDomain Domain of destination chain
+     * @param recipient Address of message recipient on destination domain as bytes32
+     * @param destinationCaller caller on the destination domain, as bytes32
+     * @param messageBody Raw bytes content of message
+     * @return nonce reserved by message
+     */
+    function sendMessageWithCaller(
+        uint32 destinationDomain,
+        bytes32 recipient,
+        bytes32 destinationCaller,
+        bytes calldata messageBody
+    ) external returns (uint64);
+}

--- a/contracts/cctp/interfaces/IMessageTransmitter.sol
+++ b/contracts/cctp/interfaces/IMessageTransmitter.sol
@@ -44,4 +44,9 @@ interface IMessageTransmitter {
         bytes32 destinationCaller,
         bytes calldata messageBody
     ) external returns (uint64);
+
+    // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
+
+    // Next available nonce from this source domain
+    function nextAvailableNonce() external view returns (uint64);
 }

--- a/contracts/cctp/interfaces/ISynapseCCTP.sol
+++ b/contracts/cctp/interfaces/ISynapseCCTP.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface ISynapseCCTP {
+    /// @notice Send a Circle token supported by CCTP to a given domain
+    /// with the request for the action to take on the destination domain.
+    /// @dev The request is a bytes array containing information about the end recipient of the tokens,
+    /// as well as an optional swap action to take on the destination domain.
+    /// @param recipient            Recipient of the tokens on destination domain
+    /// @param destinationDomain    Domain of destination chain
+    /// @param burnToken            Address of Circle token to burn
+    /// @param amount               Amount of tokens to burn
+    /// @param requestVersion       Version of the request format
+    /// @param swapParams           Swap parameters for the action to take on the destination domain (could be empty)
+    function sendCircleToken(
+        address recipient,
+        uint32 destinationDomain,
+        address burnToken,
+        uint256 amount,
+        uint32 requestVersion,
+        bytes memory swapParams
+    ) external;
+
+    /// @notice Receive  Circle token supported by CCTP with the request for the action to take.
+    /// @dev The request is a bytes array containing information about the end recipient of the tokens,
+    /// as well as an optional swap action to take on this domain.
+    /// @param message              Message raw bytes emitted by CCTP MessageTransmitter on origin domain
+    /// @param signature            Circle's attestation for the message obtained from Circle's API
+    /// @param requestVersion       Version of the request format
+    /// @param formattedRequest     Formatted request for the action to take on this domain
+    function receiveCircleToken(
+        bytes calldata message,
+        bytes calldata signature,
+        uint32 requestVersion,
+        bytes memory formattedRequest
+    ) external;
+}

--- a/contracts/cctp/interfaces/ITokenMessenger.sol
+++ b/contracts/cctp/interfaces/ITokenMessenger.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface ITokenMessenger {
+    /**
+     * @notice Deposits and burns tokens from sender to be minted on destination domain.
+     * Emits a `DepositForBurn` event.
+     * @dev reverts if:
+     * - given burnToken is not supported
+     * - given destinationDomain has no TokenMessenger registered
+     * - transferFrom() reverts. For example, if sender's burnToken balance or approved allowance
+     * to this contract is less than `amount`.
+     * - burn() reverts. For example, if `amount` is 0.
+     * - MessageTransmitter returns false or reverts.
+     * @param amount amount of tokens to burn
+     * @param destinationDomain destination domain
+     * @param mintRecipient address of mint recipient on destination domain
+     * @param burnToken address of contract to burn deposited tokens, on local domain
+     * @return _nonce unique nonce reserved by message
+     */
+    function depositForBurn(
+        uint256 amount,
+        uint32 destinationDomain,
+        bytes32 mintRecipient,
+        address burnToken
+    ) external returns (uint64 _nonce);
+
+    /**
+     * @notice Deposits and burns tokens from sender to be minted on destination domain. The mint
+     * on the destination domain must be called by `destinationCaller`.
+     * WARNING: if the `destinationCaller` does not represent a valid address as bytes32, then it will not be possible
+     * to broadcast the message on the destination domain. This is an advanced feature, and the standard
+     * depositForBurn() should be preferred for use cases where a specific destination caller is not required.
+     * Emits a `DepositForBurn` event.
+     * @dev reverts if:
+     * - given destinationCaller is zero address
+     * - given burnToken is not supported
+     * - given destinationDomain has no TokenMessenger registered
+     * - transferFrom() reverts. For example, if sender's burnToken balance or approved allowance
+     * to this contract is less than `amount`.
+     * - burn() reverts. For example, if `amount` is 0.
+     * - MessageTransmitter returns false or reverts.
+     * @param amount amount of tokens to burn
+     * @param destinationDomain destination domain
+     * @param mintRecipient address of mint recipient on destination domain
+     * @param burnToken address of contract to burn deposited tokens, on local domain
+     * @param destinationCaller caller on the destination domain, as bytes32
+     * @return nonce unique nonce reserved by message
+     */
+    function depositForBurnWithCaller(
+        uint256 amount,
+        uint32 destinationDomain,
+        bytes32 mintRecipient,
+        address burnToken,
+        bytes32 destinationCaller
+    ) external returns (uint64 nonce);
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "hardhat test --parallel",
     "build": "hardhat compile && npm run build:go",
-    "build:go": "sol-merger \"./contracts/bridge/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/bridge/wrappers/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/bridge/testing/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/amm/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/amm/meta/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/messaging/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/messaging/apps/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin",
+    "build:go": "script/sh/flatten.sh contracts/bridge/*.sol contracts/bridge/wrappers/*.sol contracts/bridge/testing/*.sol contracts/amm/*.sol contracts/messaging/*.sol contracts/messaging/apps/*.sol",
     "post-install": "build:go",
     "test:coverage": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" hardhat coverage",
     "prepublishOnly": "npm run build",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "hardhat test --parallel",
-    "build": "hardhat compile && npm run build-go",
-    "build-go": "sol-merger \"./contracts/bridge/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/bridge/wrappers/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/bridge/testing/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/amm/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/amm/meta/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/messaging/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/messaging/apps/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin",
-    "post-install": "build-go",
+    "build": "hardhat compile && npm run build:go",
+    "build:go": "sol-merger \"./contracts/bridge/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/bridge/wrappers/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/bridge/testing/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/amm/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/amm/meta/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/messaging/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin && sol-merger \"./contracts/messaging/apps/*.sol\" ./build --export-plugin SPDXLicenseRemovePlugin",
+    "post-install": "build:go",
     "test:coverage": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" hardhat coverage",
     "prepublishOnly": "npm run build",
     "lint": "npm run prettier && solhint --fix -c .solhint.json --ignore-path .prettierignore contracts/**/*.sol test/**/*.sol",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "hardhat test --parallel",
     "build": "hardhat compile && npm run build:go",
-    "build:go": "script/sh/flatten.sh contracts/bridge/*.sol contracts/bridge/wrappers/*.sol contracts/bridge/testing/*.sol contracts/amm/*.sol contracts/messaging/*.sol contracts/messaging/apps/*.sol",
+    "build:go": "script/sh/flatten.sh contracts/bridge/*.sol contracts/bridge/wrappers/*.sol contracts/bridge/testing/*.sol contracts/amm/*.sol contracts/messaging/*.sol contracts/messaging/apps/*.sol contracts/cctp/*.sol contracts/cctp/events/*.sol",
     "post-install": "build:go",
     "test:coverage": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" hardhat coverage",
     "prepublishOnly": "npm run build",

--- a/script/sh/flatten.sh
+++ b/script/sh/flatten.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# This script flattens Solidity contracts and saves them in ./flattened
+# The existing content of ./flattened is removed
+# This tool takes both globs and filenames as the list of arguments and flattens everything
+# Usage: ./script/sh/flatten.sh contracts/**.sol contracts/client/TestClient.sol <...>
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Check if arguments were supplied
+if [ $# -eq 0 ]; then
+  echo -e "${RED}Error: provide globs/filenames of the contracts to flatten!${NC}"
+  exit 1
+fi
+
+# First, we remove the existing flattened files
+rm -rf ./flattened
+
+# Track the amount of flattened files for the final report
+count=0
+# Then, we iterate over the supplied arguments
+# If any argument was a glob, this will iterate over the files it specifies
+for var in "$@"; do
+  # Strip contract name "Abc.sol" from the path
+  fn=$(basename "$var")
+  # Flatten the file and save it in ./flattened
+  # Make sure that flattened contracts base names are unique!
+  forge flatten "$var" -o "./flattened/$fn"
+  ((++count))
+done
+
+echo -e "${GREEN}Files flattened: $count${NC}"

--- a/test/cctp/harnesses/TypeCastsLibHarness.sol
+++ b/test/cctp/harnesses/TypeCastsLibHarness.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {TypeCasts} from "../../../contracts/cctp/libs/TypeCasts.sol";
+
+contract TypeCastLibHarness {
+    function addressToBytes32(address addr) public pure returns (bytes32) {
+        return TypeCasts.addressToBytes32(addr);
+    }
+
+    function bytes32ToAddress(bytes32 buf) public pure returns (address) {
+        return TypeCasts.bytes32ToAddress(buf);
+    }
+}

--- a/test/cctp/libs/TypeCasts.t.sol
+++ b/test/cctp/libs/TypeCasts.t.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {TypeCastLibHarness} from "../harnesses/TypeCastsLibHarness.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+contract TypeCastsLibraryTest is Test {
+    function testAddressToBytes32(address addr) public {
+        TypeCastLibHarness harness = new TypeCastLibHarness();
+        assertEq(harness.bytes32ToAddress(harness.addressToBytes32(addr)), addr);
+    }
+}


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

This PR adds a very rough draft for the future CCTP integration. The sender specifies Circle token to bridge, as well as the request for the action to take on the destination chain (either transfer the bridge Circle token to recipient, or add an optional swap into another token first).

The request is hashed with the origin and destination domains, as well as the nonce of the sent CCTP message. This is hash is later used on destination chain to ensure that the provided request matches the one from origin domain.
> Origin, destination domains and nonce ensure that every "request hash" is unique for every message sent through `SynapseCCTP` on all the chains.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
