### PR TITLE
Feat: CCTP fee config

### DIFF
--- a/contracts/cctp/events/SynapseCCTPFeesEvents.sol
+++ b/contracts/cctp/events/SynapseCCTPFeesEvents.sol
@@ -7,4 +7,8 @@ abstract contract SynapseCCTPFeesEvents {
     /// @param oldFeeCollector  The old fee collector address: will be able to withdraw prior fees
     /// @param newFeeCollector  The new fee collector address: will be able to withdraw future fees
     event FeeCollectorUpdated(address indexed relayer, address oldFeeCollector, address newFeeCollector);
+
+    /// @notice Emitted when the protocol fee is updated
+    /// @param newProtocolFee  The new protocol fee
+    event ProtocolFeeUpdated(uint256 newProtocolFee);
 }

--- a/contracts/cctp/events/SynapseCCTPFeesEvents.sol
+++ b/contracts/cctp/events/SynapseCCTPFeesEvents.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+abstract contract SynapseCCTPFeesEvents {
+    /// @notice Emitted when the fee collector is updated for a relayer
+    /// @param relayer          The relayer address
+    /// @param oldFeeCollector  The old fee collector address: will be able to withdraw prior fees
+    /// @param newFeeCollector  The new fee collector address: will be able to withdraw future fees
+    event FeeCollectorUpdated(address indexed relayer, address oldFeeCollector, address newFeeCollector);
+}

--- a/contracts/cctp/fees/SynapseCCTPFees.sol
+++ b/contracts/cctp/fees/SynapseCCTPFees.sol
@@ -52,8 +52,10 @@ abstract contract SynapseCCTPFees is SynapseCCTPFeesEvents, Ownable {
     mapping(string => address) public symbolToToken;
     /// @notice Maps bridge token address into CCTP fee structure
     mapping(address => CCTPFee) public feeStructures;
-    /// @notice Maps bridge token address into accumulated fees
-    mapping(address => uint256) public accumulatedFees;
+    /// @notice Maps fee collector address into accumulated fees for a token
+    /// (feeCollector => (token => amount))
+    /// @dev Fee collector address of address(0) indicates that fees are accumulated by the Protocol
+    mapping(address => mapping(address => uint256)) public accumulatedFees;
     /// @notice Maps Relayer address into collector address for accumulated Relayer's fees
     /// @dev Default value of address(0) indicates that Relayer's fees are accumulated by the Protocol
     mapping(address => address) public relayerFeeCollectors;
@@ -175,7 +177,9 @@ abstract contract SynapseCCTPFees is SynapseCCTPFeesEvents, Ownable {
         unchecked {
             amountAfterFee = amount - fee;
         }
-        accumulatedFees[token] += fee;
+        // Get the fee collector for the Relayer. If it is not set (address(0)), Protocol will collect the fees.
+        address feeCollector = relayerFeeCollectors[msg.sender];
+        accumulatedFees[feeCollector][token] += fee;
     }
 
     /// @dev Sets the fee structure for a supported Circle token.

--- a/contracts/cctp/fees/SynapseCCTPFees.sol
+++ b/contracts/cctp/fees/SynapseCCTPFees.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {CCTPSymbolAlreadyAdded, CCTPSymbolIncorrect, CCTPTokenAlreadyAdded, CCTPTokenNotFound} from "../libs/Errors.sol";
+import {TypeCasts} from "../libs/TypeCasts.sol";
+
+import {Ownable} from "@openzeppelin/contracts-4.5.0/access/Ownable.sol";
+import {EnumerableSet} from "@openzeppelin/contracts-4.5.0/utils/structs/EnumerableSet.sol";
+
+abstract contract SynapseCCTPFees is Ownable {
+    using EnumerableSet for EnumerableSet.AddressSet;
+    using TypeCasts for uint256;
+
+    /// @notice CCTP fee structure for a supported Circle token.
+    /// @dev Optimized for storage. 2**72 is 4*10**21, which is enough to represent adequate amounts
+    /// for stable coins with 18 decimals. Circle tokens have 6 decimals, so this is more than enough.
+    /// @param relayerFee   Fee % for bridging a token to this chain, multiplied by `FEE_DENOMINATOR`
+    /// @param minBaseFee   Minimum fee for bridging a token to this chain using a base request
+    /// @param minSwapFee   Minimum fee for bridging a token to this chain using a swap request
+    /// @param maxFee       Maximum fee for bridging a token to this chain
+    struct CCTPFee {
+        uint40 relayerFee;
+        uint72 minBaseFee;
+        uint72 minSwapFee;
+        uint72 maxFee;
+    }
+
+    /// @dev Denominator used to calculate the bridge fee
+    uint256 private constant FEE_DENOMINATOR = 10**10;
+    /// @dev Mandatory prefix used for CCTP token symbols to distinguish them from other bridge symbols
+    bytes private constant SYMBOL_PREFIX = "CCTP.";
+    /// @dev Length of the mandatory prefix used for CCTP token symbols
+    uint256 private constant SYMBOL_PREFIX_LENGTH = 5;
+
+    // ══════════════════════════════════════════════════ STORAGE ══════════════════════════════════════════════════════
+
+    /// @notice Maps bridge token address into bridge token symbol
+    mapping(address => string) public tokenToSymbol;
+    /// @notice Maps bridge token symbol into bridge token address
+    mapping(string => address) public symbolToToken;
+    /// @dev Maps bridge token address into CCTP fee structure
+    mapping(address => CCTPFee) internal _tokenFees;
+    /// @dev A list of all supported bridge tokens
+    EnumerableSet.AddressSet internal _bridgeTokens;
+
+    // ════════════════════════════════════════════════ ONLY OWNER ═════════════════════════════════════════════════════
+
+    /// @notice Adds a new token to the list of supported tokens, with the given symbol and fee structure.
+    /// @dev The symbol must start with "CCTP."
+    /// @param symbol       Symbol of the token
+    /// @param token        Address of the token
+    /// @param relayerFee   Fee % for bridging a token to this chain, multiplied by `FEE_DENOMINATOR`
+    /// @param minBaseFee   Minimum fee for bridging a token to this chain using a base request
+    /// @param minSwapFee   Minimum fee for bridging a token to this chain using a swap request
+    /// @param maxFee       Maximum fee for bridging a token to this chain
+    function addToken(
+        string memory symbol,
+        address token,
+        uint256 relayerFee,
+        uint256 minBaseFee,
+        uint256 minSwapFee,
+        uint256 maxFee
+    ) external onlyOwner {
+        // Add a new token to the list of supported tokens, and check that it hasn't been added before
+        if (!_bridgeTokens.add(token)) revert CCTPTokenAlreadyAdded();
+        // Check that symbol hasn't been added yet and starts with "CCTP."
+        _assertCanAddSymbol(symbol);
+        // Add token <> symbol link
+        tokenToSymbol[token] = symbol;
+        symbolToToken[symbol] = token;
+        // Set token fee
+        _setTokenFee(token, relayerFee, minBaseFee, minSwapFee, maxFee);
+    }
+
+    /// @notice Updates the fee structure for a supported Circle token.
+    /// @dev Will revert if the token is not supported.
+    /// @param token        Address of the token
+    /// @param relayerFee   Fee % for bridging a token to this chain, multiplied by `FEE_DENOMINATOR`
+    /// @param minBaseFee   Minimum fee for bridging a token to this chain using a base request
+    /// @param minSwapFee   Minimum fee for bridging a token to this chain using a swap request
+    /// @param maxFee       Maximum fee for bridging a token to this chain
+    function setTokenFee(
+        address token,
+        uint256 relayerFee,
+        uint256 minBaseFee,
+        uint256 minSwapFee,
+        uint256 maxFee
+    ) external onlyOwner {
+        if (!_bridgeTokens.contains(token)) revert CCTPTokenNotFound();
+        _setTokenFee(token, relayerFee, minBaseFee, minSwapFee, maxFee);
+    }
+
+    // ══════════════════════════════════════════════ INTERNAL LOGIC ═══════════════════════════════════════════════════
+
+    /// @dev Sets the fee structure for a supported Circle token.
+    function _setTokenFee(
+        address token,
+        uint256 relayerFee,
+        uint256 minBaseFee,
+        uint256 minSwapFee,
+        uint256 maxFee
+    ) internal {
+        _tokenFees[token] = CCTPFee({
+            relayerFee: relayerFee.safeCastToUint40(),
+            minBaseFee: minBaseFee.safeCastToUint72(),
+            minSwapFee: minSwapFee.safeCastToUint72(),
+            maxFee: maxFee.safeCastToUint72()
+        });
+    }
+
+    // ══════════════════════════════════════════════ INTERNAL VIEWS ═══════════════════════════════════════════════════
+
+    /// @dev Checks that the symbol hasn't been added yet and starts with "CCTP."
+    function _assertCanAddSymbol(string memory symbol) internal view {
+        // Check if the symbol has already been added
+        if (symbolToToken[symbol] != address(0)) revert CCTPSymbolAlreadyAdded();
+        // Cast to bytes to check the length
+        bytes memory symbolBytes = bytes(symbol);
+        // Check that symbol is correct: starts with "CCTP." and has at least 1 more character
+        if (symbolBytes.length <= SYMBOL_PREFIX_LENGTH) revert CCTPSymbolIncorrect();
+        for (uint256 i = 0; i < SYMBOL_PREFIX_LENGTH; ) {
+            if (symbolBytes[i] != SYMBOL_PREFIX[i]) revert CCTPSymbolIncorrect();
+            unchecked {
+                ++i;
+            }
+        }
+    }
+}

--- a/contracts/cctp/fees/SynapseCCTPFees.sol
+++ b/contracts/cctp/fees/SynapseCCTPFees.sol
@@ -73,6 +73,19 @@ abstract contract SynapseCCTPFees is Ownable {
         _setTokenFee(token, relayerFee, minBaseFee, minSwapFee, maxFee);
     }
 
+    /// @notice Removes a token from the list of supported tokens.
+    /// @dev Will revert if the token is not supported.
+    function removeToken(address token) external onlyOwner {
+        // Remove a token from the list of supported tokens, and check that it has been added before
+        if (!_bridgeTokens.remove(token)) revert CCTPTokenNotFound();
+        // Remove token <> symbol link
+        string memory symbol = tokenToSymbol[token];
+        delete tokenToSymbol[token];
+        delete symbolToToken[symbol];
+        // Remove token fee structure
+        delete feeStructures[token];
+    }
+
     /// @notice Updates the fee structure for a supported Circle token.
     /// @dev Will revert if the token is not supported.
     /// @param token        Address of the token

--- a/contracts/cctp/libs/Errors.sol
+++ b/contracts/cctp/libs/Errors.sol
@@ -15,7 +15,6 @@ error CCTPTokenAlreadyAdded();
 error CCTPTokenNotFound();
 
 error CCTPMessageNotReceived();
-error LocalCCTPTokenNotFound();
 error RemoteCCTPDeploymentNotSet();
 error RemoteCCTPTokenNotSet();
 

--- a/contracts/cctp/libs/Errors.sol
+++ b/contracts/cctp/libs/Errors.sol
@@ -7,6 +7,7 @@ error IncorrectRequestLength();
 error UnknownRequestVersion();
 
 error CCTPIncorrectConfig();
+error CCTPIncorrectProtocolFee();
 error CCTPInsufficientAmount();
 error CCTPSymbolAlreadyAdded();
 error CCTPSymbolIncorrect();

--- a/contracts/cctp/libs/Errors.sol
+++ b/contracts/cctp/libs/Errors.sol
@@ -7,6 +7,7 @@ error IncorrectRequestLength();
 error UnknownRequestVersion();
 
 error CCTPIncorrectConfig();
+error CCTPInsufficientAmount();
 error CCTPSymbolAlreadyAdded();
 error CCTPSymbolIncorrect();
 error CCTPTokenAlreadyAdded();

--- a/contracts/cctp/libs/Errors.sol
+++ b/contracts/cctp/libs/Errors.sol
@@ -1,8 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
+error CastOverflow();
+
 error IncorrectRequestLength();
 error UnknownRequestVersion();
+
+error CCTPSymbolAlreadyAdded();
+error CCTPSymbolIncorrect();
+error CCTPTokenAlreadyAdded();
+error CCTPTokenNotFound();
 
 error CCTPMessageNotReceived();
 error LocalCCTPTokenNotFound();

--- a/contracts/cctp/libs/Errors.sol
+++ b/contracts/cctp/libs/Errors.sol
@@ -6,6 +6,7 @@ error CastOverflow();
 error IncorrectRequestLength();
 error UnknownRequestVersion();
 
+error CCTPIncorrectConfig();
 error CCTPSymbolAlreadyAdded();
 error CCTPSymbolIncorrect();
 error CCTPTokenAlreadyAdded();

--- a/contracts/cctp/libs/Structs.sol
+++ b/contracts/cctp/libs/Structs.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+// TODO: merge with ROuterV2 structs
+struct BridgeToken {
+    string symbol;
+    address token;
+}

--- a/contracts/cctp/libs/TypeCasts.sol
+++ b/contracts/cctp/libs/TypeCasts.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
+import {CastOverflow} from "./Errors.sol";
+
 library TypeCasts {
     // alignment preserving cast
     function addressToBytes32(address addr) internal pure returns (bytes32) {
@@ -10,5 +12,21 @@ library TypeCasts {
     // alignment preserving cast
     function bytes32ToAddress(bytes32 buf) internal pure returns (address) {
         return address(uint160(uint256(buf)));
+    }
+
+    /// @dev Casts uint256 to uint40, reverts on overflow
+    function safeCastToUint40(uint256 value) internal pure returns (uint40) {
+        if (value > type(uint40).max) {
+            revert CastOverflow();
+        }
+        return uint40(value);
+    }
+
+    /// @dev Casts uint256 to uint72, reverts on overflow
+    function safeCastToUint72(uint256 value) internal pure returns (uint72) {
+        if (value > type(uint72).max) {
+            revert CastOverflow();
+        }
+        return uint72(value);
     }
 }

--- a/test/cctp/SynapseCCTP.t.sol
+++ b/test/cctp/SynapseCCTP.t.sol
@@ -63,19 +63,24 @@ contract SynapseCCTPTest is BaseCCTPTest {
 
     function testReceiveCircleTokenBaseRequest() public {
         uint256 amount = 10**8;
+        uint256 baseFeeAmount = 10**6;
+        uint256 expectedAmountOut = amount - baseFeeAmount;
         checkRequestFulfilled({
             originDomain: DOMAIN_ETH,
             destinationDomain: DOMAIN_AVAX,
             amountIn: amount,
+            expectedFeeAmount: baseFeeAmount,
             expectedTokenOut: address(cctpSetups[DOMAIN_AVAX].mintBurnToken),
-            expectedAmountOut: amount,
+            expectedAmountOut: expectedAmountOut,
             swapParams: ""
         });
-        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount);
+        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), expectedAmountOut);
     }
 
     function testReceiveCircleTokenBaseRequestRevertTransmitterReturnsFalse() public {
         uint256 amount = 10**8;
+        uint256 baseFeeAmount = 10**6;
+        uint256 expectedAmountOut = amount - baseFeeAmount;
         Params memory expected = getExpectedParams({
             originDomain: DOMAIN_ETH,
             destinationDomain: DOMAIN_AVAX,
@@ -103,7 +108,7 @@ contract SynapseCCTPTest is BaseCCTPTest {
             requestVersion: RequestLib.REQUEST_BASE,
             formattedRequest: expected.request
         });
-        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount);
+        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), expectedAmountOut);
     }
 
     function testReceiveCircleTokenBaseRequestRevertMalformedRequest() public {
@@ -210,25 +215,27 @@ contract SynapseCCTPTest is BaseCCTPTest {
 
     function testReceiveCircleTokenSwapRequest() public {
         uint256 amount = 10**8;
+        uint256 swapFeeAmount = 2 * 10**6;
         // TODO: adjust for fees when implemented
         address tokenOut = address(poolSetups[DOMAIN_AVAX].token);
-        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount);
+        uint256 expectedAmountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount - swapFeeAmount);
         bytes memory swapParams = RequestLib.formatSwapParams({
             pool: address(poolSetups[DOMAIN_AVAX].pool),
             tokenIndexFrom: 0,
             tokenIndexTo: 1,
             deadline: block.timestamp,
-            minAmountOut: amountOut
+            minAmountOut: expectedAmountOut
         });
         checkRequestFulfilled({
             originDomain: DOMAIN_ETH,
             destinationDomain: DOMAIN_AVAX,
             amountIn: amount,
+            expectedFeeAmount: swapFeeAmount,
             expectedTokenOut: tokenOut,
-            expectedAmountOut: amountOut,
+            expectedAmountOut: expectedAmountOut,
             swapParams: swapParams
         });
-        assertEq(poolSetups[DOMAIN_AVAX].token.balanceOf(recipient), amountOut);
+        assertEq(poolSetups[DOMAIN_AVAX].token.balanceOf(recipient), expectedAmountOut);
     }
 
     function testReceiveCircleTokenSwapRequestRevertMalformedRequest() public {
@@ -374,7 +381,8 @@ contract SynapseCCTPTest is BaseCCTPTest {
         // Adjust block.timestamp
         vm.warp(123456789);
         uint256 amount = 10**8;
-        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount);
+        uint256 swapFeeAmount = 2 * 10**6;
+        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount - swapFeeAmount);
         bytes memory swapParams = RequestLib.formatSwapParams({
             pool: address(poolSetups[DOMAIN_AVAX].pool),
             tokenIndexFrom: 0,
@@ -387,16 +395,18 @@ contract SynapseCCTPTest is BaseCCTPTest {
             originDomain: DOMAIN_ETH,
             destinationDomain: DOMAIN_AVAX,
             amountIn: amount,
+            expectedFeeAmount: swapFeeAmount,
             expectedTokenOut: address(cctpSetups[DOMAIN_AVAX].mintBurnToken),
-            expectedAmountOut: amount,
+            expectedAmountOut: amount - swapFeeAmount,
             swapParams: swapParams
         });
-        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount);
+        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount - swapFeeAmount);
     }
 
     function testReceiveCircleTokenSwapRequestMinAmountOutNotReached() public {
         uint256 amount = 10**8;
-        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount);
+        uint256 swapFeeAmount = 2 * 10**6;
+        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount - swapFeeAmount);
         bytes memory swapParams = RequestLib.formatSwapParams({
             pool: address(poolSetups[DOMAIN_AVAX].pool),
             tokenIndexFrom: 0,
@@ -409,16 +419,18 @@ contract SynapseCCTPTest is BaseCCTPTest {
             originDomain: DOMAIN_ETH,
             destinationDomain: DOMAIN_AVAX,
             amountIn: amount,
+            expectedFeeAmount: swapFeeAmount,
             expectedTokenOut: address(cctpSetups[DOMAIN_AVAX].mintBurnToken),
-            expectedAmountOut: amount,
+            expectedAmountOut: amount - swapFeeAmount,
             swapParams: swapParams
         });
-        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount);
+        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount - swapFeeAmount);
     }
 
     function testReceiveCircleTokenSwapRequestTokenIndexesIdentical() public {
         uint256 amount = 10**8;
-        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount);
+        uint256 swapFeeAmount = 2 * 10**6;
+        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount - swapFeeAmount);
         bytes memory swapParams = RequestLib.formatSwapParams({
             pool: address(poolSetups[DOMAIN_AVAX].pool),
             tokenIndexFrom: 0,
@@ -431,16 +443,18 @@ contract SynapseCCTPTest is BaseCCTPTest {
             originDomain: DOMAIN_ETH,
             destinationDomain: DOMAIN_AVAX,
             amountIn: amount,
+            expectedFeeAmount: swapFeeAmount,
             expectedTokenOut: address(cctpSetups[DOMAIN_AVAX].mintBurnToken),
-            expectedAmountOut: amount,
+            expectedAmountOut: amount - swapFeeAmount,
             swapParams: swapParams
         });
-        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount);
+        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount - swapFeeAmount);
     }
 
     function testReceiveCircleTokenSwapRequestTokenIndexesIncorrectOrder() public {
         uint256 amount = 10**8;
-        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount);
+        uint256 swapFeeAmount = 2 * 10**6;
+        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount - swapFeeAmount);
         bytes memory swapParams = RequestLib.formatSwapParams({
             pool: address(poolSetups[DOMAIN_AVAX].pool),
             tokenIndexFrom: 1, // incorrect order
@@ -453,16 +467,18 @@ contract SynapseCCTPTest is BaseCCTPTest {
             originDomain: DOMAIN_ETH,
             destinationDomain: DOMAIN_AVAX,
             amountIn: amount,
+            expectedFeeAmount: swapFeeAmount,
             expectedTokenOut: address(cctpSetups[DOMAIN_AVAX].mintBurnToken),
-            expectedAmountOut: amount,
+            expectedAmountOut: amount - swapFeeAmount,
             swapParams: swapParams
         });
-        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount);
+        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount - swapFeeAmount);
     }
 
     function testReceiveCircleTokenSwapRequestTokenFromIndexOutOfRange() public {
         uint256 amount = 10**8;
-        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount);
+        uint256 swapFeeAmount = 2 * 10**6;
+        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount - swapFeeAmount);
         bytes memory swapParams = RequestLib.formatSwapParams({
             pool: address(poolSetups[DOMAIN_AVAX].pool),
             tokenIndexFrom: 2, // out of range
@@ -475,16 +491,18 @@ contract SynapseCCTPTest is BaseCCTPTest {
             originDomain: DOMAIN_ETH,
             destinationDomain: DOMAIN_AVAX,
             amountIn: amount,
+            expectedFeeAmount: swapFeeAmount,
             expectedTokenOut: address(cctpSetups[DOMAIN_AVAX].mintBurnToken),
-            expectedAmountOut: amount,
+            expectedAmountOut: amount - swapFeeAmount,
             swapParams: swapParams
         });
-        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount);
+        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount - swapFeeAmount);
     }
 
     function testReceiveCircleTokenSwapRequestTokenToIndexOutOfRange() public {
         uint256 amount = 10**8;
-        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount);
+        uint256 swapFeeAmount = 2 * 10**6;
+        uint256 amountOut = poolSetups[DOMAIN_AVAX].pool.calculateSwap(0, 1, amount - swapFeeAmount);
         bytes memory swapParams = RequestLib.formatSwapParams({
             pool: address(poolSetups[DOMAIN_AVAX].pool),
             tokenIndexFrom: 0,
@@ -497,11 +515,12 @@ contract SynapseCCTPTest is BaseCCTPTest {
             originDomain: DOMAIN_ETH,
             destinationDomain: DOMAIN_AVAX,
             amountIn: amount,
+            expectedFeeAmount: swapFeeAmount,
             expectedTokenOut: address(cctpSetups[DOMAIN_AVAX].mintBurnToken),
-            expectedAmountOut: amount,
+            expectedAmountOut: amount - swapFeeAmount,
             swapParams: swapParams
         });
-        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount);
+        assertEq(cctpSetups[DOMAIN_AVAX].mintBurnToken.balanceOf(recipient), amount - swapFeeAmount);
     }
 
     // ══════════════════════════════════════════════════ HELPERS ══════════════════════════════════════════════════════
@@ -510,6 +529,7 @@ contract SynapseCCTPTest is BaseCCTPTest {
         uint32 originDomain,
         uint32 destinationDomain,
         uint256 amountIn,
+        uint256 expectedFeeAmount,
         address expectedTokenOut,
         uint256 expectedAmountOut,
         bytes memory swapParams
@@ -529,12 +549,11 @@ contract SynapseCCTPTest is BaseCCTPTest {
             mintToken: destMintToken,
             amount: amountIn
         });
-        // TODO: adjust when fees are implemented
         vm.expectEmit();
         emit CircleRequestFulfilled({
             recipient: recipient,
             mintToken: destMintToken,
-            fee: 0,
+            fee: expectedFeeAmount,
             token: expectedTokenOut,
             amount: expectedAmountOut,
             kappa: expected.kappa

--- a/test/cctp/fees/SynapseCCTPFees.t.sol
+++ b/test/cctp/fees/SynapseCCTPFees.t.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {CCTPSymbolAlreadyAdded, CCTPSymbolIncorrect, CCTPTokenAlreadyAdded, CCTPTokenNotFound} from "../../../contracts/cctp/libs/Errors.sol";
+import {BridgeToken, SynapseCCTPFees} from "../../../contracts/cctp/fees/SynapseCCTPFees.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+// solhint-disable-next-line no-empty-blocks
+contract SynapseCCTPFeesHarness is SynapseCCTPFees {
+
+}
+
+contract SynapseCCTPFeesTest is Test {
+    SynapseCCTPFeesHarness public cctpFees;
+    address public owner;
+    address public usdc;
+    address public eurc;
+
+    function setUp() public {
+        cctpFees = new SynapseCCTPFeesHarness();
+        owner = makeAddr("Owner");
+        cctpFees.transferOwnership(owner);
+        usdc = makeAddr("USDC");
+        eurc = makeAddr("EURC");
+    }
+
+    function testSetup() public {
+        assertEq(cctpFees.owner(), owner);
+        assertEq(cctpFees.getBridgeTokens().length, 0);
+    }
+
+    // ═══════════════════════════════════════════ TESTS: ADDING TOKENS ════════════════════════════════════════════════
+
+    function addTokens() public {
+        // add USDC: 5bp relayer fee, 1 USDC min base fee, 5 USDC min swap fee, 100 USDC max fee
+        vm.prank(owner);
+        cctpFees.addToken("CCTP.USDC", usdc, 5 * 10**6, 1 * 10**6, 5 * 10**6, 100 * 10**6);
+        // add EURC: 10bp relayer fee, 2 EURC min base fee, 10 EURC min swap fee, 50 EURC max fee
+        vm.prank(owner);
+        cctpFees.addToken("CCTP.EURC", eurc, 10 * 10**6, 2 * 10**6, 10 * 10**6, 50 * 10**6);
+    }
+
+    function testAddTokenSavesBridgeTokensList() public {
+        addTokens();
+        BridgeToken[] memory tokens = cctpFees.getBridgeTokens();
+        assertEq(tokens.length, 2);
+        assertEq(tokens[0].symbol, "CCTP.USDC");
+        assertEq(tokens[0].token, usdc);
+        assertEq(tokens[1].symbol, "CCTP.EURC");
+        assertEq(tokens[1].token, eurc);
+    }
+
+    function testAddTokenSavesFeeStructure() public {
+        addTokens();
+        (uint256 relayerFee, uint256 minBaseFee, uint256 minSwapFee, uint256 maxFee) = cctpFees.feeStructures(usdc);
+        assertEq(relayerFee, 5 * 10**6);
+        assertEq(minBaseFee, 1 * 10**6);
+        assertEq(minSwapFee, 5 * 10**6);
+        assertEq(maxFee, 100 * 10**6);
+        (relayerFee, minBaseFee, minSwapFee, maxFee) = cctpFees.feeStructures(eurc);
+        assertEq(relayerFee, 10 * 10**6);
+        assertEq(minBaseFee, 2 * 10**6);
+        assertEq(minSwapFee, 10 * 10**6);
+        assertEq(maxFee, 50 * 10**6);
+    }
+
+    function testAddTokenSavesTokenAddress() public {
+        addTokens();
+        assertEq(cctpFees.tokenToSymbol(usdc), "CCTP.USDC");
+        assertEq(cctpFees.tokenToSymbol(eurc), "CCTP.EURC");
+    }
+
+    function testAddTokenSavesTokenSymbol() public {
+        addTokens();
+        assertEq(cctpFees.symbolToToken("CCTP.USDC"), usdc);
+        assertEq(cctpFees.symbolToToken("CCTP.EURC"), eurc);
+    }
+
+    function testAddTokenRevertsWhenCallerNotOwner(address caller) public {
+        vm.assume(caller != owner);
+        vm.prank(caller);
+        vm.expectRevert("Ownable: caller is not the owner");
+        cctpFees.addToken("CCTP.USDC", address(1), 0, 0, 0, 0);
+    }
+
+    function testAddTokenRevertsWhenSymbolAlreadyAdded() public {
+        addTokens();
+        vm.expectRevert(CCTPSymbolAlreadyAdded.selector);
+        vm.prank(owner);
+        cctpFees.addToken("CCTP.USDC", address(1), 0, 0, 0, 0);
+    }
+
+    function checkAddIncorrectSymbol(string memory symbol) public {
+        vm.expectRevert(CCTPSymbolIncorrect.selector);
+        vm.prank(owner);
+        cctpFees.addToken(symbol, address(1), 0, 0, 0, 0);
+    }
+
+    function testAddTokenRevertsWhenSymbolPrefixIncorrect() public {
+        checkAddIncorrectSymbol("CCTP-Token");
+        checkAddIncorrectSymbol("CCTp.Token");
+        checkAddIncorrectSymbol("CCtP.Token");
+        checkAddIncorrectSymbol("CcTP.Token");
+        checkAddIncorrectSymbol("cCTP.Token");
+    }
+
+    function testAddTokenRevertsWhenSymbolTooShort() public {
+        checkAddIncorrectSymbol("CCTP.");
+        checkAddIncorrectSymbol("CCTP");
+        checkAddIncorrectSymbol("CCT");
+        checkAddIncorrectSymbol("CC");
+        checkAddIncorrectSymbol("C");
+        checkAddIncorrectSymbol("");
+    }
+
+    function testAddTokenRevertsWhenTokenAlreadyAdded() public {
+        addTokens();
+        vm.expectRevert(CCTPTokenAlreadyAdded.selector);
+        vm.prank(owner);
+        cctpFees.addToken("CCTP.USDC-new", usdc, 0, 0, 0, 0);
+    }
+
+    // ════════════════════════════════════════ TESTS: UPDATING TOKEN FEES ═════════════════════════════════════════════
+
+    function testSetTokenFee() public {
+        addTokens();
+        // New fees: 1bp relayer fee, 2 USDC min base fee, 3 USDC min swap fee, 4 USDC max fee
+        vm.prank(owner);
+        cctpFees.setTokenFee(usdc, 1 * 10**6, 2 * 10**6, 3 * 10**6, 4 * 10**6);
+        (uint256 relayerFee, uint256 minBaseFee, uint256 minSwapFee, uint256 maxFee) = cctpFees.feeStructures(usdc);
+        assertEq(relayerFee, 1 * 10**6);
+        assertEq(minBaseFee, 2 * 10**6);
+        assertEq(minSwapFee, 3 * 10**6);
+        assertEq(maxFee, 4 * 10**6);
+    }
+
+    function testSetTokenFeeRevertsWhenCallerNotOwner(address caller) public {
+        addTokens();
+        vm.assume(caller != owner);
+        vm.prank(caller);
+        vm.expectRevert("Ownable: caller is not the owner");
+        cctpFees.setTokenFee(usdc, 0, 0, 0, 0);
+    }
+
+    function testSetTokenFeeRevertsWhenTokenNotFound() public {
+        vm.expectRevert(CCTPTokenNotFound.selector);
+        vm.prank(owner);
+        cctpFees.setTokenFee(usdc, 0, 0, 0, 0);
+    }
+
+    // ══════════════════════════════════════ TESTS: CALCULATING BRIDGE FEES ═══════════════════════════════════════════
+
+    function testCalculateFeeAmountReturnsMinFee() public {
+        addTokens();
+        assertEq(cctpFees.calculateFeeAmount(usdc, 10**9, false), 1 * 10**6);
+        assertEq(cctpFees.calculateFeeAmount(usdc, 10**9, true), 5 * 10**6);
+        assertEq(cctpFees.calculateFeeAmount(eurc, 10**9, false), 2 * 10**6);
+        assertEq(cctpFees.calculateFeeAmount(eurc, 10**9, true), 10 * 10**6);
+    }
+
+    function testCalculateFeeAmountReturnsMaxFee() public {
+        addTokens();
+        assertEq(cctpFees.calculateFeeAmount(usdc, 10**12, false), 100 * 10**6);
+        assertEq(cctpFees.calculateFeeAmount(usdc, 10**12, true), 100 * 10**6);
+        assertEq(cctpFees.calculateFeeAmount(eurc, 10**12, false), 50 * 10**6);
+        assertEq(cctpFees.calculateFeeAmount(eurc, 10**12, true), 50 * 10**6);
+    }
+
+    function testCalculateFeeAmountReturnsCorrectPercentageFee() public {
+        addTokens();
+        // USDC fee is 5bps
+        assertEq(cctpFees.calculateFeeAmount(usdc, 10**10, false), 5 * 10**6);
+        assertEq(cctpFees.calculateFeeAmount(usdc, 2 * 10**10, true), 10 * 10**6);
+        // EURC fee is 10bps
+        assertEq(cctpFees.calculateFeeAmount(eurc, 10**10, false), 10 * 10**6);
+        assertEq(cctpFees.calculateFeeAmount(eurc, 2 * 10**10, true), 20 * 10**6);
+    }
+}


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

This PR allows to setup and configure the "relayer fees" in `SynapseCCTP` contract. The relayer fees have a following structure:
- A percentage fee is applied to the amount of bridged Circle tokens. This fee has a hard cap of `10 bps`.
- The resulting fee has is then compared to the minimal relayer fee, and increased to match it, if needed.
  - The minimal fee **is different** for Base and Swap requests. This is done to ensure that "brdige" fee could be smaller than "bridge + swap" fee.
- The fee is then compared to the maximum fee, and decreased to match it, if needed.

Anyone could be a relayer, as the integrity of the provided request is secured by CCTP itself (more details could be found in #233 and #235). Any relayer has an option to set up an address that will collect their earned relayer fees. Therefore there could be two kinds of relayers:
- Ones that haven't setup such address. All their fees are collected by the Protocol (the Treasury).
- Relayers that registered a "fee collector" address. Their earned fees (minus the protocol fees, more details below) could be claimed by the collector address at any time.

`SynapseCCTP` contract applies a protocol fee for the "registeted" realyers, as a percentage of the relayer fee. This protocol fee is set by the contract owner and has a hard cap of `50%`.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
