### PR TITLE
Feat: CCTP swap requests

### DIFF
--- a/contracts/cctp/interfaces/IDefaultPool.sol
+++ b/contracts/cctp/interfaces/IDefaultPool.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+// TODO: deprecate when LinkedPool PR is merged
+interface IDefaultPool {
+    function swap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx,
+        uint256 minDy,
+        uint256 deadline
+    ) external returns (uint256 amountOut);
+
+    function calculateSwap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx
+    ) external view returns (uint256 amountOut);
+
+    function getToken(uint8 index) external view returns (address token);
+}

--- a/test/cctp/BaseCCTP.t.sol
+++ b/test/cctp/BaseCCTP.t.sol
@@ -6,6 +6,9 @@ import {MockMintBurnToken} from "./mocks/MockMintBurnToken.sol";
 import {MockTokenMessenger} from "./mocks/MockTokenMessenger.sol";
 import {MockTokenMinter} from "./mocks/MockTokenMinter.sol";
 
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockDefaultPool} from "./mocks/MockDefaultPool.sol";
+
 import {MessageTransmitterEvents} from "../../contracts/cctp/events/MessageTransmitterEvents.sol";
 import {TokenMessengerEvents} from "../../contracts/cctp/events/TokenMessengerEvents.sol";
 import {MinimalForwarderLib} from "../../contracts/cctp/libs/MinimalForwarder.sol";
@@ -22,6 +25,11 @@ abstract contract BaseCCTPTest is MessageTransmitterEvents, TokenMessengerEvents
         MockTokenMinter tokenMinter;
     }
 
+    struct PoolSetup {
+        MockERC20 token;
+        MockDefaultPool pool;
+    }
+
     uint256 public constant CHAINID_ETH = 1;
     uint256 public constant CHAINID_AVAX = 43114;
 
@@ -30,6 +38,7 @@ abstract contract BaseCCTPTest is MessageTransmitterEvents, TokenMessengerEvents
 
     mapping(uint32 => CCTPSetup) public cctpSetups;
     mapping(uint32 => SynapseCCTP) public synapseCCTPs;
+    mapping(uint32 => PoolSetup) public poolSetups;
 
     address public user;
     address public recipient;
@@ -40,6 +49,8 @@ abstract contract BaseCCTPTest is MessageTransmitterEvents, TokenMessengerEvents
         deploySynapseCCTP(DOMAIN_ETH);
         deploySynapseCCTP(DOMAIN_AVAX);
         linkDomains(CHAINID_ETH, DOMAIN_ETH, CHAINID_AVAX, DOMAIN_AVAX);
+        deployPool(DOMAIN_ETH);
+        deployPool(DOMAIN_AVAX);
         user = makeAddr("User");
         recipient = makeAddr("Recipient");
     }
@@ -102,6 +113,18 @@ abstract contract BaseCCTPTest is MessageTransmitterEvents, TokenMessengerEvents
 
         synapseCCTPs[domainA].setLocalToken({remoteDomain: domainB, remoteToken: address(setupB.mintBurnToken)});
         synapseCCTPs[domainB].setLocalToken({remoteDomain: domainA, remoteToken: address(setupA.mintBurnToken)});
+    }
+
+    function deployPool(uint32 domain) public returns (PoolSetup memory setup) {
+        setup.token = new MockERC20("MockT", 6);
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(cctpSetups[domain].mintBurnToken);
+        tokens[1] = address(setup.token);
+        setup.pool = new MockDefaultPool(tokens);
+        // Mint some initial tokens to the pool
+        cctpSetups[domain].mintBurnToken.mintPublic(address(setup.pool), 10**10);
+        setup.token.mint(address(setup.pool), 10**10);
+        poolSetups[domain] = setup;
     }
 
     function getExpectedMessage(

--- a/test/cctp/SynapseCCTP.t.sol
+++ b/test/cctp/SynapseCCTP.t.sol
@@ -59,6 +59,8 @@ contract SynapseCCTPTest is BaseCCTPTest {
         assertEq(cctpSetups[DOMAIN_ETH].mintBurnToken.balanceOf(user), 0);
     }
 
+    // ═════════════════════════════════════ TESTS: RECEIVE WITH BASE REQUEST ══════════════════════════════════════════
+
     function testReceiveCircleTokenBaseRequest() public {
         address destMintToken = address(cctpSetups[DOMAIN_AVAX].mintBurnToken);
         uint256 amount = 10**8;
@@ -225,6 +227,192 @@ contract SynapseCCTPTest is BaseCCTPTest {
             formattedRequest: swapRequest
         });
     }
+
+    // ═════════════════════════════════════ TESTS: RECEIVE WITH SWAP REQUEST ══════════════════════════════════════════
+
+    function testReceiveCircleTokenSwapRequest() public {
+        address destMintToken = address(cctpSetups[DOMAIN_AVAX].mintBurnToken);
+        uint256 amount = 10**8;
+        // TODO: adjust for fees when implemented
+        address tokenOut = address(poolSetups[DOMAIN_AVAX].token);
+        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount);
+        bytes memory swapParams = RequestLib.formatSwapParams({
+            pool: address(poolSetups[DOMAIN_AVAX].pool),
+            tokenIndexFrom: 0,
+            tokenIndexTo: 1,
+            deadline: block.timestamp,
+            minAmountOut: amountOut
+        });
+        Params memory expected = getExpectedParams({
+            originDomain: DOMAIN_ETH,
+            destinationDomain: DOMAIN_AVAX,
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_SWAP,
+            swapParams: swapParams
+        });
+        vm.expectEmit();
+        emit MintAndWithdraw({
+            mintRecipient: address(synapseCCTPs[DOMAIN_AVAX]),
+            mintToken: destMintToken,
+            amount: amount
+        });
+        // TODO: adjust when fees are implemented
+        vm.expectEmit();
+        emit CircleRequestFulfilled({
+            recipient: recipient,
+            mintToken: destMintToken,
+            fee: 0,
+            token: tokenOut,
+            amount: amountOut,
+            kappa: expected.kappa
+        });
+        synapseCCTPs[DOMAIN_AVAX].receiveCircleToken({
+            message: expected.message,
+            signature: "",
+            requestVersion: RequestLib.REQUEST_SWAP,
+            formattedRequest: expected.request
+        });
+        assertEq(poolSetups[DOMAIN_AVAX].token.balanceOf(recipient), amountOut);
+    }
+
+    function testReceiveCircleTokenSwapRequestRevertMalformedRequest() public {
+        uint256 amount = 10**8;
+        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount);
+        bytes memory swapParams = RequestLib.formatSwapParams({
+            pool: address(poolSetups[DOMAIN_AVAX].pool),
+            tokenIndexFrom: 0,
+            tokenIndexTo: 1,
+            deadline: block.timestamp,
+            minAmountOut: amountOut
+        });
+        Params memory expectedBase = getExpectedParams({
+            originDomain: DOMAIN_ETH,
+            destinationDomain: DOMAIN_AVAX,
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_BASE,
+            swapParams: ""
+        });
+        Params memory expected = getExpectedParams({
+            originDomain: DOMAIN_ETH,
+            destinationDomain: DOMAIN_AVAX,
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_SWAP,
+            swapParams: swapParams
+        });
+        // Test all possible malformed base requests: we change a lowest byte in one of the request fields:
+        // originDomain, nonce, originBurnToken, amount, recipient
+        for (uint256 i = 0; i < 5; ++i) {
+            bytes memory malformedRequest = abi.encodePacked(expectedBase.request);
+            // Figure out the byte index of the field we want to change
+            // request[byteIndex] is the lowest byte of the field `i`
+            uint256 byteIndex = 32 * i + 31;
+            for (uint8 j = 0; j < 8; ++j) {
+                // Change j-th bit in request[byteIndex], leaving others unchanged
+                malformedRequest[byteIndex] = expectedBase.request[byteIndex] ^ bytes1(uint8(1) << j);
+                bytes memory malformedSwapRequest = RequestLib.formatRequest({
+                    requestVersion: RequestLib.REQUEST_SWAP,
+                    baseRequest: malformedRequest,
+                    swapParams: swapParams
+                });
+                // destinationCaller check in MessageTransmitter should fail
+                vm.expectRevert("Invalid caller for message");
+                synapseCCTPs[DOMAIN_AVAX].receiveCircleToken({
+                    message: expected.message,
+                    signature: "",
+                    requestVersion: RequestLib.REQUEST_SWAP,
+                    formattedRequest: malformedSwapRequest
+                });
+            }
+        }
+        // Test all possible malformed swap params: we change a lowest byte in one of the request fields:
+        // pool, tokenIndexFrom, tokenIndexTo, deadline, minAmountOut
+        for (uint256 i = 0; i < 5; ++i) {
+            bytes memory malformedSwapParams = abi.encodePacked(swapParams);
+            // Figure out the byte index of the field we want to change
+            // swapParams[byteIndex] is the lowest byte of the field `i`
+            uint256 byteIndex = 32 * i + 31;
+            for (uint8 j = 0; j < 8; ++j) {
+                // Change j-th bit in swapParams[byteIndex], leaving others unchanged
+                malformedSwapParams[byteIndex] = swapParams[byteIndex] ^ bytes1(uint8(1) << j);
+                bytes memory malformedSwapRequest = RequestLib.formatRequest({
+                    requestVersion: RequestLib.REQUEST_SWAP,
+                    baseRequest: expectedBase.request,
+                    swapParams: malformedSwapParams
+                });
+                // destinationCaller check in MessageTransmitter should fail
+                vm.expectRevert("Invalid caller for message");
+                synapseCCTPs[DOMAIN_AVAX].receiveCircleToken({
+                    message: expected.message,
+                    signature: "",
+                    requestVersion: RequestLib.REQUEST_SWAP,
+                    formattedRequest: malformedSwapRequest
+                });
+            }
+        }
+    }
+
+    function testReceiveCircleTokenSwapRequestRevertChangedRequestType() public {
+        uint256 amount = 10**8;
+        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount);
+        bytes memory swapParams = RequestLib.formatSwapParams({
+            pool: address(poolSetups[DOMAIN_AVAX].pool),
+            tokenIndexFrom: 0,
+            tokenIndexTo: 1,
+            deadline: block.timestamp,
+            minAmountOut: amountOut
+        });
+        Params memory expected = getExpectedParams({
+            originDomain: DOMAIN_ETH,
+            destinationDomain: DOMAIN_AVAX,
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_SWAP,
+            swapParams: swapParams
+        });
+        // Simply changing the request type should fail when request is wrapped
+        vm.expectRevert(IncorrectRequestLength.selector);
+        synapseCCTPs[DOMAIN_AVAX].receiveCircleToken({
+            message: expected.message,
+            signature: "",
+            requestVersion: RequestLib.REQUEST_BASE,
+            formattedRequest: expected.request
+        });
+    }
+
+    function testReceiveCircleTokenSwapRequestRevertChangedRequestTypeRemovedSwapParams() public {
+        uint256 amount = 10**8;
+        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount);
+        bytes memory swapParams = RequestLib.formatSwapParams({
+            pool: address(poolSetups[DOMAIN_AVAX].pool),
+            tokenIndexFrom: 0,
+            tokenIndexTo: 1,
+            deadline: block.timestamp,
+            minAmountOut: amountOut
+        });
+        Params memory expected = getExpectedParams({
+            originDomain: DOMAIN_ETH,
+            destinationDomain: DOMAIN_AVAX,
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_SWAP,
+            swapParams: swapParams
+        });
+        Params memory expectedBase = getExpectedParams({
+            originDomain: DOMAIN_ETH,
+            destinationDomain: DOMAIN_AVAX,
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_BASE,
+            swapParams: ""
+        });
+        // Proving a valid request of another type leads to a failed destinationCaller check in MessageTransmitter
+        vm.expectRevert("Invalid caller for message");
+        synapseCCTPs[DOMAIN_AVAX].receiveCircleToken({
+            message: expected.message,
+            signature: "",
+            requestVersion: RequestLib.REQUEST_BASE,
+            formattedRequest: expectedBase.request
+        });
+    }
+
+    // ══════════════════════════════════════════════════ HELPERS ══════════════════════════════════════════════════════
 
     function getExpectedParams(
         uint32 originDomain,

--- a/test/cctp/mocks/MockDefaultPool.sol
+++ b/test/cctp/mocks/MockDefaultPool.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IDefaultPool} from "../../../contracts/cctp/interfaces/IDefaultPool.sol";
+
+import {IERC20, SafeERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/utils/SafeERC20.sol";
+
+/// A simple lightweight mock of the Default pool contract for testing purposes.
+/// Note that the mock is using the UniSwap formula for price calculations. This is done to simplify the logic.
+/// Note there is no addLiquidity or removeLiquidity. This pool is using the whole balance of each token as liquidity.
+/// Mint of transfer test tokens to the pool address before using the pool.
+// TODO: deprecate when LinkedPool PR is merged
+contract MockDefaultPool is IDefaultPool {
+    using SafeERC20 for IERC20;
+
+    address[] internal _tokens;
+    uint256 internal _coins;
+
+    // We don't expose paused() in this contract to test that LinkedPool could handle pools without this function.
+    bool internal _paused;
+
+    constructor(address[] memory tokens) {
+        _tokens = tokens;
+        _coins = tokens.length;
+    }
+
+    function swap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx,
+        uint256 minDy,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
+        if (_paused) revert("Siesta time");
+        amountOut = _calculateSwap(tokenIndexFrom, tokenIndexTo, dx);
+        require(amountOut >= minDy, "Insufficient output amount");
+        // solhint-disable-next-line not-rely-on-time
+        require(deadline >= block.timestamp, "Deadline expired");
+        IERC20(_getToken(tokenIndexFrom)).safeTransferFrom(msg.sender, address(this), dx);
+        IERC20(_getToken(tokenIndexTo)).safeTransfer(msg.sender, amountOut);
+    }
+
+    function calculateSwap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx
+    ) external view returns (uint256 amountOut) {
+        return _calculateSwap(tokenIndexFrom, tokenIndexTo, dx);
+    }
+
+    function getToken(uint8 index) external view returns (address token) {
+        return _getToken(index);
+    }
+
+    // ══════════════════════════════════════════════ INTERNAL VIEWS ═══════════════════════════════════════════════════
+
+    function _calculateSwap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx
+    ) internal view returns (uint256 amountOut) {
+        if (tokenIndexFrom == tokenIndexTo) return 0;
+        if (tokenIndexFrom >= _coins || tokenIndexTo >= _coins) return 0;
+        uint256 balanceFrom = _getBalance(_getToken(tokenIndexFrom));
+        uint256 balanceTo = _getBalance(_getToken(tokenIndexTo));
+        require(balanceFrom > 0 && balanceTo > 0, "No liquidity");
+        // Follow the Uniswap formula for calculating the amountOut
+        amountOut = (dx * balanceTo * 997) / (balanceFrom * 1000 + dx * 997);
+    }
+
+    function _getBalance(address token) internal view returns (uint256 balance) {
+        return IERC20(token).balanceOf(address(this));
+    }
+
+    function _getToken(uint8 index) internal view returns (address token) {
+        require(index < _coins, "Incorrect token index");
+        return _tokens[index];
+    }
+}

--- a/test/cctp/mocks/MockERC20.sol
+++ b/test/cctp/mocks/MockERC20.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {ERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/ERC20.sol";
+
+// TODO: deprecate when LinkedPool PR is merged
+contract MockERC20 is ERC20 {
+    uint8 private _decimals;
+
+    constructor(string memory name_, uint8 decimals_) ERC20(name_, name_) {
+        _decimals = decimals_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+
+    function burn(address account, uint256 amount) external {
+        _burn(account, amount);
+    }
+
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
+    }
+}


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

This PR adds support for "Swap" CCTP bridge requests. The origin sender has to specify following parameters for executing a swap on the destination chain:
https://github.com/synapsecns/synapse-contracts/blob/6bf4b6a33ba7b41022a6f4df98e20ea5ad00e81a/contracts/cctp/libs/Request.sol#L18-L24

On the destination chain, `SynapseCCTP` will try to perform a swap using the parameters from the origin request. Should the swap fail, the minted Circle token will be transferred to the recipient instead.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
