### PR TITLE
Feat: first MVP for Synapse CCTP

### DIFF
--- a/contracts/cctp/SynapseCCTP.sol
+++ b/contracts/cctp/SynapseCCTP.sol
@@ -116,8 +116,20 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
     function _kappa(
         uint32 destinationDomain,
         uint32 requestVersion,
-        bytes memory request
-    ) internal pure returns (bytes32) {
-        // TODO: implement
+        bytes memory formattedRequest
+    ) internal pure returns (bytes32 kappa) {
+        // Merge the destination domain and the request version into a single uint256.
+        uint256 prefix = (uint256(destinationDomain) << 32) | requestVersion;
+        bytes32 requestHash = keccak256(formattedRequest);
+        // Use assembly to return hash of the prefix and the request hash.
+        // We are using scratch space to avoid unnecessary memory expansion.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // Store prefix in memory at 0x00, and requestHash at 0x20.
+            mstore(0x00, prefix)
+            mstore(0x20, requestHash)
+            // Return hash of first 64 bytes of memory.
+            kappa := keccak256(0, 64)
+        }
     }
 }

--- a/contracts/cctp/SynapseCCTP.sol
+++ b/contracts/cctp/SynapseCCTP.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
+import {RemoteCCTPTokenNotSet} from "./libs/Errors.sol";
 import {SynapseCCTPEvents} from "./events/SynapseCCTPEvents.sol";
 import {IMessageTransmitter} from "./interfaces/IMessageTransmitter.sol";
 import {ISynapseCCTP} from "./interfaces/ISynapseCCTP.sol";
@@ -19,6 +20,7 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
     IMessageTransmitter public messageTransmitter;
     ITokenMessenger public tokenMessenger;
     mapping(uint32 => bytes32) public remoteSynapseCCTP;
+    mapping(uint256 => address) internal _remoteTokenIdToLocalToken;
 
     /// @inheritdoc ISynapseCCTP
     function sendCircleToken(
@@ -71,7 +73,7 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
         bytes32 kappa = _kappa(localDomain, requestVersion, formattedRequest);
         // Kindly ask the Circle Bridge to mint the tokens for us.
         _mintCircleToken(message, signature, kappa);
-        address token = _getMintedToken(originDomain, originBurnToken);
+        address token = _getLocalMintedToken(originDomain, originBurnToken);
         uint256 fee;
         // Apply the bridging fee. This will revert if amount <= fee.
         (amount, fee) = _applyFee(token, amount);
@@ -116,8 +118,10 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
     // ══════════════════════════════════════════════ INTERNAL VIEWS ═══════════════════════════════════════════════════
 
     /// @dev Fetches the address and the amount of the minted Circle token.
-    function _getMintedToken(uint32 originDomain, address originBurnToken) internal view returns (address token) {
-        // TODO: implement
+    function _getLocalMintedToken(uint32 originDomain, address originBurnToken) internal view returns (address token) {
+        // Map the remote token to the local token.
+        token = _remoteTokenIdToLocalToken[_remoteTokenId(originDomain, originBurnToken)];
+        if (token == address(0)) revert RemoteCCTPTokenNotSet();
     }
 
     /// @dev Predicts the address of the destination caller that will be used to call the Circle Message Transmitter.
@@ -138,11 +142,16 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
         // We are using scratch space to avoid unnecessary memory expansion.
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            // Store prefix in memory at 0x00, and requestHash at 0x20.
-            mstore(0x00, prefix)
-            mstore(0x20, requestHash)
+            // Store prefix in memory at 0, and requestHash at 32.
+            mstore(0, prefix)
+            mstore(32, requestHash)
             // Return hash of first 64 bytes of memory.
             kappa := keccak256(0, 64)
         }
+    }
+
+    /// @dev Packs the domain and the token into a single uint256 value using bitwise operations.
+    function _remoteTokenId(uint32 remoteDomain, address remoteToken) internal pure returns (uint256) {
+        return (uint256(remoteDomain) << 160) | uint160(remoteToken);
     }
 }

--- a/contracts/cctp/SynapseCCTP.sol
+++ b/contracts/cctp/SynapseCCTP.sol
@@ -64,6 +64,8 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
         uint32 requestVersion,
         bytes memory swapParams
     ) external {
+        // Pull token from user and update the amount in case of transfer fee.
+        amount = _pullToken(burnToken, amount);
         uint64 nonce = messageTransmitter.nextAvailableNonce();
         // This will revert if the request version is not supported, or swap params are not properly formatted.
         bytes memory formattedRequest = RequestLib.formatRequest(
@@ -77,6 +79,8 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
         // Origin domain and nonce are included in `formattedRequest`, so we only need to add the destination domain.
         bytes32 dstSynapseCCTP = remoteSynapseCCTP[destinationDomain];
         bytes32 kappa = _kappa(destinationDomain, requestVersion, formattedRequest);
+        // Issue allowance if needed
+        _approveToken(burnToken, amount);
         tokenMessenger.depositForBurnWithCaller(
             amount,
             destinationDomain,
@@ -128,6 +132,23 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
     function _applyFee(address token, uint256 amount) internal returns (uint256 amountAfterFee, uint256 fee) {
         // TODO: implement actual fee logic
         return (amount, 0);
+    }
+
+    /// @dev Approves the token to be transferred to the Circle Bridge.
+    function _approveToken(address token, uint256 amount) internal {
+        uint256 allowance = IERC20(token).allowance(address(this), address(tokenMessenger));
+        if (allowance < amount) {
+            // Reset allowance to 0 before setting it to the new value.
+            if (allowance != 0) IERC20(token).safeApprove(address(tokenMessenger), 0);
+            IERC20(token).safeApprove(address(tokenMessenger), type(uint256).max);
+        }
+    }
+
+    /// @dev Pulls the token from the sender.
+    function _pullToken(address token, uint256 amount) internal returns (uint256 amountPulled) {
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+        amountPulled = IERC20(token).balanceOf(address(this)) - balanceBefore;
     }
 
     /// @dev Mints the Circle token by sending the message and signature to the Circle Bridge.

--- a/contracts/cctp/SynapseCCTP.sol
+++ b/contracts/cctp/SynapseCCTP.sol
@@ -87,7 +87,7 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
             burnToken,
             _destinationCaller(dstSynapseCCTP.bytes32ToAddress(), kappa)
         );
-        emit CircleRequestSent(destinationDomain, nonce, requestVersion, formattedRequest, kappa);
+        emit CircleRequestSent(destinationDomain, nonce, burnToken, amount, requestVersion, formattedRequest, kappa);
     }
 
     // TODO: guard this to be only callable by the validators?
@@ -114,8 +114,8 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
         // Apply the bridging fee. This will revert if amount <= fee.
         (amount, fee) = _applyFee(token, amount);
         // Fulfill the request: perform an optional swap and send the end tokens to the recipient.
-        _fulfillRequest(recipient, token, amount, swapParams);
-        emit CircleRequestFulfilled(recipient, token, amount, fee, kappa);
+        (address tokenOut, uint256 amountOut) = _fulfillRequest(recipient, token, amount, swapParams);
+        emit CircleRequestFulfilled(recipient, token, fee, tokenOut, amountOut, kappa);
     }
 
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
@@ -172,8 +172,10 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
         address token,
         uint256 amount,
         bytes memory swapParams
-    ) internal {
+    ) internal returns (address tokenOut, uint256 amountOut) {
         // TODO: implement swap logic
+        tokenOut = token;
+        amountOut = amount;
         IERC20(token).safeTransfer(recipient, amount);
     }
 

--- a/contracts/cctp/SynapseCCTP.sol
+++ b/contracts/cctp/SynapseCCTP.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import {RemoteCCTPDeploymentNotSet, RemoteCCTPTokenNotSet} from "./libs/Errors.sol";
+import {LocalCCTPTokenNotFound, RemoteCCTPDeploymentNotSet, RemoteCCTPTokenNotSet} from "./libs/Errors.sol";
 import {SynapseCCTPEvents} from "./events/SynapseCCTPEvents.sol";
 import {IMessageTransmitter} from "./interfaces/IMessageTransmitter.sol";
 import {ISynapseCCTP} from "./interfaces/ISynapseCCTP.sol";
@@ -39,11 +39,9 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
     // TODO: add ownerOnly modifier
     function setLocalToken(uint32 remoteDomain, address remoteToken) external {
         ITokenMinter minter = ITokenMinter(tokenMessenger.localMinter());
-        // TODO: add address(0) check
-        _remoteTokenIdToLocalToken[_remoteTokenId(remoteDomain, remoteToken)] = minter.getLocalToken(
-            remoteDomain,
-            remoteToken.addressToBytes32()
-        );
+        address localToken = minter.getLocalToken(remoteDomain, remoteToken.addressToBytes32());
+        if (localToken == address(0)) revert LocalCCTPTokenNotFound();
+        _remoteTokenIdToLocalToken[_remoteTokenId(remoteDomain, remoteToken)] = localToken;
     }
 
     /// @notice Sets the remote deployment of SynapseCCTP for the given remote domain.

--- a/contracts/cctp/SynapseCCTP.sol
+++ b/contracts/cctp/SynapseCCTP.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import {RemoteCCTPTokenNotSet} from "./libs/Errors.sol";
+import {RemoteCCTPDeploymentNotSet, RemoteCCTPTokenNotSet} from "./libs/Errors.sol";
 import {SynapseCCTPEvents} from "./events/SynapseCCTPEvents.sol";
 import {IMessageTransmitter} from "./interfaces/IMessageTransmitter.sol";
 import {ISynapseCCTP} from "./interfaces/ISynapseCCTP.sol";
@@ -78,6 +78,7 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
         // This is done by including origin and destination domains as well as origin nonce in the hashed data.
         // Origin domain and nonce are included in `formattedRequest`, so we only need to add the destination domain.
         bytes32 dstSynapseCCTP = remoteSynapseCCTP[destinationDomain];
+        if (dstSynapseCCTP == 0) revert RemoteCCTPDeploymentNotSet();
         bytes32 kappa = _kappa(destinationDomain, requestVersion, formattedRequest);
         // Issue allowance if needed
         _approveToken(burnToken, amount);

--- a/contracts/cctp/SynapseCCTP.sol
+++ b/contracts/cctp/SynapseCCTP.sol
@@ -5,22 +5,55 @@ import {RemoteCCTPTokenNotSet} from "./libs/Errors.sol";
 import {SynapseCCTPEvents} from "./events/SynapseCCTPEvents.sol";
 import {IMessageTransmitter} from "./interfaces/IMessageTransmitter.sol";
 import {ISynapseCCTP} from "./interfaces/ISynapseCCTP.sol";
+import {ITokenMinter} from "./interfaces/ITokenMinter.sol";
 import {ITokenMessenger} from "./interfaces/ITokenMessenger.sol";
 import {RequestLib} from "./libs/Request.sol";
 import {MinimalForwarderLib} from "./libs/MinimalForwarder.sol";
 import {TypeCasts} from "./libs/TypeCasts.sol";
 
+import {SafeERC20, IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/utils/SafeERC20.sol";
+
 contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
     using MinimalForwarderLib for address;
+    using SafeERC20 for IERC20;
     using TypeCasts for address;
     using TypeCasts for bytes32;
 
-    // TODO: add setters for these (or make them immutable)
-    uint32 public localDomain;
-    IMessageTransmitter public messageTransmitter;
-    ITokenMessenger public tokenMessenger;
+    uint32 public immutable localDomain;
+    IMessageTransmitter public immutable messageTransmitter;
+    ITokenMessenger public immutable tokenMessenger;
+
+    // TODO: onlyOwner setters for these
     mapping(uint32 => bytes32) public remoteSynapseCCTP;
     mapping(uint256 => address) internal _remoteTokenIdToLocalToken;
+
+    constructor(ITokenMessenger tokenMessenger_) {
+        tokenMessenger = tokenMessenger_;
+        messageTransmitter = IMessageTransmitter(tokenMessenger_.localMessageTransmitter());
+        localDomain = messageTransmitter.localDomain();
+    }
+
+    // ═════════════════════════════════════════════ SET CONFIG LOGIC ══════════════════════════════════════════════════
+
+    /// @notice Sets the local token associated with the given remote domain and token.
+    // TODO: add ownerOnly modifier
+    function setLocalToken(uint32 remoteDomain, address remoteToken) external {
+        ITokenMinter minter = ITokenMinter(tokenMessenger.localMinter());
+        // TODO: add address(0) check
+        _remoteTokenIdToLocalToken[_remoteTokenId(remoteDomain, remoteToken)] = minter.getLocalToken(
+            remoteDomain,
+            remoteToken.addressToBytes32()
+        );
+    }
+
+    /// @notice Sets the remote deployment of SynapseCCTP for the given remote domain.
+    // TODO: add ownerOnly modifier
+    function setRemoteSynapseCCTP(uint32 remoteDomain, address remoteSynapseCCTP_) external {
+        // TODO: add zero checks
+        remoteSynapseCCTP[remoteDomain] = remoteSynapseCCTP_.addressToBytes32();
+    }
+
+    // ════════════════════════════════════════════════ CCTP LOGIC ═════════════════════════════════════════════════════
 
     /// @inheritdoc ISynapseCCTP
     function sendCircleToken(
@@ -82,11 +115,19 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
         emit CircleRequestFulfilled(recipient, token, amount, fee, kappa);
     }
 
+    // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
+
+    /// @notice Get the local token associated with the given remote domain and token.
+    function getLocalToken(uint32 remoteDomain, address remoteToken) external view returns (address) {
+        return _remoteTokenIdToLocalToken[_remoteTokenId(remoteDomain, remoteToken)];
+    }
+
     // ══════════════════════════════════════════════ INTERNAL LOGIC ═══════════════════════════════════════════════════
 
     /// @dev Applies the bridging fee. Will revert if amount <= fee.
     function _applyFee(address token, uint256 amount) internal returns (uint256 amountAfterFee, uint256 fee) {
-        // TODO: implement
+        // TODO: implement actual fee logic
+        return (amount, 0);
     }
 
     /// @dev Mints the Circle token by sending the message and signature to the Circle Bridge.
@@ -112,7 +153,8 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
         uint256 amount,
         bytes memory swapParams
     ) internal {
-        // TODO: implement
+        // TODO: implement swap logic
+        IERC20(token).safeTransfer(recipient, amount);
     }
 
     // ══════════════════════════════════════════════ INTERNAL VIEWS ═══════════════════════════════════════════════════

--- a/contracts/cctp/SynapseCCTP.sol
+++ b/contracts/cctp/SynapseCCTP.sol
@@ -19,12 +19,25 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
     using TypeCasts for address;
     using TypeCasts for bytes32;
 
+    /// @notice Struct defining the configuration of a remote domain that has SynapseCCTP deployed.
+    /// @dev CCTP uses the following convention for domain numbers:
+    /// - 0: Ethereum Mainnet
+    /// - 1: Avalanche Mainnet
+    /// With more chains added, the convention will be extended.
+    /// @param domain       Value for the remote domain used in CCTP messages.
+    /// @param synapseCCTP  Address of the SynapseCCTP deployed on the remote chain.
+    struct DomainConfig {
+        uint32 domain;
+        address synapseCCTP;
+    }
+
     uint32 public immutable localDomain;
     IMessageTransmitter public immutable messageTransmitter;
     ITokenMessenger public immutable tokenMessenger;
 
     // TODO: onlyOwner setters for these
-    mapping(uint32 => bytes32) public remoteSynapseCCTP;
+    // (chainId => configuration of the remote chain)
+    mapping(uint256 => DomainConfig) public remoteDomainConfig;
     mapping(uint256 => address) internal _remoteTokenIdToLocalToken;
 
     constructor(ITokenMessenger tokenMessenger_) {
@@ -44,11 +57,15 @@ contract SynapseCCTP is SynapseCCTPEvents, ISynapseCCTP {
         _remoteTokenIdToLocalToken[_remoteTokenId(remoteDomain, remoteToken)] = localToken;
     }
 
-    /// @notice Sets the remote deployment of SynapseCCTP for the given remote domain.
+    /// @notice Sets the remote domain and deployment of SynapseCCTP for the given remote chainId.
     // TODO: add ownerOnly modifier
-    function setRemoteSynapseCCTP(uint32 remoteDomain, address remoteSynapseCCTP_) external {
+    function setRemoteDomainConfig(
+        uint256 remoteChainId,
+        uint32 remoteDomain,
+        address remoteSynapseCCTP
+    ) external {
         // TODO: add zero checks
-        remoteSynapseCCTP[remoteDomain] = remoteSynapseCCTP_.addressToBytes32();
+        remoteDomainConfig[remoteChainId] = DomainConfig(remoteDomain, remoteSynapseCCTP);
     }
 
     // ════════════════════════════════════════════════ CCTP LOGIC ═════════════════════════════════════════════════════

--- a/contracts/cctp/events/SynapseCCTPEvents.sol
+++ b/contracts/cctp/events/SynapseCCTPEvents.sol
@@ -7,17 +7,17 @@ abstract contract SynapseCCTPEvents {
     /// @notice Emitted when a Circle token is sent with an attached action request.
     /// @dev To fulfill the request, the validator needs to fetch `message` from `MessageSent` event
     /// emitted by Circle's MessageTransmitter in the same tx, then fetch `signature` for the message from Circle API.
-    /// This data will need to be presented to SynapseCCTP on the destination domain,
+    /// This data will need to be presented to SynapseCCTP on the destination chain,
     /// along with `requestVersion` and `formattedRequest` emitted in this event.
-    /// @param destinationDomain    Domain of destination chain
-    /// @param nonce                Nonce of the CCTP message on origin domain
+    /// @param chainId              Chain ID of the destination chain
+    /// @param nonce                Nonce of the CCTP message on origin chain
     /// @param token                Address of Circle token that was burnt
     /// @param amount               Amount of Circle tokens burnt
     /// @param requestVersion       Version of the request format
-    /// @param formattedRequest     Formatted request for the action to take on the destination domain
+    /// @param formattedRequest     Formatted request for the action to take on the destination chain
     /// @param kappa                Unique identifier of the request
     event CircleRequestSent(
-        uint32 destinationDomain,
+        uint256 chainId,
         uint64 nonce,
         address token,
         uint256 amount,
@@ -27,7 +27,7 @@ abstract contract SynapseCCTPEvents {
     );
 
     /// @notice Emitted when a Circle token is received with an attached action request.
-    /// @param recipient            End recipient of the tokens on this domain
+    /// @param recipient            End recipient of the tokens on this chain
     /// @param mintToken            Address of the minted Circle token
     /// @param fee                  Fee paid for fulfilling the request, in minted tokens
     /// @param token                Address of token that recipient received

--- a/contracts/cctp/events/SynapseCCTPEvents.sol
+++ b/contracts/cctp/events/SynapseCCTPEvents.sol
@@ -11,12 +11,16 @@ abstract contract SynapseCCTPEvents {
     /// along with `requestVersion` and `formattedRequest` emitted in this event.
     /// @param destinationDomain    Domain of destination chain
     /// @param nonce                Nonce of the CCTP message on origin domain
+    /// @param token                Address of Circle token that was burnt
+    /// @param amount               Amount of Circle tokens burnt
     /// @param requestVersion       Version of the request format
     /// @param formattedRequest     Formatted request for the action to take on the destination domain
     /// @param kappa                Unique identifier of the request
     event CircleRequestSent(
         uint32 destinationDomain,
         uint64 nonce,
+        address token,
+        uint256 amount,
         uint32 requestVersion,
         bytes formattedRequest,
         bytes32 indexed kappa
@@ -24,15 +28,17 @@ abstract contract SynapseCCTPEvents {
 
     /// @notice Emitted when a Circle token is received with an attached action request.
     /// @param recipient            End recipient of the tokens on this domain
-    /// @param token                Address of Circle token received on this domain
-    /// @param amount               Amount of tokens received
-    /// @param fee                  Fee paid for fulfilling the request
+    /// @param mintToken            Address of the minted Circle token
+    /// @param fee                  Fee paid for fulfilling the request, in minted tokens
+    /// @param token                Address of token that recipient received
+    /// @param amount               Amount of tokens received by recipient
     /// @param kappa                Unique identifier of the request
     event CircleRequestFulfilled(
         address indexed recipient,
+        address mintToken,
+        uint256 fee,
         address token,
         uint256 amount,
-        uint256 fee,
         bytes32 indexed kappa
     );
 }

--- a/contracts/cctp/interfaces/IMessageTransmitter.sol
+++ b/contracts/cctp/interfaces/IMessageTransmitter.sol
@@ -47,6 +47,9 @@ interface IMessageTransmitter {
 
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
 
+    // Domain of chain on which the contract is deployed
+    function localDomain() external view returns (uint32);
+
     // Next available nonce from this source domain
     function nextAvailableNonce() external view returns (uint64);
 }

--- a/contracts/cctp/interfaces/IMessageTransmitter.sol
+++ b/contracts/cctp/interfaces/IMessageTransmitter.sol
@@ -12,20 +12,6 @@ interface IMessageTransmitter {
     function receiveMessage(bytes calldata message, bytes calldata signature) external returns (bool success);
 
     /**
-     * @notice Sends an outgoing message from the source domain.
-     * @dev Increment nonce, format the message, and emit `MessageSent` event with message information.
-     * @param destinationDomain Domain of destination chain
-     * @param recipient Address of message recipient on destination domain as bytes32
-     * @param messageBody Raw bytes content of message
-     * @return nonce reserved by message
-     */
-    function sendMessage(
-        uint32 destinationDomain,
-        bytes32 recipient,
-        bytes calldata messageBody
-    ) external returns (uint64);
-
-    /**
      * @notice Sends an outgoing message from the source domain, with a specified caller on the
      * destination domain.
      * @dev Increment nonce, format the message, and emit `MessageSent` event with message information.

--- a/contracts/cctp/interfaces/IMintBurnToken.sol
+++ b/contracts/cctp/interfaces/IMintBurnToken.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/IERC20.sol";
+
+/**
+ * @title IMintBurnToken
+ * @notice interface for mintable and burnable ERC20 token
+ */
+interface IMintBurnToken is IERC20 {
+    /**
+     * @dev Function to mint tokens
+     * @param to The address that will receive the minted tokens.
+     * @param amount The amount of tokens to mint. Must be less than or equal
+     * to the minterAllowance of the caller.
+     * @return A boolean that indicates if the operation was successful.
+     */
+    function mint(address to, uint256 amount) external returns (bool);
+
+    /**
+     * @dev allows a minter to burn some of its own tokens
+     * Validates that caller is a minter and that sender is not blacklisted
+     * amount is less than or equal to the minter's account balance
+     * @param amount uint256 the amount of tokens to be burned
+     */
+    function burn(uint256 amount) external;
+}

--- a/contracts/cctp/interfaces/ISynapseCCTP.sol
+++ b/contracts/cctp/interfaces/ISynapseCCTP.sol
@@ -2,19 +2,20 @@
 pragma solidity 0.8.17;
 
 interface ISynapseCCTP {
-    /// @notice Send a Circle token supported by CCTP to a given domain
-    /// with the request for the action to take on the destination domain.
+    /// @notice Send a Circle token supported by CCTP to a given chain
+    /// with the request for the action to take on the destination chain.
     /// @dev The request is a bytes array containing information about the end recipient of the tokens,
-    /// as well as an optional swap action to take on the destination domain.
-    /// @param recipient            Recipient of the tokens on destination domain
-    /// @param destinationDomain    Domain of destination chain
+    /// as well as an optional swap action to take on the destination chain.
+    /// `chainId` refers to value from EIP-155 (block.chainid).
+    /// @param recipient            Recipient of the tokens on destination chain
+    /// @param chainId              Chain ID of the destination chain
     /// @param burnToken            Address of Circle token to burn
     /// @param amount               Amount of tokens to burn
     /// @param requestVersion       Version of the request format
-    /// @param swapParams           Swap parameters for the action to take on the destination domain (could be empty)
+    /// @param swapParams           Swap parameters for the action to take on the destination chain (could be empty)
     function sendCircleToken(
         address recipient,
-        uint32 destinationDomain,
+        uint256 chainId,
         address burnToken,
         uint256 amount,
         uint32 requestVersion,
@@ -23,11 +24,11 @@ interface ISynapseCCTP {
 
     /// @notice Receive  Circle token supported by CCTP with the request for the action to take.
     /// @dev The request is a bytes array containing information about the end recipient of the tokens,
-    /// as well as an optional swap action to take on this domain.
-    /// @param message              Message raw bytes emitted by CCTP MessageTransmitter on origin domain
+    /// as well as an optional swap action to take on this chain.
+    /// @param message              Message raw bytes emitted by CCTP MessageTransmitter on origin chain
     /// @param signature            Circle's attestation for the message obtained from Circle's API
     /// @param requestVersion       Version of the request format
-    /// @param formattedRequest     Formatted request for the action to take on this domain
+    /// @param formattedRequest     Formatted request for the action to take on this chain
     function receiveCircleToken(
         bytes calldata message,
         bytes calldata signature,

--- a/contracts/cctp/interfaces/ITokenMessenger.sol
+++ b/contracts/cctp/interfaces/ITokenMessenger.sol
@@ -54,4 +54,12 @@ interface ITokenMessenger {
         address burnToken,
         bytes32 destinationCaller
     ) external returns (uint64 nonce);
+
+    // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
+
+    // Local Message Transmitter responsible for sending and receiving messages to/from remote domains
+    function localMessageTransmitter() external view returns (address);
+
+    // Minter responsible for minting and burning tokens on the local domain
+    function localMinter() external view returns (address);
 }

--- a/contracts/cctp/interfaces/ITokenMessenger.sol
+++ b/contracts/cctp/interfaces/ITokenMessenger.sol
@@ -3,29 +3,6 @@ pragma solidity 0.8.17;
 
 interface ITokenMessenger {
     /**
-     * @notice Deposits and burns tokens from sender to be minted on destination domain.
-     * Emits a `DepositForBurn` event.
-     * @dev reverts if:
-     * - given burnToken is not supported
-     * - given destinationDomain has no TokenMessenger registered
-     * - transferFrom() reverts. For example, if sender's burnToken balance or approved allowance
-     * to this contract is less than `amount`.
-     * - burn() reverts. For example, if `amount` is 0.
-     * - MessageTransmitter returns false or reverts.
-     * @param amount amount of tokens to burn
-     * @param destinationDomain destination domain
-     * @param mintRecipient address of mint recipient on destination domain
-     * @param burnToken address of contract to burn deposited tokens, on local domain
-     * @return _nonce unique nonce reserved by message
-     */
-    function depositForBurn(
-        uint256 amount,
-        uint32 destinationDomain,
-        bytes32 mintRecipient,
-        address burnToken
-    ) external returns (uint64 _nonce);
-
-    /**
      * @notice Deposits and burns tokens from sender to be minted on destination domain. The mint
      * on the destination domain must be called by `destinationCaller`.
      * WARNING: if the `destinationCaller` does not represent a valid address as bytes32, then it will not be possible
@@ -54,6 +31,23 @@ interface ITokenMessenger {
         address burnToken,
         bytes32 destinationCaller
     ) external returns (uint64 nonce);
+
+    /**
+     * @notice Handles an incoming message received by the local MessageTransmitter,
+     * and takes the appropriate action. For a burn message, mints the
+     * associated token to the requested recipient on the local domain.
+     * @dev Validates the local sender is the local MessageTransmitter, and the
+     * remote sender is a registered remote TokenMessenger for `remoteDomain`.
+     * @param remoteDomain The domain where the message originated from.
+     * @param sender The sender of the message (remote TokenMessenger).
+     * @param messageBody The message body bytes.
+     * @return success Bool, true if successful.
+     */
+    function handleReceiveMessage(
+        uint32 remoteDomain,
+        bytes32 sender,
+        bytes calldata messageBody
+    ) external returns (bool success);
 
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
 

--- a/contracts/cctp/interfaces/ITokenMinter.sol
+++ b/contracts/cctp/interfaces/ITokenMinter.sol
@@ -3,6 +3,35 @@ pragma solidity 0.8.17;
 
 interface ITokenMinter {
     /**
+     * @notice Mints `amount` of local tokens corresponding to the
+     * given (`sourceDomain`, `burnToken`) pair, to `to` address.
+     * @dev reverts if the (`sourceDomain`, `burnToken`) pair does not
+     * map to a nonzero local token address. This mapping can be queried using
+     * getLocalToken().
+     * @param sourceDomain Source domain where `burnToken` was burned.
+     * @param burnToken Burned token address as bytes32.
+     * @param to Address to receive minted tokens, corresponding to `burnToken`,
+     * on this domain.
+     * @param amount Amount of tokens to mint. Must be less than or equal
+     * to the minterAllowance of this TokenMinter for given `_mintToken`.
+     * @return mintToken token minted.
+     */
+    function mint(
+        uint32 sourceDomain,
+        bytes32 burnToken,
+        address to,
+        uint256 amount
+    ) external returns (address mintToken);
+
+    /**
+     * @notice Burn tokens owned by this ITokenMinter.
+     * @param burnToken burnable token.
+     * @param amount amount of tokens to burn. Must be less than or equal to this ITokenMinter's
+     * account balance of the given `_burnToken`.
+     */
+    function burn(address burnToken, uint256 amount) external;
+
+    /**
      * @notice Get the local token associated with the given remote domain and token.
      * @param remoteDomain Remote domain
      * @param remoteToken Remote token

--- a/contracts/cctp/interfaces/ITokenMinter.sol
+++ b/contracts/cctp/interfaces/ITokenMinter.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface ITokenMinter {
+    /**
+     * @notice Get the local token associated with the given remote domain and token.
+     * @param remoteDomain Remote domain
+     * @param remoteToken Remote token
+     * @return local token address
+     */
+    function getLocalToken(uint32 remoteDomain, bytes32 remoteToken) external view returns (address);
+}

--- a/contracts/cctp/libs/Errors.sol
+++ b/contracts/cctp/libs/Errors.sol
@@ -4,4 +4,6 @@ pragma solidity 0.8.17;
 error IncorrectRequestLength();
 error UnknownRequestVersion();
 
+error RemoteCCTPTokenNotSet();
+
 error ForwarderDeploymentFailed();

--- a/contracts/cctp/libs/Errors.sol
+++ b/contracts/cctp/libs/Errors.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 error IncorrectRequestLength();
 error UnknownRequestVersion();
 
+error LocalCCTPTokenNotFound();
 error RemoteCCTPDeploymentNotSet();
 error RemoteCCTPTokenNotSet();
 

--- a/contracts/cctp/libs/Errors.sol
+++ b/contracts/cctp/libs/Errors.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 error IncorrectRequestLength();
 error UnknownRequestVersion();
 
+error RemoteCCTPDeploymentNotSet();
 error RemoteCCTPTokenNotSet();
 
 error ForwarderDeploymentFailed();

--- a/contracts/cctp/libs/Errors.sol
+++ b/contracts/cctp/libs/Errors.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 error IncorrectRequestLength();
 error UnknownRequestVersion();
 
+error CCTPMessageNotReceived();
 error LocalCCTPTokenNotFound();
 error RemoteCCTPDeploymentNotSet();
 error RemoteCCTPTokenNotSet();

--- a/test/cctp/BaseCCTP.t.sol
+++ b/test/cctp/BaseCCTP.t.sol
@@ -6,11 +6,15 @@ import {MockMintBurnToken} from "./mocks/MockMintBurnToken.sol";
 import {MockTokenMessenger} from "./mocks/MockTokenMessenger.sol";
 import {MockTokenMinter} from "./mocks/MockTokenMinter.sol";
 
-import {SynapseCCTP} from "../../contracts/cctp/SynapseCCTP.sol";
+import {MessageTransmitterEvents} from "../../contracts/cctp/events/MessageTransmitterEvents.sol";
+import {TokenMessengerEvents} from "../../contracts/cctp/events/TokenMessengerEvents.sol";
+import {MinimalForwarderLib} from "../../contracts/cctp/libs/MinimalForwarder.sol";
+import {RequestLib} from "../../contracts/cctp/libs/Request.sol";
+import {SynapseCCTPEvents, SynapseCCTP} from "../../contracts/cctp/SynapseCCTP.sol";
 
 import {Test} from "forge-std/Test.sol";
 
-abstract contract BaseCCTPTest is Test {
+abstract contract BaseCCTPTest is MessageTransmitterEvents, TokenMessengerEvents, SynapseCCTPEvents, Test {
     struct CCTPSetup {
         MockMessageTransmitter messageTransmitter;
         MockMintBurnToken mintBurnToken;
@@ -24,12 +28,17 @@ abstract contract BaseCCTPTest is Test {
     mapping(uint32 => CCTPSetup) public cctpSetups;
     mapping(uint32 => SynapseCCTP) public synapseCCTPs;
 
+    address public user;
+    address public recipient;
+
     function setUp() public virtual {
         deployCCTP(DOMAIN_ETH);
         deployCCTP(DOMAIN_AVAX);
         linkDomains(DOMAIN_ETH, DOMAIN_AVAX);
         deploySynapseCCTP(DOMAIN_ETH);
         deploySynapseCCTP(DOMAIN_AVAX);
+        user = makeAddr("User");
+        recipient = makeAddr("Recipient");
     }
 
     function deployCCTP(uint32 domain) public returns (CCTPSetup memory setup) {
@@ -70,6 +79,86 @@ abstract contract BaseCCTPTest is Test {
             remoteDomain: domainA,
             remoteToken: bytes32(uint256(uint160(address(setupA.mintBurnToken)))),
             localToken: address(setupB.mintBurnToken)
+        });
+    }
+
+    function getExpectedMessage(
+        uint32 originDomain,
+        uint32 destinationDomain,
+        address finalRecipient,
+        address originBurnToken,
+        uint256 amount,
+        bytes32 destinationCaller
+    ) public view returns (bytes memory expectedMessage) {
+        bytes32 remoteSynapseCCTP = bytes32(uint256(uint160(address(synapseCCTPs[destinationDomain]))));
+        bytes memory messageBody = cctpSetups[originDomain].tokenMessenger.formatTokenMessage({
+            amount: amount,
+            mintRecipient: remoteSynapseCCTP,
+            burnToken: originBurnToken
+        });
+        expectedMessage = cctpSetups[originDomain].messageTransmitter.formatMessage({
+            remoteDomain: originDomain,
+            sender: address(cctpSetups[originDomain].tokenMessenger),
+            recipient: finalRecipient,
+            destinationCaller: destinationCaller,
+            messageBody: messageBody
+        });
+    }
+
+    function getExpectedKappa(
+        uint32 originDomain,
+        uint32 destinationDomain,
+        address finalRecipient,
+        address originBurnToken,
+        uint256 amount,
+        uint32 requestVersion,
+        bytes memory swapParams
+    ) public view returns (bytes32 kappa) {
+        uint64 nonce = cctpSetups[originDomain].messageTransmitter.nextAvailableNonce();
+        bytes memory formattedRequest = RequestLib.formatRequest({
+            requestVersion: requestVersion,
+            baseRequest: RequestLib.formatBaseRequest({
+                originDomain: originDomain,
+                nonce: nonce,
+                originBurnToken: originBurnToken,
+                amount: amount,
+                recipient: finalRecipient
+            }),
+            swapParams: swapParams
+        });
+        bytes32 requestHash = keccak256(formattedRequest);
+        uint256 prefix = uint256(destinationDomain) * 2**32 + requestVersion;
+        kappa = keccak256(abi.encodePacked(prefix, requestHash));
+    }
+
+    function getExpectedDstCaller(uint32 destinationDomain, bytes32 kappa)
+        public
+        view
+        returns (bytes32 destinationCaller)
+    {
+        address dstCaller = MinimalForwarderLib.predictAddress({
+            deployer: address(synapseCCTPs[destinationDomain]),
+            salt: kappa
+        });
+        destinationCaller = bytes32(uint256(uint160(dstCaller)));
+    }
+
+    function getExpectedRequest(
+        uint32 originDomain,
+        uint256 amount,
+        uint32 requestVersion,
+        bytes memory swapParams
+    ) public view returns (bytes memory expectedRequest) {
+        expectedRequest = RequestLib.formatRequest({
+            requestVersion: requestVersion,
+            baseRequest: RequestLib.formatBaseRequest({
+                originDomain: originDomain,
+                nonce: cctpSetups[originDomain].messageTransmitter.nextAvailableNonce(),
+                originBurnToken: address(cctpSetups[DOMAIN_ETH].mintBurnToken),
+                amount: amount,
+                recipient: recipient
+            }),
+            swapParams: swapParams
         });
     }
 }

--- a/test/cctp/BaseCCTP.t.sol
+++ b/test/cctp/BaseCCTP.t.sol
@@ -94,7 +94,6 @@ abstract contract BaseCCTPTest is MessageTransmitterEvents, TokenMessengerEvents
     function getExpectedMessage(
         uint32 originDomain,
         uint32 destinationDomain,
-        address finalRecipient,
         address originBurnToken,
         uint256 amount,
         bytes32 destinationCaller
@@ -108,7 +107,7 @@ abstract contract BaseCCTPTest is MessageTransmitterEvents, TokenMessengerEvents
         expectedMessage = cctpSetups[originDomain].messageTransmitter.formatMessage({
             remoteDomain: originDomain,
             sender: address(cctpSetups[originDomain].tokenMessenger),
-            recipient: finalRecipient,
+            recipient: address(cctpSetups[destinationDomain].tokenMessenger),
             destinationCaller: destinationCaller,
             messageBody: messageBody
         });

--- a/test/cctp/BaseCCTP.t.sol
+++ b/test/cctp/BaseCCTP.t.sol
@@ -34,9 +34,9 @@ abstract contract BaseCCTPTest is MessageTransmitterEvents, TokenMessengerEvents
     function setUp() public virtual {
         deployCCTP(DOMAIN_ETH);
         deployCCTP(DOMAIN_AVAX);
-        linkDomains(DOMAIN_ETH, DOMAIN_AVAX);
         deploySynapseCCTP(DOMAIN_ETH);
         deploySynapseCCTP(DOMAIN_AVAX);
+        linkDomains(DOMAIN_ETH, DOMAIN_AVAX);
         user = makeAddr("User");
         recipient = makeAddr("Recipient");
     }
@@ -79,6 +79,15 @@ abstract contract BaseCCTPTest is MessageTransmitterEvents, TokenMessengerEvents
             remoteDomain: domainA,
             remoteToken: bytes32(uint256(uint160(address(setupA.mintBurnToken)))),
             localToken: address(setupB.mintBurnToken)
+        });
+
+        synapseCCTPs[domainA].setRemoteSynapseCCTP({
+            remoteDomain: domainB,
+            remoteSynapseCCTP_: address(synapseCCTPs[domainB])
+        });
+        synapseCCTPs[domainB].setRemoteSynapseCCTP({
+            remoteDomain: domainA,
+            remoteSynapseCCTP_: address(synapseCCTPs[domainA])
         });
     }
 

--- a/test/cctp/BaseCCTP.t.sol
+++ b/test/cctp/BaseCCTP.t.sol
@@ -22,8 +22,11 @@ abstract contract BaseCCTPTest is MessageTransmitterEvents, TokenMessengerEvents
         MockTokenMinter tokenMinter;
     }
 
-    uint32 public constant DOMAIN_ETH = 1;
-    uint32 public constant DOMAIN_AVAX = 43114;
+    uint256 public constant CHAINID_ETH = 1;
+    uint256 public constant CHAINID_AVAX = 43114;
+
+    uint32 public constant DOMAIN_ETH = 0;
+    uint32 public constant DOMAIN_AVAX = 1;
 
     mapping(uint32 => CCTPSetup) public cctpSetups;
     mapping(uint32 => SynapseCCTP) public synapseCCTPs;
@@ -36,7 +39,7 @@ abstract contract BaseCCTPTest is MessageTransmitterEvents, TokenMessengerEvents
         deployCCTP(DOMAIN_AVAX);
         deploySynapseCCTP(DOMAIN_ETH);
         deploySynapseCCTP(DOMAIN_AVAX);
-        linkDomains(DOMAIN_ETH, DOMAIN_AVAX);
+        linkDomains(CHAINID_ETH, DOMAIN_ETH, CHAINID_AVAX, DOMAIN_AVAX);
         user = makeAddr("User");
         recipient = makeAddr("Recipient");
     }
@@ -57,7 +60,12 @@ abstract contract BaseCCTPTest is MessageTransmitterEvents, TokenMessengerEvents
         synapseCCTPs[domain] = synapseCCTP;
     }
 
-    function linkDomains(uint32 domainA, uint32 domainB) public {
+    function linkDomains(
+        uint256 chainIdA,
+        uint32 domainA,
+        uint256 chainIdB,
+        uint32 domainB
+    ) public {
         CCTPSetup memory setupA = cctpSetups[domainA];
         CCTPSetup memory setupB = cctpSetups[domainB];
 
@@ -81,13 +89,15 @@ abstract contract BaseCCTPTest is MessageTransmitterEvents, TokenMessengerEvents
             localToken: address(setupB.mintBurnToken)
         });
 
-        synapseCCTPs[domainA].setRemoteSynapseCCTP({
+        synapseCCTPs[domainA].setRemoteDomainConfig({
+            remoteChainId: chainIdB,
             remoteDomain: domainB,
-            remoteSynapseCCTP_: address(synapseCCTPs[domainB])
+            remoteSynapseCCTP: address(synapseCCTPs[domainB])
         });
-        synapseCCTPs[domainB].setRemoteSynapseCCTP({
+        synapseCCTPs[domainB].setRemoteDomainConfig({
+            remoteChainId: chainIdA,
             remoteDomain: domainA,
-            remoteSynapseCCTP_: address(synapseCCTPs[domainA])
+            remoteSynapseCCTP: address(synapseCCTPs[domainA])
         });
 
         synapseCCTPs[domainA].setLocalToken({remoteDomain: domainB, remoteToken: address(setupB.mintBurnToken)});

--- a/test/cctp/BaseCCTP.t.sol
+++ b/test/cctp/BaseCCTP.t.sol
@@ -89,6 +89,9 @@ abstract contract BaseCCTPTest is MessageTransmitterEvents, TokenMessengerEvents
             remoteDomain: domainA,
             remoteSynapseCCTP_: address(synapseCCTPs[domainA])
         });
+
+        synapseCCTPs[domainA].setLocalToken({remoteDomain: domainB, remoteToken: address(setupB.mintBurnToken)});
+        synapseCCTPs[domainB].setLocalToken({remoteDomain: domainA, remoteToken: address(setupA.mintBurnToken)});
     }
 
     function getExpectedMessage(

--- a/test/cctp/BaseCCTP.t.sol
+++ b/test/cctp/BaseCCTP.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {MockMessageTransmitter} from "./mocks/MockMessageTransmitter.sol";
+import {MockMintBurnToken} from "./mocks/MockMintBurnToken.sol";
+import {MockTokenMessenger} from "./mocks/MockTokenMessenger.sol";
+import {MockTokenMinter} from "./mocks/MockTokenMinter.sol";
+
+import {SynapseCCTP} from "../../contracts/cctp/SynapseCCTP.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+abstract contract BaseCCTPTest is Test {
+    struct CCTPSetup {
+        MockMessageTransmitter messageTransmitter;
+        MockMintBurnToken mintBurnToken;
+        MockTokenMessenger tokenMessenger;
+        MockTokenMinter tokenMinter;
+    }
+
+    uint32 public constant DOMAIN_ETH = 1;
+    uint32 public constant DOMAIN_AVAX = 43114;
+
+    mapping(uint32 => CCTPSetup) public cctpSetups;
+    mapping(uint32 => SynapseCCTP) public synapseCCTPs;
+
+    function setUp() public virtual {
+        deployCCTP(DOMAIN_ETH);
+        deployCCTP(DOMAIN_AVAX);
+        linkDomains(DOMAIN_ETH, DOMAIN_AVAX);
+        deploySynapseCCTP(DOMAIN_ETH);
+        deploySynapseCCTP(DOMAIN_AVAX);
+    }
+
+    function deployCCTP(uint32 domain) public returns (CCTPSetup memory setup) {
+        setup.messageTransmitter = new MockMessageTransmitter(domain);
+        setup.tokenMessenger = new MockTokenMessenger(address(setup.messageTransmitter));
+        setup.tokenMinter = new MockTokenMinter(address(setup.tokenMessenger));
+        setup.mintBurnToken = new MockMintBurnToken(address(setup.tokenMinter));
+
+        setup.tokenMessenger.setLocalMinter(address(setup.tokenMinter));
+
+        cctpSetups[domain] = setup;
+    }
+
+    function deploySynapseCCTP(uint32 domain) public returns (SynapseCCTP synapseCCTP) {
+        synapseCCTP = new SynapseCCTP(cctpSetups[domain].tokenMessenger);
+        synapseCCTPs[domain] = synapseCCTP;
+    }
+
+    function linkDomains(uint32 domainA, uint32 domainB) public {
+        CCTPSetup memory setupA = cctpSetups[domainA];
+        CCTPSetup memory setupB = cctpSetups[domainB];
+
+        setupA.tokenMessenger.setRemoteTokenMessenger({
+            remoteDomain: domainB,
+            remoteTokenMessenger_: bytes32(uint256(uint160(address(setupB.tokenMessenger))))
+        });
+        setupB.tokenMessenger.setRemoteTokenMessenger({
+            remoteDomain: domainA,
+            remoteTokenMessenger_: bytes32(uint256(uint160(address(setupA.tokenMessenger))))
+        });
+
+        setupA.tokenMinter.setLocalToken({
+            remoteDomain: domainB,
+            remoteToken: bytes32(uint256(uint160(address(setupB.mintBurnToken)))),
+            localToken: address(setupA.mintBurnToken)
+        });
+        setupB.tokenMinter.setLocalToken({
+            remoteDomain: domainA,
+            remoteToken: bytes32(uint256(uint160(address(setupA.mintBurnToken)))),
+            localToken: address(setupB.mintBurnToken)
+        });
+    }
+}

--- a/test/cctp/SynapseCCTP.t.sol
+++ b/test/cctp/SynapseCCTP.t.sol
@@ -16,30 +16,12 @@ contract SynapseCCTPTest is BaseCCTPTest {
         uint256 amount = 10**8;
         prepareUser(DOMAIN_ETH, amount);
         uint64 nonce = cctpSetups[DOMAIN_ETH].messageTransmitter.nextAvailableNonce();
-        Params memory expected;
-        expected.kappa = getExpectedKappa({
+        Params memory expected = getExpectedParams({
             originDomain: DOMAIN_ETH,
             destinationDomain: DOMAIN_AVAX,
-            finalRecipient: recipient,
-            originBurnToken: originBurnToken,
             amount: amount,
             requestVersion: RequestLib.REQUEST_BASE,
             swapParams: ""
-        });
-        expected.request = getExpectedRequest({
-            originDomain: DOMAIN_ETH,
-            amount: amount,
-            requestVersion: RequestLib.REQUEST_BASE,
-            swapParams: ""
-        });
-        expected.destinationCaller = getExpectedDstCaller({destinationDomain: DOMAIN_AVAX, kappa: expected.kappa});
-        expected.message = getExpectedMessage({
-            originDomain: DOMAIN_ETH,
-            destinationDomain: DOMAIN_AVAX,
-            finalRecipient: recipient,
-            originBurnToken: originBurnToken,
-            amount: amount,
-            destinationCaller: expected.destinationCaller
         });
         vm.expectEmit();
         emit MessageSent(expected.message);
@@ -70,6 +52,42 @@ contract SynapseCCTPTest is BaseCCTPTest {
             amount: amount,
             requestVersion: RequestLib.REQUEST_BASE,
             swapParams: ""
+        });
+    }
+
+    function getExpectedParams(
+        uint32 originDomain,
+        uint32 destinationDomain,
+        uint256 amount,
+        uint32 requestVersion,
+        bytes memory swapParams
+    ) public view returns (Params memory expected) {
+        address originBurnToken = address(cctpSetups[originDomain].mintBurnToken);
+        expected.kappa = getExpectedKappa({
+            originDomain: originDomain,
+            destinationDomain: destinationDomain,
+            finalRecipient: recipient,
+            originBurnToken: originBurnToken,
+            amount: amount,
+            requestVersion: requestVersion,
+            swapParams: swapParams
+        });
+        expected.request = getExpectedRequest({
+            originDomain: originDomain,
+            amount: amount,
+            requestVersion: requestVersion,
+            swapParams: swapParams
+        });
+        expected.destinationCaller = getExpectedDstCaller({
+            destinationDomain: destinationDomain,
+            kappa: expected.kappa
+        });
+        expected.message = getExpectedMessage({
+            originDomain: originDomain,
+            destinationDomain: destinationDomain,
+            originBurnToken: originBurnToken,
+            amount: amount,
+            destinationCaller: expected.destinationCaller
         });
     }
 

--- a/test/cctp/SynapseCCTP.t.sol
+++ b/test/cctp/SynapseCCTP.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
+import {IncorrectRequestLength} from "../../contracts/cctp/libs/Errors.sol";
 import {BaseCCTPTest, RequestLib} from "./BaseCCTP.t.sol";
 
 contract SynapseCCTPTest is BaseCCTPTest {
@@ -88,6 +89,106 @@ contract SynapseCCTPTest is BaseCCTPTest {
             formattedRequest: expected.request
         });
         assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount);
+    }
+
+    function testReceiveCircleTokenBaseRequestRevertMalformedRequest() public {
+        uint256 amount = 10**8;
+        Params memory expected = getExpectedParams({
+            originDomain: DOMAIN_ETH,
+            destinationDomain: DOMAIN_AVAX,
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_BASE,
+            swapParams: ""
+        });
+        // Test all possible malformed requests: we change a lowest byte in one of the request fields:
+        // originDomain, nonce, originBurnToken, amount, recipient
+        for (uint256 i = 0; i < 5; ++i) {
+            bytes memory malformedRequest = abi.encodePacked(expected.request);
+            // Figure out the byte index of the field we want to change
+            // request[byteIndex] is the lowest byte of the field `i`
+            uint256 byteIndex = 32 * i + 31;
+            for (uint8 j = 0; j < 8; ++j) {
+                // Change j-th bit in request[byteIndex], leaving others unchanged
+                malformedRequest[byteIndex] = expected.request[byteIndex] ^ bytes1(uint8(1) << j);
+                // destinationCaller check in MessageTransmitter should fail
+                vm.expectRevert("Invalid caller for message");
+                synapseCCTPs[DOMAIN_AVAX].receiveCircleToken({
+                    message: expected.message,
+                    signature: "",
+                    requestVersion: RequestLib.REQUEST_BASE,
+                    formattedRequest: malformedRequest
+                });
+            }
+        }
+    }
+
+    function testReceiveCircleTokenBaseRequestRevertChangedRequestType() public {
+        uint256 amount = 10**8;
+        Params memory expected = getExpectedParams({
+            originDomain: DOMAIN_ETH,
+            destinationDomain: DOMAIN_AVAX,
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_BASE,
+            swapParams: ""
+        });
+        // Simply changing the request type should fail when request is wrapped
+        vm.expectRevert(IncorrectRequestLength.selector);
+        synapseCCTPs[DOMAIN_AVAX].receiveCircleToken({
+            message: expected.message,
+            signature: "",
+            requestVersion: RequestLib.REQUEST_SWAP,
+            formattedRequest: expected.request
+        });
+    }
+
+    function testReceiveCircleTokenBaseRequestRevertAddedSwapParams() public {
+        uint256 amount = 10**8;
+        Params memory expected = getExpectedParams({
+            originDomain: DOMAIN_ETH,
+            destinationDomain: DOMAIN_AVAX,
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_BASE,
+            swapParams: ""
+        });
+        // Use Swap Request instead of the origin's Base Request
+        bytes memory swapRequest = RequestLib.formatRequest({
+            requestVersion: RequestLib.REQUEST_SWAP,
+            baseRequest: expected.request,
+            swapParams: RequestLib.formatSwapParams(address(0), 0, 0, 0, 0)
+        });
+        // Simply adding swap params w/o changing the request type should fail when request is wrapped
+        vm.expectRevert(IncorrectRequestLength.selector);
+        synapseCCTPs[DOMAIN_AVAX].receiveCircleToken({
+            message: expected.message,
+            signature: "",
+            requestVersion: RequestLib.REQUEST_BASE,
+            formattedRequest: swapRequest
+        });
+    }
+
+    function testReceiveCircleTokenBaseRequestRevertAddedSwapParamsChangedRequestType() public {
+        uint256 amount = 10**8;
+        Params memory expected = getExpectedParams({
+            originDomain: DOMAIN_ETH,
+            destinationDomain: DOMAIN_AVAX,
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_BASE,
+            swapParams: ""
+        });
+        // Use Swap Request instead of the origin's Base Request
+        bytes memory swapRequest = RequestLib.formatRequest({
+            requestVersion: RequestLib.REQUEST_SWAP,
+            baseRequest: expected.request,
+            swapParams: RequestLib.formatSwapParams(address(0), 0, 0, 0, 0)
+        });
+        // Proving a valid request of another type leads to a failed destinationCaller check in MessageTransmitter
+        vm.expectRevert("Invalid caller for message");
+        synapseCCTPs[DOMAIN_AVAX].receiveCircleToken({
+            message: expected.message,
+            signature: "",
+            requestVersion: RequestLib.REQUEST_SWAP,
+            formattedRequest: swapRequest
+        });
     }
 
     function getExpectedParams(

--- a/test/cctp/SynapseCCTP.t.sol
+++ b/test/cctp/SynapseCCTP.t.sol
@@ -41,6 +41,8 @@ contract SynapseCCTPTest is BaseCCTPTest {
         emit CircleRequestSent({
             destinationDomain: DOMAIN_AVAX,
             nonce: nonce,
+            token: originBurnToken,
+            amount: amount,
             requestVersion: RequestLib.REQUEST_BASE,
             formattedRequest: expected.request,
             kappa: expected.kappa
@@ -77,9 +79,10 @@ contract SynapseCCTPTest is BaseCCTPTest {
         vm.expectEmit();
         emit CircleRequestFulfilled({
             recipient: recipient,
+            mintToken: destMintToken,
+            fee: 0,
             token: destMintToken,
             amount: amount,
-            fee: 0,
             kappa: expected.kappa
         });
         synapseCCTPs[DOMAIN_AVAX].receiveCircleToken({

--- a/test/cctp/SynapseCCTP.t.sol
+++ b/test/cctp/SynapseCCTP.t.sol
@@ -53,6 +53,41 @@ contract SynapseCCTPTest is BaseCCTPTest {
             requestVersion: RequestLib.REQUEST_BASE,
             swapParams: ""
         });
+        assertEq(cctpSetups[DOMAIN_ETH].mintBurnToken.balanceOf(user), 0);
+    }
+
+    function testReceiveCircleTokenBaseRequest() public {
+        address destMintToken = address(cctpSetups[DOMAIN_AVAX].mintBurnToken);
+        uint256 amount = 10**8;
+        Params memory expected = getExpectedParams({
+            originDomain: DOMAIN_ETH,
+            destinationDomain: DOMAIN_AVAX,
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_BASE,
+            swapParams: ""
+        });
+        vm.expectEmit();
+        emit MintAndWithdraw({
+            mintRecipient: address(synapseCCTPs[DOMAIN_AVAX]),
+            mintToken: destMintToken,
+            amount: amount
+        });
+        // TODO: adjust when fees are implemented
+        vm.expectEmit();
+        emit CircleRequestFulfilled({
+            recipient: recipient,
+            token: destMintToken,
+            amount: amount,
+            fee: 0,
+            kappa: expected.kappa
+        });
+        synapseCCTPs[DOMAIN_AVAX].receiveCircleToken({
+            message: expected.message,
+            signature: "",
+            requestVersion: RequestLib.REQUEST_BASE,
+            formattedRequest: expected.request
+        });
+        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount);
     }
 
     function getExpectedParams(

--- a/test/cctp/SynapseCCTP.t.sol
+++ b/test/cctp/SynapseCCTP.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {BaseCCTPTest, RequestLib} from "./BaseCCTP.t.sol";
+
+contract SynapseCCTPTest is BaseCCTPTest {
+    struct Params {
+        bytes32 kappa;
+        bytes request;
+        bytes32 destinationCaller;
+        bytes message;
+    }
+
+    function testSendCircleTokenBaseRequest() public {
+        address originBurnToken = address(cctpSetups[DOMAIN_ETH].mintBurnToken);
+        uint256 amount = 10**8;
+        prepareUser(DOMAIN_ETH, amount);
+        uint64 nonce = cctpSetups[DOMAIN_ETH].messageTransmitter.nextAvailableNonce();
+        Params memory expected;
+        expected.kappa = getExpectedKappa({
+            originDomain: DOMAIN_ETH,
+            destinationDomain: DOMAIN_AVAX,
+            finalRecipient: recipient,
+            originBurnToken: originBurnToken,
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_BASE,
+            swapParams: ""
+        });
+        expected.request = getExpectedRequest({
+            originDomain: DOMAIN_ETH,
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_BASE,
+            swapParams: ""
+        });
+        expected.destinationCaller = getExpectedDstCaller({destinationDomain: DOMAIN_AVAX, kappa: expected.kappa});
+        expected.message = getExpectedMessage({
+            originDomain: DOMAIN_ETH,
+            destinationDomain: DOMAIN_AVAX,
+            finalRecipient: recipient,
+            originBurnToken: originBurnToken,
+            amount: amount,
+            destinationCaller: expected.destinationCaller
+        });
+        vm.expectEmit();
+        emit MessageSent(expected.message);
+        vm.expectEmit();
+        emit DepositForBurn({
+            nonce: nonce,
+            burnToken: originBurnToken,
+            amount: amount,
+            depositor: address(synapseCCTPs[DOMAIN_ETH]),
+            mintRecipient: bytes32(uint256(uint160(address(synapseCCTPs[DOMAIN_AVAX])))),
+            destinationDomain: DOMAIN_AVAX,
+            destinationTokenMessenger: bytes32(uint256(uint160(address(cctpSetups[DOMAIN_AVAX].tokenMessenger)))),
+            destinationCaller: expected.destinationCaller
+        });
+        vm.expectEmit();
+        emit CircleRequestSent({
+            destinationDomain: DOMAIN_AVAX,
+            nonce: nonce,
+            requestVersion: RequestLib.REQUEST_BASE,
+            formattedRequest: expected.request,
+            kappa: expected.kappa
+        });
+        vm.prank(user);
+        synapseCCTPs[DOMAIN_ETH].sendCircleToken({
+            recipient: recipient,
+            destinationDomain: DOMAIN_AVAX,
+            burnToken: address(cctpSetups[DOMAIN_ETH].mintBurnToken),
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_BASE,
+            swapParams: ""
+        });
+    }
+
+    function prepareUser(uint32 originDomain, uint256 amount) public {
+        CCTPSetup memory setup = cctpSetups[originDomain];
+        setup.mintBurnToken.mintPublic(user, amount);
+        vm.prank(user);
+        setup.mintBurnToken.approve(address(synapseCCTPs[originDomain]), amount);
+    }
+}

--- a/test/cctp/SynapseCCTP.t.sol
+++ b/test/cctp/SynapseCCTP.t.sol
@@ -39,7 +39,7 @@ contract SynapseCCTPTest is BaseCCTPTest {
         });
         vm.expectEmit();
         emit CircleRequestSent({
-            destinationDomain: DOMAIN_AVAX,
+            chainId: CHAINID_AVAX,
             nonce: nonce,
             token: originBurnToken,
             amount: amount,
@@ -50,7 +50,7 @@ contract SynapseCCTPTest is BaseCCTPTest {
         vm.prank(user);
         synapseCCTPs[DOMAIN_ETH].sendCircleToken({
             recipient: recipient,
-            destinationDomain: DOMAIN_AVAX,
+            chainId: CHAINID_AVAX,
             burnToken: address(cctpSetups[DOMAIN_ETH].mintBurnToken),
             amount: amount,
             requestVersion: RequestLib.REQUEST_BASE,

--- a/test/cctp/mocks/MockMessageTransmitter.sol
+++ b/test/cctp/mocks/MockMessageTransmitter.sol
@@ -10,6 +10,8 @@ contract MockMessageTransmitter is MessageTransmitterEvents, IMessageTransmitter
     uint32 public override localDomain;
     uint64 public override nextAvailableNonce;
 
+    event SignatureReceived(bytes signature);
+
     constructor(uint32 localDomain_) {
         localDomain = localDomain_;
         nextAvailableNonce = 1;
@@ -52,6 +54,7 @@ contract MockMessageTransmitter is MessageTransmitterEvents, IMessageTransmitter
             ITokenMessenger(recipient).handleReceiveMessage(remoteDomain, sender, messageBody),
             "handleReceiveMessage() failed"
         );
+        emit SignatureReceived(signature);
         return true;
     }
 

--- a/test/cctp/mocks/MockMessageTransmitter.sol
+++ b/test/cctp/mocks/MockMessageTransmitter.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IMessageTransmitter} from "../../../contracts/cctp/interfaces/IMessageTransmitter.sol";
+import {ITokenMessenger} from "../../../contracts/cctp/interfaces/ITokenMessenger.sol";
+
+/// Very simplified version of CCTP's MessageTransmitter for testing purposes.
+contract MockMessageTransmitter is IMessageTransmitter {
+    uint32 public override localDomain;
+    uint64 public override nextAvailableNonce;
+
+    constructor(uint32 localDomain_) {
+        localDomain = localDomain_;
+        nextAvailableNonce = 1;
+    }
+
+    function sendMessageWithCaller(
+        uint32,
+        bytes32,
+        bytes32,
+        bytes calldata
+    ) external returns (uint64 reservedNonce) {
+        reservedNonce = nextAvailableNonce;
+        nextAvailableNonce = reservedNonce + 1;
+    }
+
+    function receiveMessage(bytes calldata message, bytes calldata signature) external returns (bool success) {
+        require(signature.length % 65 == 0, "Invalid attestation length");
+        (
+            uint32 remoteDomain,
+            bytes32 sender,
+            address recipient,
+            bytes32 destinationCaller,
+            bytes memory messageBody
+        ) = abi.decode(message, (uint32, bytes32, address, bytes32, bytes));
+        if (destinationCaller != 0) {
+            require(destinationCaller == bytes32(uint256(uint160(msg.sender))), "Invalid caller for message");
+        }
+        require(
+            ITokenMessenger(recipient).handleReceiveMessage(remoteDomain, sender, messageBody),
+            "handleReceiveMessage() failed"
+        );
+        return true;
+    }
+
+    function formatMessage(
+        uint32 remoteDomain,
+        address sender,
+        address recipient,
+        bytes32 destinationCaller,
+        bytes memory messageBody
+    ) external pure returns (bytes memory message) {
+        message = abi.encode(remoteDomain, sender, recipient, destinationCaller, messageBody);
+    }
+}

--- a/test/cctp/mocks/MockMessageTransmitter.sol
+++ b/test/cctp/mocks/MockMessageTransmitter.sol
@@ -35,6 +35,8 @@ contract MockMessageTransmitter is MessageTransmitterEvents, IMessageTransmitter
     }
 
     function receiveMessage(bytes calldata message, bytes calldata signature) external returns (bool success) {
+        // This is added to test if SynapseCCTP could handle MessageTransmitter returning false.
+        if (signature.length == 1) return false;
         require(signature.length % 65 == 0, "Invalid attestation length");
         (
             uint32 remoteDomain,

--- a/test/cctp/mocks/MockMessageTransmitter.sol
+++ b/test/cctp/mocks/MockMessageTransmitter.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
+import {MessageTransmitterEvents} from "../../../contracts/cctp/events/MessageTransmitterEvents.sol";
 import {IMessageTransmitter} from "../../../contracts/cctp/interfaces/IMessageTransmitter.sol";
 import {ITokenMessenger} from "../../../contracts/cctp/interfaces/ITokenMessenger.sol";
 
 /// Very simplified version of CCTP's MessageTransmitter for testing purposes.
-contract MockMessageTransmitter is IMessageTransmitter {
+contract MockMessageTransmitter is MessageTransmitterEvents, IMessageTransmitter {
     uint32 public override localDomain;
     uint64 public override nextAvailableNonce;
 
@@ -18,10 +19,11 @@ contract MockMessageTransmitter is IMessageTransmitter {
         uint32,
         bytes32,
         bytes32,
-        bytes calldata
+        bytes calldata message
     ) external returns (uint64 reservedNonce) {
         reservedNonce = nextAvailableNonce;
         nextAvailableNonce = reservedNonce + 1;
+        emit MessageSent(message);
     }
 
     function receiveMessage(bytes calldata message, bytes calldata signature) external returns (bool success) {

--- a/test/cctp/mocks/MockMessageTransmitter.sol
+++ b/test/cctp/mocks/MockMessageTransmitter.sol
@@ -17,13 +17,21 @@ contract MockMessageTransmitter is MessageTransmitterEvents, IMessageTransmitter
 
     function sendMessageWithCaller(
         uint32,
-        bytes32,
-        bytes32,
-        bytes calldata message
+        bytes32 recipient,
+        bytes32 destinationCaller,
+        bytes calldata messageBody
     ) external returns (uint64 reservedNonce) {
         reservedNonce = nextAvailableNonce;
         nextAvailableNonce = reservedNonce + 1;
-        emit MessageSent(message);
+        emit MessageSent(
+            formatMessage({
+                remoteDomain: localDomain,
+                sender: msg.sender,
+                recipient: address(uint160(uint256(recipient))),
+                destinationCaller: destinationCaller,
+                messageBody: messageBody
+            })
+        );
     }
 
     function receiveMessage(bytes calldata message, bytes calldata signature) external returns (bool success) {
@@ -51,7 +59,7 @@ contract MockMessageTransmitter is MessageTransmitterEvents, IMessageTransmitter
         address recipient,
         bytes32 destinationCaller,
         bytes memory messageBody
-    ) external pure returns (bytes memory message) {
+    ) public pure returns (bytes memory message) {
         message = abi.encode(remoteDomain, sender, recipient, destinationCaller, messageBody);
     }
 }

--- a/test/cctp/mocks/MockMintBurnToken.sol
+++ b/test/cctp/mocks/MockMintBurnToken.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IMintBurnToken} from "../../../contracts/cctp/interfaces/IMintBurnToken.sol";
+import {ERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/ERC20.sol";
+
+contract MockMintBurnToken is ERC20, IMintBurnToken {
+    address public minter;
+
+    constructor(address minter_) ERC20("MockC", "MockC") {
+        minter = minter_;
+    }
+
+    function mint(address to, uint256 amount) external returns (bool) {
+        require(msg.sender == minter, "Only minter can mint");
+        _mint(to, amount);
+        return true;
+    }
+
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+}

--- a/test/cctp/mocks/MockMintBurnToken.sol
+++ b/test/cctp/mocks/MockMintBurnToken.sol
@@ -17,7 +17,15 @@ contract MockMintBurnToken is ERC20, IMintBurnToken {
         return true;
     }
 
+    function mintPublic(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
     function burn(uint256 amount) external {
         _burn(msg.sender, amount);
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return 6;
     }
 }

--- a/test/cctp/mocks/MockTokenMessenger.sol
+++ b/test/cctp/mocks/MockTokenMessenger.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IMessageTransmitter} from "../../../contracts/cctp/interfaces/IMessageTransmitter.sol";
+import {ITokenMessenger} from "../../../contracts/cctp/interfaces/ITokenMessenger.sol";
+import {ITokenMinter} from "../../../contracts/cctp/interfaces/ITokenMinter.sol";
+
+import {SafeERC20, IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/utils/SafeERC20.sol";
+
+contract MockTokenMessenger is ITokenMessenger {
+    using SafeERC20 for IERC20;
+
+    address public override localMessageTransmitter;
+    address public override localMinter;
+    mapping(uint32 => bytes32) public remoteTokenMessenger;
+
+    constructor(address localMessageTransmitter_) {
+        localMessageTransmitter = localMessageTransmitter_;
+    }
+
+    function setLocalMinter(address localMinter_) external {
+        localMinter = localMinter_;
+    }
+
+    function setRemoteTokenMessenger(uint32 remoteDomain, bytes32 remoteTokenMessenger_) external {
+        remoteTokenMessenger[remoteDomain] = remoteTokenMessenger_;
+    }
+
+    function depositForBurnWithCaller(
+        uint256 amount,
+        uint32 destinationDomain,
+        bytes32 mintRecipient,
+        address burnToken,
+        bytes32 destinationCaller
+    ) external returns (uint64 nonce) {
+        IERC20(burnToken).safeTransferFrom(msg.sender, localMinter, amount);
+        ITokenMinter(localMinter).burn(burnToken, amount);
+        bytes memory messageBody = formatTokenMessage(amount, mintRecipient, burnToken);
+        nonce = IMessageTransmitter(localMessageTransmitter).sendMessageWithCaller(
+            destinationDomain,
+            remoteTokenMessenger[destinationDomain],
+            destinationCaller,
+            messageBody
+        );
+    }
+
+    function handleReceiveMessage(
+        uint32 remoteDomain,
+        bytes32 sender,
+        bytes calldata messageBody
+    ) external returns (bool success) {
+        require(msg.sender == localMessageTransmitter, "Invalid message transmitter");
+        require(sender == remoteTokenMessenger[remoteDomain], "Remote TokenMessenger unsupported");
+        (uint256 amount, bytes32 mintRecipient, bytes32 burnToken) = abi.decode(
+            messageBody,
+            (uint256, bytes32, bytes32)
+        );
+        ITokenMinter(localMinter).mint(remoteDomain, burnToken, address(uint160(uint256(mintRecipient))), amount);
+        return true;
+    }
+
+    function formatTokenMessage(
+        uint256 amount,
+        bytes32 mintRecipient,
+        address burnToken
+    ) public pure returns (bytes memory tokenMessage) {
+        return abi.encode(amount, mintRecipient, bytes32(uint256(uint160(burnToken))));
+    }
+}

--- a/test/cctp/mocks/MockTokenMinter.sol
+++ b/test/cctp/mocks/MockTokenMinter.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {ITokenMinter} from "../../../contracts/cctp/interfaces/ITokenMinter.sol";
+import {IMintBurnToken} from "../../../contracts/cctp/interfaces/IMintBurnToken.sol";
+
+contract MockTokenMinter is ITokenMinter {
+    mapping(uint32 => mapping(bytes32 => address)) internal localTokens;
+    address public localTokenMessenger;
+
+    constructor(address localTokenMessenger_) {
+        localTokenMessenger = localTokenMessenger_;
+    }
+
+    function setLocalToken(
+        uint32 remoteDomain,
+        bytes32 remoteToken,
+        address localToken
+    ) external {
+        localTokens[remoteDomain][remoteToken] = localToken;
+    }
+
+    function mint(
+        uint32 sourceDomain,
+        bytes32 burnToken,
+        address to,
+        uint256 amount
+    ) external returns (address mintToken) {
+        require(msg.sender == localTokenMessenger, "Caller not local TokenMessenger");
+        mintToken = localTokens[sourceDomain][burnToken];
+        require(mintToken != address(0), "Mint token not supported");
+        IMintBurnToken(mintToken).mint(to, amount);
+    }
+
+    function burn(address burnToken, uint256 amount) external {
+        require(msg.sender == localTokenMessenger, "Caller not local TokenMessenger");
+        IMintBurnToken(burnToken).burn(amount);
+    }
+
+    function getLocalToken(uint32 remoteDomain, bytes32 remoteToken) external view returns (address) {
+        return localTokens[remoteDomain][remoteToken];
+    }
+}


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

First MVP implementation to get the Go tests started (and potentially fork tests as well).

- Only "base requests" are implemented at the moment.
  - For base requests `requestVersion == 0` and `swapParams = ""`
- Support for bridge+swap will be added in the next PRs
- Bridge fees will be also added in the next PRs.
- `forge flatten` as well as a collection of mocks is added for go generate tests.

The implementation takes advantage of the fact that it's possible to restrict the destination caller that would be able to execute the CCTP message. Create2-deployed address with salt based on the request hash, origin and destination domains, as well as origin nonce is used. More details could be found in #233 description.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
