### PR TITLE
Feat: common base for Router contracts

### DIFF
--- a/contracts/router/DefaultRouter.sol
+++ b/contracts/router/DefaultRouter.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {DefaultAdapter} from "./adapters/DefaultAdapter.sol";
+import {MsgValueIncorrect, TokenNotETH} from "./libs/Errors.sol";
+import {UniversalTokenLib} from "./libs/UniversalToken.sol";
+
+import {SafeERC20, IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/utils/SafeERC20.sol";
+
+/// @title DefaultRouter
+/// @notice Base contract for all Synapse Routers, that is able to natively work with Default Pools
+/// due to the fact that it inherits from DefaultAdapter.
+abstract contract DefaultRouter is DefaultAdapter {
+    using SafeERC20 for IERC20;
+    using UniversalTokenLib for address;
+
+    /// @dev Pulls a requested token from the user to the requested recipient.
+    /// Or, if msg.value was provided, check that ETH_ADDRESS was used and msg.value is correct.
+    function _pullToken(
+        address recipient,
+        address token,
+        uint256 amount
+    ) internal returns (uint256 amountPulled) {
+        if (msg.value == 0) {
+            token.assertIsContract();
+            // Record token balance before transfer
+            amountPulled = IERC20(token).balanceOf(recipient);
+            // Token needs to be pulled only if msg.value is zero
+            // This way user can specify WETH as the origin asset
+            IERC20(token).safeTransferFrom(msg.sender, recipient, amount);
+            // Use the difference between the recorded balance and the current balance as the amountPulled
+            amountPulled = IERC20(token).balanceOf(recipient) - amountPulled;
+        } else {
+            // Otherwise, we need to check that ETH was specified
+            if (token != UniversalTokenLib.ETH_ADDRESS) revert TokenNotETH();
+            // And that amount matches msg.value
+            if (amount != msg.value) revert MsgValueIncorrect();
+            // We will forward msg.value in the external call later, if recipient is not this contract
+            amountPulled = msg.value;
+        }
+    }
+}

--- a/contracts/router/DefaultRouter.sol
+++ b/contracts/router/DefaultRouter.sol
@@ -2,7 +2,9 @@
 pragma solidity 0.8.17;
 
 import {DefaultAdapter} from "./adapters/DefaultAdapter.sol";
-import {MsgValueIncorrect, TokenNotETH} from "./libs/Errors.sol";
+import {IRouterAdapter} from "./interfaces/IRouterAdapter.sol";
+import {DeadlineExceeded, InsufficientOutputAmount, MsgValueIncorrect, TokenNotETH} from "./libs/Errors.sol";
+import {Action, DefaultParams, SwapQuery} from "./libs/Structs.sol";
 import {UniversalTokenLib} from "./libs/UniversalToken.sol";
 
 import {SafeERC20, IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/utils/SafeERC20.sol";
@@ -13,6 +15,43 @@ import {SafeERC20, IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/utils
 abstract contract DefaultRouter is DefaultAdapter {
     using SafeERC20 for IERC20;
     using UniversalTokenLib for address;
+
+    /// @dev Performs a "swap from tokenIn" following instructions from `query`.
+    /// `query` will include the router adapter to use, and the exact type of "tokenIn -> tokenOut swap"
+    /// should be encoded in `query.rawParams`.
+    function _doSwap(
+        address recipient,
+        address tokenIn,
+        uint256 amountIn,
+        SwapQuery memory query
+    ) internal returns (address tokenOut, uint256 amountOut) {
+        // First, check the deadline for the swap
+        // solhint-disable-next-line not-rely-on-time
+        if (block.timestamp > query.deadline) revert DeadlineExceeded();
+        // Pull initial token from the user to specified router adapter
+        amountIn = _pullToken(query.routerAdapter, tokenIn, amountIn);
+        tokenOut = query.tokenOut;
+        address routerAdapter = query.routerAdapter;
+        if (routerAdapter == address(this)) {
+            // If the router adapter is this contract, we can perform the swap directly and trust the result
+            amountOut = _adapterSwap(recipient, tokenIn, amountIn, tokenOut, query.rawParams);
+        } else {
+            // Otherwise, we need to call the router adapter. Adapters are permissionless, so we verify the result
+            // Record tokenOut balance before swap
+            amountOut = tokenOut.universalBalanceOf(recipient);
+            IRouterAdapter(routerAdapter).adapterSwap{value: msg.value}({
+                recipient: recipient,
+                tokenIn: tokenIn,
+                amountIn: amountIn,
+                tokenOut: tokenOut,
+                rawParams: query.rawParams
+            });
+            // Use the difference between the recorded balance and the current balance as the amountOut
+            amountOut = tokenOut.universalBalanceOf(recipient) - amountOut;
+        }
+        // Finally, check that the recipient received at least as much as they wanted
+        if (amountOut < query.minAmountOut) revert InsufficientOutputAmount();
+    }
 
     /// @dev Pulls a requested token from the user to the requested recipient.
     /// Or, if msg.value was provided, check that ETH_ADDRESS was used and msg.value is correct.

--- a/contracts/router/adapters/DefaultAdapter.sol
+++ b/contracts/router/adapters/DefaultAdapter.sol
@@ -230,6 +230,32 @@ contract DefaultAdapter is IRouterAdapter {
         }
     }
 
+    /// @dev Returns the tokens in the given pool.
+    function _getPoolTokens(address pool) internal view returns (address[] memory tokens) {
+        uint256 numTokens = _getPoolNumTokens(pool);
+        tokens = new address[](numTokens);
+        for (uint8 i = 0; i < numTokens; ++i) {
+            // This will not revert because we already know the number of tokens in the pool
+            tokens[i] = IDefaultPool(pool).getToken(i);
+        }
+    }
+
+    /// @dev Returns the quote for a swap through the given pool.
+    /// Note: will return 0 on invalid swaps.
+    function _getPoolSwapQuote(
+        address pool,
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 amountIn
+    ) internal view returns (uint256 amountOut) {
+        try IDefaultPool(pool).calculateSwap(tokenIndexFrom, tokenIndexTo, amountIn) returns (uint256 dy) {
+            amountOut = dy;
+        } catch {
+            // Return 0 instead of reverting
+            amountOut = 0;
+        }
+    }
+
     // ════════════════════════════════════════ INTERNAL LOGIC: ETH <> WETH ════════════════════════════════════════════
 
     /// @dev Wraps ETH into WETH.

--- a/contracts/router/adapters/DefaultAdapter.sol
+++ b/contracts/router/adapters/DefaultAdapter.sol
@@ -37,7 +37,7 @@ contract DefaultAdapter is IRouterAdapter {
         uint256 amountIn,
         address tokenOut,
         bytes memory rawParams
-    ) internal returns (uint256 amountOut) {
+    ) internal virtual returns (uint256 amountOut) {
         // We define a few phases for the whole Adapter's swap process.
         // (?) means the phase is optional.
         // (!) means the phase is mandatory.

--- a/contracts/router/adapters/DefaultAdapter.sol
+++ b/contracts/router/adapters/DefaultAdapter.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+// TODO: migrate this to `router` folder
+import {IDefaultPool} from "../../cctp/interfaces/IDefaultPool.sol";
+import {IRouterAdapter} from "../interfaces/IRouterAdapter.sol";
+import {DefaultParams} from "../libs/Structs.sol";
+import {UniversalTokenLib} from "../libs/UniversalToken.sol";
+
+contract DefaultAdapter is IRouterAdapter {
+    using UniversalTokenLib for address;
+
+    /// @inheritdoc IRouterAdapter
+    function adapterSwap(
+        address recipient,
+        address tokenIn,
+        uint256 amountIn,
+        address tokenOut,
+        bytes memory rawParams
+    ) external payable returns (uint256 amountOut) {
+        return _adapterSwap(recipient, tokenIn, amountIn, tokenOut, rawParams);
+    }
+
+    /// @dev Internal logic for doing a tokenIn -> tokenOut swap.
+    /// Note: `tokenIn` is assumed to have already been transferred to this contract.
+    function _adapterSwap(
+        address recipient,
+        address tokenIn,
+        uint256 amountIn,
+        address tokenOut,
+        bytes memory rawParams
+    ) internal returns (uint256 amountOut) {}
+
+    // ═══════════════════════════════════════ INTERNAL LOGIC: SWAP ACTIONS ════════════════════════════════════════════
+
+    /// @dev Performs a swap through the given pool.
+    /// Note: The pool should be already approved for spending `tokenIn`.
+    function _swap(
+        IDefaultPool pool,
+        DefaultParams memory params,
+        uint256 amountIn,
+        address tokenOut
+    ) internal returns (uint256 amountOut) {}
+
+    /// @dev Adds liquidity in a form of a single token to the given pool.
+    /// Note: The pool should be already approved for spending `tokenIn`.
+    function _addLiquidity(
+        IDefaultPool pool,
+        DefaultParams memory params,
+        uint256 amountIn,
+        address tokenOut
+    ) internal returns (uint256 amountOut) {}
+
+    /// @dev Removes liquidity in a form of a single token from the given pool.
+    /// Note: The pool should be already approved for spending `tokenIn`.
+    function _removeLiquidity(
+        IDefaultPool pool,
+        DefaultParams memory params,
+        uint256 amountIn,
+        address tokenOut
+    ) internal returns (uint256 amountOut) {}
+
+    // ════════════════════════════════════════ INTERNAL LOGIC: ETH <> WETH ════════════════════════════════════════════
+
+    /// @dev Wraps ETH into WETH.
+    function _wrapETH(address weth, uint256 amount) internal {}
+
+    /// @dev Unwraps WETH into ETH.
+    function _unwrapETH(address weth, uint256 amount) internal {}
+}

--- a/contracts/router/adapters/DefaultAdapter.sol
+++ b/contracts/router/adapters/DefaultAdapter.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-// TODO: migrate this to `router` folder
-import {IDefaultPool} from "../../cctp/interfaces/IDefaultPool.sol";
+import {IDefaultPool, IDefaultExtendedPool} from "../interfaces/IDefaultExtendedPool.sol";
 import {IRouterAdapter} from "../interfaces/IRouterAdapter.sol";
+import {TokenAddressMismatch} from "../libs/Errors.sol";
 import {DefaultParams} from "../libs/Structs.sol";
 import {UniversalTokenLib} from "../libs/UniversalToken.sol";
 
@@ -36,29 +36,82 @@ contract DefaultAdapter is IRouterAdapter {
     /// @dev Performs a swap through the given pool.
     /// Note: The pool should be already approved for spending `tokenIn`.
     function _swap(
-        IDefaultPool pool,
+        address pool,
         DefaultParams memory params,
         uint256 amountIn,
         address tokenOut
-    ) internal returns (uint256 amountOut) {}
+    ) internal returns (uint256 amountOut) {
+        // tokenOut should match the "swap to" token
+        if (IDefaultPool(pool).getToken(params.tokenIndexTo) != tokenOut) revert TokenAddressMismatch();
+        // amountOut and deadline are not checked in RouterAdapter
+        amountOut = IDefaultPool(pool).swap({
+            tokenIndexFrom: params.tokenIndexFrom,
+            tokenIndexTo: params.tokenIndexTo,
+            dx: amountIn,
+            minDy: 0,
+            deadline: type(uint256).max
+        });
+    }
 
     /// @dev Adds liquidity in a form of a single token to the given pool.
     /// Note: The pool should be already approved for spending `tokenIn`.
     function _addLiquidity(
-        IDefaultPool pool,
+        address pool,
         DefaultParams memory params,
         uint256 amountIn,
         address tokenOut
-    ) internal returns (uint256 amountOut) {}
+    ) internal returns (uint256 amountOut) {
+        uint256 numTokens = _getPoolNumTokens(pool);
+        address lpToken = _getPoolLPToken(pool);
+        // tokenOut should match the LP token
+        if (lpToken != tokenOut) revert TokenAddressMismatch();
+        uint256[] memory amounts = new uint256[](numTokens);
+        amounts[params.tokenIndexFrom] = amountIn;
+        // amountOut and deadline are not checked in RouterAdapter
+        amountOut = IDefaultExtendedPool(pool).addLiquidity({
+            amounts: amounts,
+            minToMint: 0,
+            deadline: type(uint256).max
+        });
+    }
 
     /// @dev Removes liquidity in a form of a single token from the given pool.
     /// Note: The pool should be already approved for spending `tokenIn`.
     function _removeLiquidity(
-        IDefaultPool pool,
+        address pool,
         DefaultParams memory params,
         uint256 amountIn,
         address tokenOut
-    ) internal returns (uint256 amountOut) {}
+    ) internal returns (uint256 amountOut) {
+        // tokenOut should match the "swap to" token
+        if (IDefaultPool(pool).getToken(params.tokenIndexTo) != tokenOut) revert TokenAddressMismatch();
+        // amountOut and deadline are not checked in RouterAdapter
+        amountOut = IDefaultExtendedPool(pool).removeLiquidityOneToken({
+            tokenAmount: amountIn,
+            tokenIndex: params.tokenIndexTo,
+            minAmount: 0,
+            deadline: type(uint256).max
+        });
+    }
+
+    // ═════════════════════════════════════════ INTERNAL LOGIC: POOL LENS ═════════════════════════════════════════════
+
+    /// @dev Returns the LP token address of the given pool.
+    function _getPoolLPToken(address pool) internal view returns (address lpToken) {
+        (, , , , , , lpToken) = IDefaultExtendedPool(pool).swapStorage();
+    }
+
+    /// @dev Returns the number of tokens in the given pool.
+    function _getPoolNumTokens(address pool) internal view returns (uint256 numTokens) {
+        // Iterate over all tokens in the pool until the end is reached
+        for (uint8 index = 0; ; ++index) {
+            try IDefaultPool(pool).getToken(index) returns (address) {} catch {
+                // End of pool reached
+                numTokens = index;
+                break;
+            }
+        }
+    }
 
     // ════════════════════════════════════════ INTERNAL LOGIC: ETH <> WETH ════════════════════════════════════════════
 

--- a/contracts/router/interfaces/IDefaultExtendedPool.sol
+++ b/contracts/router/interfaces/IDefaultExtendedPool.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IDefaultPool} from "./IDefaultPool.sol";
+
+interface IDefaultExtendedPool is IDefaultPool {
+    function addLiquidity(
+        uint256[] calldata amounts,
+        uint256 minToMint,
+        uint256 deadline
+    ) external returns (uint256);
+
+    function removeLiquidityOneToken(
+        uint256 tokenAmount,
+        uint8 tokenIndex,
+        uint256 minAmount,
+        uint256 deadline
+    ) external returns (uint256);
+
+    // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
+
+    function swapStorage()
+        external
+        view
+        returns (
+            uint256 initialA,
+            uint256 futureA,
+            uint256 initialATime,
+            uint256 futureATime,
+            uint256 swapFee,
+            uint256 adminFee,
+            address lpToken
+        );
+}

--- a/contracts/router/interfaces/IDefaultPool.sol
+++ b/contracts/router/interfaces/IDefaultPool.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface IDefaultPool {
+    function swap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx,
+        uint256 minDy,
+        uint256 deadline
+    ) external returns (uint256 amountOut);
+
+    function calculateSwap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx
+    ) external view returns (uint256 amountOut);
+
+    function getToken(uint8 index) external view returns (address token);
+}

--- a/contracts/router/interfaces/IRouterAdapter.sol
+++ b/contracts/router/interfaces/IRouterAdapter.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface IRouterAdapter {
+    /// @notice Performs a tokenIn -> tokenOut swap, according to the provided params.
+    /// If tokenIn is ETH_ADDRESS, this method should be invoked with `msg.value = amountIn`.
+    /// If tokenIn is ERC20, the tokens should be already transferred to this contract (using `msg.value = 0`).
+    /// If tokenOut is ETH_ADDRESS, native ETH will be sent to the recipient (be aware of potential reentrancy).
+    /// If tokenOut is ERC20, the tokens will be transferred to the recipient.
+    /// @dev Contracts implementing {IRouterAdapter} interface are required to enforce the above restrictions.
+    /// On top of that, they must ensure that exactly `amountOut` worth of `tokenOut` is transferred to the recipient.
+    /// Swap deadline and slippage is checked outside of this contract.
+    /// @param recipient    Address to receive the swapped token
+    /// @param tokenIn      Token to sell (use ETH_ADDRESS to start from native ETH)
+    /// @param amountIn     Amount of tokens to sell
+    /// @param tokenOut     Token to buy (use ETH_ADDRESS to end with native ETH)
+    /// @param rawParams    Additional swap parameters
+    /// @return amountOut   Amount of bought tokens
+    function adapterSwap(
+        address recipient,
+        address tokenIn,
+        uint256 amountIn,
+        address tokenOut,
+        bytes calldata rawParams
+    ) external payable returns (uint256 amountOut);
+}

--- a/contracts/router/interfaces/IWETH9.sol
+++ b/contracts/router/interfaces/IWETH9.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface IWETH9 {
+    function deposit() external payable;
+
+    function withdraw(uint256 wad) external;
+}

--- a/contracts/router/libs/Errors.sol
+++ b/contracts/router/libs/Errors.sol
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
+error DeadlineExceeded();
+error InsufficientOutputAmount();
+
 error MsgValueIncorrect();
 error PoolNotFound();
 error TokenAddressMismatch();
 error TokenNotContract();
+error TokenNotETH();
 error TokensIdentical();

--- a/contracts/router/libs/Errors.sol
+++ b/contracts/router/libs/Errors.sol
@@ -4,4 +4,5 @@ pragma solidity 0.8.17;
 error MsgValueIncorrect();
 error PoolNotFound();
 error TokenAddressMismatch();
+error TokenNotContract();
 error TokensIdentical();

--- a/contracts/router/libs/Errors.sol
+++ b/contracts/router/libs/Errors.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
+error MsgValueIncorrect();
 error TokenAddressMismatch();

--- a/contracts/router/libs/Errors.sol
+++ b/contracts/router/libs/Errors.sol
@@ -2,4 +2,6 @@
 pragma solidity 0.8.17;
 
 error MsgValueIncorrect();
+error PoolNotFound();
 error TokenAddressMismatch();
+error TokensIdentical();

--- a/contracts/router/libs/Errors.sol
+++ b/contracts/router/libs/Errors.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+error TokenAddressMismatch();

--- a/contracts/router/libs/Structs.sol
+++ b/contracts/router/libs/Structs.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13; // "using A for B global" requires 0.8.13 or higher
+
+// ══════════════════════════════════════════ TOKEN AND POOL DESCRIPTION ═══════════════════════════════════════════════
+
+/// @notice Struct representing a bridge token. Used as the return value in view functions.
+/// @param symbol   Bridge token symbol: unique token ID consistent among all chains
+/// @param token    Bridge token address
+struct BridgeToken {
+    string symbol;
+    address token;
+}
+
+/// @notice Struct used by IPoolHandler to represent a token in a pool
+/// @param index    Token index in the pool
+/// @param token    Token address
+struct IndexedToken {
+    uint8 index;
+    address token;
+}
+
+/// @notice Struct representing a token, and the available Actions for performing a swap.
+/// @param actionMask   Bitmask representing what actions (see ActionLib) are available for swapping a token
+/// @param token        Token address
+struct LimitedToken {
+    uint256 actionMask;
+    address token;
+}
+
+/// @notice Struct representing how pool tokens are stored by `SwapQuoter`.
+/// @param isWeth   Whether the token represents Wrapped ETH.
+/// @param token    Token address.
+struct PoolToken {
+    bool isWeth;
+    address token;
+}
+
+/// @notice Struct representing a liquidity pool. Used as the return value in view functions.
+/// @param pool         Pool address.
+/// @param lpToken      Address of pool's LP token.
+/// @param tokens       List of pool's tokens.
+struct Pool {
+    address pool;
+    address lpToken;
+    PoolToken[] tokens;
+}
+
+// ════════════════════════════════════════════════ ROUTER STRUCTS ═════════════════════════════════════════════════════
+
+/// @notice Struct representing a quote request for swapping a bridge token.
+/// Used in destination chain's SynapseRouter, hence the name "Destination Request".
+/// @dev tokenOut is passed externally.
+/// @param symbol   Bridge token symbol: unique token ID consistent among all chains
+/// @param amountIn Amount of bridge token to start with, before the bridge fee is applied
+struct DestRequest {
+    string symbol;
+    uint256 amountIn;
+}
+
+/// @notice Struct representing a swap request for SynapseRouter.
+/// @dev tokenIn is supplied separately.
+/// @param routerAdapter    Contract that will perform the swap for the Router. Address(0) specifies a "no swap" query.
+/// @param tokenOut         Token address to swap to.
+/// @param minAmountOut     Minimum amount of tokens to receive after the swap, or tx will be reverted.
+/// @param deadline         Latest timestamp for when the transaction needs to be executed, or tx will be reverted.
+/// @param rawParams        ABI-encoded params for the swap that will be passed to `routerAdapter`.
+///                         Should be DefaultParams for swaps via DefaultAdapter.
+struct SwapQuery {
+    address routerAdapter;
+    address tokenOut;
+    uint256 minAmountOut;
+    uint256 deadline;
+    bytes rawParams;
+}
+
+// ════════════════════════════════════════════════ ADAPTER STRUCTS ════════════════════════════════════════════════════
+
+/// @notice Struct representing parameters for swapping via DefaultAdapter.
+/// @param action           Action that DefaultAdapter needs to perform.
+/// @param pool             Liquidity pool that will be used for Swap/AddLiquidity/RemoveLiquidity actions.
+/// @param tokenIndexFrom   Token index to swap from. Used for swap/addLiquidity actions.
+/// @param tokenIndexTo     Token index to swap to. Used for swap/removeLiquidity actions.
+struct DefaultParams {
+    Action action;
+    address pool;
+    uint8 tokenIndexFrom;
+    uint8 tokenIndexTo;
+}
+
+/// @notice All possible actions that DefaultAdapter could perform.
+enum Action {
+    Swap, // swap between two pools tokens
+    AddLiquidity, // add liquidity in a form of a single pool token
+    RemoveLiquidity, // remove liquidity in a form of a single pool token
+    HandleEth // ETH <> WETH interaction
+}
+
+using ActionLib for Action global;
+
+/// @notice Library for dealing with bit masks which describe what set of Actions is available.
+library ActionLib {
+    /// @notice Returns a bitmask with all possible actions set to True.
+    function allActions() internal pure returns (uint256 actionMask) {
+        actionMask = type(uint256).max;
+    }
+
+    /// @notice Returns whether the given action is set to True in the bitmask.
+    function isIncluded(Action action, uint256 actionMask) internal pure returns (bool) {
+        return actionMask & mask(action) != 0;
+    }
+
+    /// @notice Returns a bitmask with only the given action set to True.
+    function mask(Action action) internal pure returns (uint256) {
+        return 1 << uint256(action);
+    }
+
+    /// @notice Returns a bitmask with only two given actions set to True.
+    function mask(Action a, Action b) internal pure returns (uint256) {
+        return mask(a) | mask(b);
+    }
+}

--- a/contracts/router/libs/UniversalToken.sol
+++ b/contracts/router/libs/UniversalToken.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
+import {TokenNotContract} from "./Errors.sol";
 import {SafeERC20, IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/utils/SafeERC20.sol";
 
 library UniversalTokenLib {
@@ -26,5 +27,22 @@ library UniversalTokenLib {
         } else {
             IERC20(token).safeTransfer(to, value);
         }
+    }
+
+    /// @notice Returns the balance of the given token (or native ETH) for the given account.
+    function universalBalanceOf(address token, address account) internal view returns (uint256) {
+        if (token == ETH_ADDRESS) {
+            return account.balance;
+        } else {
+            return IERC20(token).balanceOf(account);
+        }
+    }
+
+    /// @dev Checks that token is a contract and not ETH_ADDRESS.
+    function assertIsContract(address token) internal view {
+        // Check that ETH_ADDRESS was not used (in case this is a predeploy on any of the chains)
+        if (token == UniversalTokenLib.ETH_ADDRESS) revert TokenNotContract();
+        // Check that token is not an EOA
+        if (token.code.length == 0) revert TokenNotContract();
     }
 }

--- a/contracts/router/libs/UniversalToken.sol
+++ b/contracts/router/libs/UniversalToken.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {SafeERC20, IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/utils/SafeERC20.sol";
+
+library UniversalTokenLib {
+    using SafeERC20 for IERC20;
+
+    address internal constant ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    /// @notice Transfers tokens to the given account. Reverts if transfer is not successful.
+    /// @dev This might trigger fallback, if ETH is transferred to the contract.
+    /// Make sure this can not lead to reentrancy attacks.
+    function universalTransfer(
+        address token,
+        address to,
+        uint256 value
+    ) internal {
+        // Don't do anything, if need to send tokens to this address
+        if (to == address(this)) return;
+        if (token == ETH_ADDRESS) {
+            /// @dev Note: this can potentially lead to executing code in `to`.
+            // solhint-disable-next-line avoid-low-level-calls
+            (bool success, ) = to.call{value: value}("");
+            require(success, "ETH transfer failed");
+        } else {
+            IERC20(token).safeTransfer(to, value);
+        }
+    }
+}

--- a/test/mocks/MockTokenWithFee.sol
+++ b/test/mocks/MockTokenWithFee.sol
@@ -34,6 +34,11 @@ contract MockTokenWithFee is ERC20, Ownable {
         _burn(user, amount);
     }
 
+    function setFee(uint256 _fee) external {
+        require(_fee <= wad, "fee > max");
+        fee = _fee;
+    }
+
     function _afterTokenTransfer(
         address from,
         address to,

--- a/test/router/BaseTest.t.sol
+++ b/test/router/BaseTest.t.sol
@@ -91,6 +91,27 @@ abstract contract BaseTest is Test {
 
     // ══════════════════════════════════════════════ COMMON HELPERS ═══════════════════════════════════════════════════
 
+    function calculateAddLiquidity(address token, uint256 amount) public view returns (uint256) {
+        uint8 index = tokenToIndex[token];
+        uint256[] memory amounts = new uint256[](poolTokens[address(nusdPool)].length);
+        amounts[index] = amount;
+        return nusdPool.calculateAddLiquidity(amounts);
+    }
+
+    function mintToUserAndApprove(
+        address token,
+        address spender,
+        uint256 amount
+    ) public {
+        if (token == ETH) {
+            deal(user, amount);
+        } else {
+            MockERC20(token).mint(user, amount);
+            vm.prank(user);
+            MockERC20(token).approve(spender, amount);
+        }
+    }
+
     function clearBalance(address token, address who) public {
         if (token == ETH) {
             deal(who, 0);

--- a/test/router/BaseTest.t.sol
+++ b/test/router/BaseTest.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {MockDefaultPool, MockDefaultExtendedPool} from "./mocks/MockDefaultExtendedPool.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockWETH} from "./mocks/MockWETH.sol";
+
+import {IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/IERC20.sol";
+import {Test} from "forge-std/Test.sol";
+
+abstract contract BaseTest is Test {
+    address public constant ETH = address(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
+
+    MockDefaultPool public nethPool;
+    MockWETH public weth;
+    MockERC20 public neth;
+
+    MockDefaultExtendedPool public nusdPool;
+    MockERC20 public nusd;
+    MockERC20 public dai;
+    MockERC20 public usdc;
+    MockERC20 public usdt;
+
+    mapping(address => uint8) public tokenToIndex;
+    mapping(address => address[]) public poolTokens;
+
+    address public user;
+    address public userRecipient;
+
+    function setUp() public virtual {
+        user = makeAddr("User");
+        userRecipient = makeAddr("Recipient");
+
+        deployEthTokens();
+        deployEthPool();
+        mintEthPoolTokens();
+
+        deployUsdTokens();
+        deployUsdPool();
+        mintUsdPoolTokens();
+    }
+
+    function deployEthTokens() public virtual {
+        weth = new MockWETH();
+        neth = new MockERC20("nETH", 18);
+    }
+
+    function deployEthPool() public virtual {
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(neth);
+        tokens[1] = address(weth);
+        nethPool = new MockDefaultPool(tokens);
+
+        poolTokens[address(nethPool)] = tokens;
+        tokenToIndex[address(neth)] = 0;
+        tokenToIndex[address(weth)] = 1;
+        tokenToIndex[ETH] = 1;
+    }
+
+    function mintEthPoolTokens() public virtual {
+        weth.mint(address(nethPool), 10 * 10**18);
+        neth.mint(address(nethPool), 10.5 * 10**18);
+    }
+
+    function deployUsdTokens() public virtual {
+        dai = new MockERC20("DAI", 18);
+        usdc = new MockERC20("USDC", 6);
+        usdt = new MockERC20("USDT", 6);
+    }
+
+    function deployUsdPool() public virtual {
+        address[] memory tokens = new address[](3);
+        tokens[0] = address(dai);
+        tokens[1] = address(usdc);
+        tokens[2] = address(usdt);
+        nusdPool = new MockDefaultExtendedPool(tokens, "nUSD");
+
+        nusd = nusdPool.lpToken();
+        poolTokens[address(nusdPool)] = tokens;
+        tokenToIndex[address(dai)] = 0;
+        tokenToIndex[address(usdc)] = 1;
+        tokenToIndex[address(usdt)] = 2;
+        tokenToIndex[address(nusd)] = 0xFF;
+    }
+
+    function mintUsdPoolTokens() public virtual {
+        dai.mint(address(nusdPool), 1000 * 10**18);
+        usdc.mint(address(nusdPool), 1020 * 10**6);
+        usdt.mint(address(nusdPool), 1040 * 10**6);
+    }
+
+    // ══════════════════════════════════════════════ COMMON HELPERS ═══════════════════════════════════════════════════
+
+    function clearBalance(address token, address who) public {
+        if (token == ETH) {
+            deal(who, 0);
+        } else {
+            MockERC20(token).burn(who, MockERC20(token).balanceOf(who));
+        }
+    }
+
+    function balanceOf(address token, address who) public view returns (uint256) {
+        if (token == ETH) {
+            return who.balance;
+        } else {
+            return IERC20(token).balanceOf(who);
+        }
+    }
+}

--- a/test/router/DefaultRouter.t.sol
+++ b/test/router/DefaultRouter.t.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {DefaultRouter} from "../../contracts/router/DefaultRouter.sol";
+// prettier-ignore
+import {
+    DeadlineExceeded,
+    InsufficientOutputAmount,
+    MsgValueIncorrect,
+    TokenNotContract,
+    TokenNotETH
+} from "../../contracts/router/libs/Errors.sol";
+
+import {MockTokenWithFee} from "../mocks/MockTokenWithFee.sol";
+import {BaseTest, MockDefaultPool, MockERC20} from "./BaseTest.t.sol";
+
+contract DefaultRouterHarness is DefaultRouter {
+    function pullToken(
+        address recipient,
+        address token,
+        uint256 amount
+    ) external payable returns (uint256 amountPulled) {
+        return _pullToken(recipient, token, amount);
+    }
+}
+
+contract DefaultRouterTest is BaseTest {
+    DefaultRouterHarness public router;
+
+    function setUp() public override {
+        super.setUp();
+        router = new DefaultRouterHarness();
+    }
+
+    function deployUsdTokens() public virtual override {
+        dai = new MockERC20("DAI", 18);
+        usdc = new MockERC20("USDC", 6);
+        MockTokenWithFee usdt_ = new MockTokenWithFee("USDT", "USDT", 6, 0);
+        usdt = MockERC20(address(usdt_));
+    }
+
+    // ══════════════════════════════════════════════ TESTS: PULLING ═══════════════════════════════════════════════════
+
+    function testPullTokenERC20RecipientSelf() public {
+        uint256 amount = 10**18;
+        usdc.mint(user, amount);
+        vm.prank(user);
+        usdc.approve(address(router), amount);
+        vm.prank(user);
+        uint256 amountPulled = router.pullToken(address(router), address(usdc), amount);
+        assertEq(amountPulled, amount);
+        assertEq(usdc.balanceOf(address(router)), amount);
+    }
+
+    function testPullTokenERC20RecipientExternal() public {
+        uint256 amount = 10**18;
+        usdc.mint(user, amount);
+        vm.prank(user);
+        usdc.approve(address(router), amount);
+        vm.prank(user);
+        uint256 amountPulled = router.pullToken(userRecipient, address(usdc), amount);
+        assertEq(amountPulled, amount);
+        assertEq(usdc.balanceOf(address(userRecipient)), amount);
+    }
+
+    function testPullTokenERC20WithFeeRecipientSelf() public {
+        // set fee to 1%
+        setFee(10**16);
+        uint256 amount = 10**18;
+        uint256 amountAfterFee = amount - (amount / 100);
+        usdt.mint(user, amount);
+        vm.prank(user);
+        usdt.approve(address(router), amount);
+        vm.prank(user);
+        uint256 amountPulled = router.pullToken(address(router), address(usdt), amount);
+        assertEq(amountPulled, amountAfterFee);
+        assertEq(usdt.balanceOf(address(router)), amountAfterFee);
+    }
+
+    function testPullTokenERC20WithFeeRecipientExternal() public {
+        // set fee to 1%
+        setFee(10**16);
+        uint256 amount = 10**18;
+        uint256 amountAfterFee = amount - (amount / 100);
+        usdt.mint(user, amount);
+        vm.prank(user);
+        usdt.approve(address(router), amount);
+        vm.prank(user);
+        uint256 amountPulled = router.pullToken(userRecipient, address(usdt), amount);
+        assertEq(amountPulled, amountAfterFee);
+        assertEq(usdt.balanceOf(address(userRecipient)), amountAfterFee);
+    }
+
+    function testPullTokenERC20RevertsWhenMsgValueSupplied() public {
+        uint256 amount = 10**18;
+        deal(user, amount);
+        usdc.mint(user, amount);
+        vm.prank(user);
+        usdc.approve(address(router), amount);
+        vm.expectRevert(TokenNotETH.selector);
+        vm.prank(user);
+        router.pullToken{value: amount}(address(router), address(usdc), amount);
+    }
+
+    function testPullTokenERC20RevertsWhenNotContract() public {
+        vm.expectRevert(TokenNotContract.selector);
+        vm.prank(user);
+        // pass EOA as token address
+        router.pullToken(address(router), address(userRecipient), 10**18);
+    }
+
+    function testPullTokenETHRecipientSelf() public {
+        uint256 amount = 10**18;
+        deal(user, amount);
+        vm.prank(user);
+        uint256 amountPulled = router.pullToken{value: amount}(address(router), ETH, amount);
+        assertEq(amountPulled, amount);
+        assertEq(address(router).balance, amount);
+    }
+
+    function testPullTokenETHRecipientExternal() public {
+        uint256 amount = 10**18;
+        deal(user, amount);
+        vm.prank(user);
+        uint256 amountPulled = router.pullToken{value: amount}(userRecipient, ETH, amount);
+        assertEq(amountPulled, amount);
+        // pullToken does not forward ETH to recipient, this is done in the next external call
+        assertEq(address(router).balance, amount);
+    }
+
+    function testPullTokenETHRevertsWhenMsgValueZero() public {
+        vm.expectRevert(TokenNotContract.selector);
+        vm.prank(user);
+        router.pullToken{value: 0}(address(router), ETH, 10**18);
+    }
+
+    function testPullTokenETHRevertsWhenMsgValueLower() public {
+        uint256 amount = 10**18;
+        deal(user, amount - 1);
+        deal(address(router), 1);
+        vm.expectRevert(MsgValueIncorrect.selector);
+        vm.prank(user);
+        router.pullToken{value: amount - 1}(address(router), ETH, amount);
+    }
+
+    function testPullTokenETHRevertsWhenMsgValueHigher() public {
+        uint256 amount = 10**18;
+        deal(user, amount + 1);
+        vm.expectRevert(MsgValueIncorrect.selector);
+        vm.prank(user);
+        router.pullToken{value: amount + 1}(address(router), ETH, amount);
+    }
+
+    // ══════════════════════════════════════════════════ HELPERS ══════════════════════════════════════════════════════
+
+    function setFee(uint256 fee) public {
+        MockTokenWithFee(address(usdt)).setFee(fee);
+    }
+}

--- a/test/router/DefaultRouter.t.sol
+++ b/test/router/DefaultRouter.t.sol
@@ -10,11 +10,24 @@ import {
     TokenNotContract,
     TokenNotETH
 } from "../../contracts/router/libs/Errors.sol";
+import {Action, DefaultParams, SwapQuery} from "../../contracts/router/libs/Structs.sol";
+
+import {FlakyAdapter} from "./harnesses/FlakyAdapter.sol";
 
 import {MockTokenWithFee} from "../mocks/MockTokenWithFee.sol";
 import {BaseTest, MockDefaultPool, MockERC20} from "./BaseTest.t.sol";
 
+// solhint-disable not-rely-on-time
 contract DefaultRouterHarness is DefaultRouter {
+    function doSwap(
+        address recipient,
+        address tokenIn,
+        uint256 amountIn,
+        SwapQuery memory query
+    ) external payable returns (address tokenOut, uint256 amountOut) {
+        return _doSwap(recipient, tokenIn, amountIn, query);
+    }
+
     function pullToken(
         address recipient,
         address token,
@@ -26,10 +39,12 @@ contract DefaultRouterHarness is DefaultRouter {
 
 contract DefaultRouterTest is BaseTest {
     DefaultRouterHarness public router;
+    FlakyAdapter public flakyAdapter;
 
     function setUp() public override {
         super.setUp();
         router = new DefaultRouterHarness();
+        flakyAdapter = new FlakyAdapter();
     }
 
     function deployUsdTokens() public virtual override {
@@ -149,6 +164,564 @@ contract DefaultRouterTest is BaseTest {
         vm.expectRevert(MsgValueIncorrect.selector);
         vm.prank(user);
         router.pullToken{value: amount + 1}(address(router), ETH, amount);
+    }
+
+    // ═══════════════════════════════════════════════ TESTS: SWAPS ════════════════════════════════════════════════════
+
+    function testAdapterActionSwapTokenToToken() public {
+        checkAdapterActionSwapTokenToToken(address(router));
+    }
+
+    function testAdapterActionSwapTokenToTokenUsingFlakyAdapter() public {
+        checkAdapterActionSwapTokenToToken(address(flakyAdapter));
+    }
+
+    function checkAdapterActionSwapTokenToToken(address routerAdapter) public {
+        // DAI (0) -> USDC (1) swap
+        uint256 amount = 10**18;
+        uint256 expectedAmountOut = nusdPool.calculateSwap(0, 1, amount);
+        bytes memory rawParams = abi.encode(
+            DefaultParams({action: Action.Swap, pool: address(nusdPool), tokenIndexFrom: 0, tokenIndexTo: 1})
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: address(usdc),
+            minAmountOut: expectedAmountOut,
+            deadline: block.timestamp,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(dai), spender: address(router), amount: amount});
+        vm.prank(user);
+        (address tokenOut, uint256 amountOut) = router.doSwap({
+            recipient: userRecipient,
+            tokenIn: address(dai),
+            amountIn: amount,
+            query: query
+        });
+        assertEq(tokenOut, address(usdc));
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(usdc.balanceOf(address(userRecipient)), expectedAmountOut);
+    }
+
+    function testAdapterActionSwapTokenWithFeeToToken() public {
+        checkAdapterActionSwapTokenWithFeeToToken(address(router));
+    }
+
+    function testAdapterActionSwapTokenWithFeeToTokenUsingFlakyAdapter() public {
+        checkAdapterActionSwapTokenWithFeeToToken(address(flakyAdapter));
+    }
+
+    function checkAdapterActionSwapTokenWithFeeToToken(address routerAdapter) public {
+        // Set fee to 1%
+        setFee(10**16);
+        // USDT (2) -> USDC (1) swap
+        uint256 amount = 10**6;
+        uint256 amountAfterFee = amount - (amount / 100);
+        uint256 expectedAmountOut = nusdPool.calculateSwap(2, 1, amountAfterFee);
+        bytes memory rawParams = abi.encode(
+            DefaultParams({action: Action.Swap, pool: address(nusdPool), tokenIndexFrom: 2, tokenIndexTo: 1})
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: address(usdc),
+            minAmountOut: expectedAmountOut,
+            deadline: block.timestamp,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(usdt), spender: address(router), amount: amount});
+        vm.prank(user);
+        (address tokenOut, uint256 amountOut) = router.doSwap({
+            recipient: userRecipient,
+            tokenIn: address(usdt),
+            amountIn: amount,
+            query: query
+        });
+        assertEq(tokenOut, address(usdc));
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(usdc.balanceOf(address(userRecipient)), expectedAmountOut);
+    }
+
+    function testAdapterActionSwapTokenToETH() public {
+        checkAdapterActionSwapTokenToETH(address(router));
+    }
+
+    function testAdapterActionSwapTokenToETHUsingFlakyAdapter() public {
+        checkAdapterActionSwapTokenToETH(address(flakyAdapter));
+    }
+
+    function checkAdapterActionSwapTokenToTokenWithFee(address routerAdapter) public {
+        // Set fee to 1%
+        setFee(10**16);
+        // DAI (0) -> USDT (2) swap
+        uint256 amount = 10**18;
+        uint256 amountOutBeforeFee = nusdPool.calculateSwap(0, 2, amount);
+        // First time fee is applied when swap is performed, and tokens are sent to the Adapter
+        uint256 amountOutPostSwap = amountOutBeforeFee - (amountOutBeforeFee / 100);
+        // Second time fee is applied when tokens are sent to the recipient
+        uint256 expectedAmountOut = amountOutPostSwap - (amountOutPostSwap / 100);
+        bytes memory rawParams = abi.encode(
+            DefaultParams({action: Action.Swap, pool: address(nusdPool), tokenIndexFrom: 0, tokenIndexTo: 2})
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: address(usdt),
+            minAmountOut: expectedAmountOut,
+            deadline: block.timestamp,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(dai), spender: address(router), amount: amount});
+        vm.prank(user);
+        (address tokenOut, uint256 amountOut) = router.doSwap({
+            recipient: userRecipient,
+            tokenIn: address(dai),
+            amountIn: amount,
+            query: query
+        });
+        assertEq(tokenOut, address(usdt));
+        // NOTE: this will return the amount of tokens "sent" to recipient
+        assertEq(amountOut, amountOutPostSwap);
+        // However, the recipient will receive less due to the fee
+        assertEq(usdt.balanceOf(address(userRecipient)), expectedAmountOut);
+    }
+
+    function checkAdapterActionSwapTokenToETH(address routerAdapter) public {
+        // nETH(0) -> ETH (1) swap
+        uint256 amount = 10**18;
+        uint256 expectedAmountOut = nethPool.calculateSwap(0, 1, amount);
+        bytes memory rawParams = abi.encode(
+            DefaultParams({action: Action.Swap, pool: address(nethPool), tokenIndexFrom: 0, tokenIndexTo: 1})
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: ETH,
+            minAmountOut: expectedAmountOut,
+            deadline: block.timestamp,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(neth), spender: address(router), amount: amount});
+        vm.prank(user);
+        (address tokenOut, uint256 amountOut) = router.doSwap({
+            recipient: userRecipient,
+            tokenIn: address(neth),
+            amountIn: amount,
+            query: query
+        });
+        assertEq(tokenOut, ETH);
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(address(userRecipient).balance, expectedAmountOut);
+    }
+
+    function testAdapterActionSwapETHToToken() public {
+        checkAdapterActionSwapETHToToken(address(router));
+    }
+
+    function testAdapterActionSwapETHToTokenUsingFlakyAdapter() public {
+        checkAdapterActionSwapETHToToken(address(flakyAdapter));
+    }
+
+    function checkAdapterActionSwapETHToToken(address routerAdapter) public {
+        // ETH (1) -> nETH(0) swap
+        uint256 amount = 10**18;
+        uint256 expectedAmountOut = nethPool.calculateSwap(1, 0, amount);
+        bytes memory rawParams = abi.encode(
+            DefaultParams({action: Action.Swap, pool: address(nethPool), tokenIndexFrom: 1, tokenIndexTo: 0})
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: address(neth),
+            minAmountOut: expectedAmountOut,
+            deadline: block.timestamp,
+            rawParams: rawParams
+        });
+        deal(user, amount);
+        vm.prank(user);
+        (address tokenOut, uint256 amountOut) = router.doSwap{value: amount}({
+            recipient: userRecipient,
+            tokenIn: ETH,
+            amountIn: amount,
+            query: query
+        });
+        assertEq(tokenOut, address(neth));
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(neth.balanceOf(address(userRecipient)), expectedAmountOut);
+    }
+
+    function testAdapterActionSwapRevertsWhenDeadlineExceeded() public {
+        checkAdapterActionSwapRevertsWhenDeadlineExceeded(address(router));
+    }
+
+    function testAdapterActionSwapRevertsWhenDeadlineExceededUsingFlakyAdapter() public {
+        checkAdapterActionSwapRevertsWhenDeadlineExceeded(address(flakyAdapter));
+    }
+
+    function checkAdapterActionSwapRevertsWhenDeadlineExceeded(address routerAdapter) public {
+        // DAI (0) -> USDC (1) swap
+        uint256 amount = 10**18;
+        bytes memory rawParams = abi.encode(
+            DefaultParams({action: Action.Swap, pool: address(nusdPool), tokenIndexFrom: 0, tokenIndexTo: 1})
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: address(usdc),
+            minAmountOut: 0,
+            deadline: block.timestamp - 1,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(dai), spender: address(router), amount: amount});
+        vm.expectRevert(DeadlineExceeded.selector);
+        vm.prank(user);
+        router.doSwap({recipient: userRecipient, tokenIn: address(dai), amountIn: amount, query: query});
+    }
+
+    function testAdapterActionSwapRevertsWhenInsufficientOutputAmount() public {
+        checkAdapterActionSwapRevertsWhenInsufficientOutputAmount(address(router));
+    }
+
+    function testAdapterActionSwapRevertsWhenInsufficientOutputAmountUsingFlakyAdapter() public {
+        checkAdapterActionSwapRevertsWhenInsufficientOutputAmount(address(flakyAdapter));
+    }
+
+    function checkAdapterActionSwapRevertsWhenInsufficientOutputAmount(address routerAdapter) public {
+        // DAI (0) -> USDC (1) swap
+        uint256 amount = 10**18;
+        uint256 expectedAmountOut = nusdPool.calculateSwap(0, 1, amount);
+        bytes memory rawParams = abi.encode(
+            DefaultParams({action: Action.Swap, pool: address(nusdPool), tokenIndexFrom: 0, tokenIndexTo: 1})
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: address(usdc),
+            minAmountOut: expectedAmountOut + 1,
+            deadline: block.timestamp,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(dai), spender: address(router), amount: amount});
+        vm.expectRevert(InsufficientOutputAmount.selector);
+        vm.prank(user);
+        router.doSwap({recipient: userRecipient, tokenIn: address(dai), amountIn: amount, query: query});
+    }
+
+    // ══════════════════════════════════════════ TESTS: ADDING LIQUIDITY ══════════════════════════════════════════════
+
+    function testAdapterActionAddLiquidity() public {
+        checkAdapterActionAddLiquidity(address(router));
+    }
+
+    function testAdapterActionAddLiquidityUsingFlakyAdapter() public {
+        checkAdapterActionAddLiquidity(address(flakyAdapter));
+    }
+
+    function checkAdapterActionAddLiquidity(address routerAdapter) public {
+        // DAI (0) -> nUSD (0xFF) add liquidity
+        uint256 amount = 10**18;
+        uint256 expectedAmountOut = calculateAddLiquidity(address(dai), amount);
+        bytes memory rawParams = abi.encode(
+            DefaultParams({action: Action.AddLiquidity, pool: address(nusdPool), tokenIndexFrom: 0, tokenIndexTo: 0xFF})
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: address(nusd),
+            minAmountOut: expectedAmountOut,
+            deadline: block.timestamp,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(dai), spender: address(router), amount: amount});
+        vm.prank(user);
+        (address tokenOut, uint256 amountOut) = router.doSwap({
+            recipient: userRecipient,
+            tokenIn: address(dai),
+            amountIn: amount,
+            query: query
+        });
+        assertEq(tokenOut, address(nusd));
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(nusd.balanceOf(address(userRecipient)), expectedAmountOut);
+    }
+
+    function testAdapterActionAddLiquidityRevertsWhenDeadlineExceeded() public {
+        checkAdapterActionAddLiquidityRevertsWhenDeadlineExceeded(address(router));
+    }
+
+    function testAdapterActionAddLiquidityRevertsWhenDeadlineExceededUsingFlakyAdapter() public {
+        checkAdapterActionAddLiquidityRevertsWhenDeadlineExceeded(address(flakyAdapter));
+    }
+
+    function checkAdapterActionAddLiquidityRevertsWhenDeadlineExceeded(address routerAdapter) public {
+        // DAI (0) -> nUSD (0xFF) add liquidity
+        uint256 amount = 10**18;
+        bytes memory rawParams = abi.encode(
+            DefaultParams({action: Action.AddLiquidity, pool: address(nusdPool), tokenIndexFrom: 0, tokenIndexTo: 0xFF})
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: address(nusd),
+            minAmountOut: 0,
+            deadline: block.timestamp - 1,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(dai), spender: address(router), amount: amount});
+        vm.expectRevert(DeadlineExceeded.selector);
+        vm.prank(user);
+        router.doSwap({recipient: userRecipient, tokenIn: address(dai), amountIn: amount, query: query});
+    }
+
+    function testAdapterActionAddLiquidityRevertsWhenInsufficientOutputAmount() public {
+        checkAdapterActionAddLiquidityRevertsWhenInsufficientOutputAmount(address(router));
+    }
+
+    function testAdapterActionAddLiquidityRevertsWhenInsufficientOutputAmountUsingFlakyAdapter() public {
+        checkAdapterActionAddLiquidityRevertsWhenInsufficientOutputAmount(address(flakyAdapter));
+    }
+
+    function checkAdapterActionAddLiquidityRevertsWhenInsufficientOutputAmount(address routerAdapter) public {
+        // DAI (0) -> nUSD (0xFF) add liquidity
+        uint256 amount = 10**18;
+        uint256 expectedAmountOut = calculateAddLiquidity(address(dai), amount);
+        bytes memory rawParams = abi.encode(
+            DefaultParams({action: Action.AddLiquidity, pool: address(nusdPool), tokenIndexFrom: 0, tokenIndexTo: 0xFF})
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: address(nusd),
+            minAmountOut: expectedAmountOut + 1,
+            deadline: block.timestamp,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(dai), spender: address(router), amount: amount});
+        vm.expectRevert(InsufficientOutputAmount.selector);
+        vm.prank(user);
+        router.doSwap({recipient: userRecipient, tokenIn: address(dai), amountIn: amount, query: query});
+    }
+
+    // ═════════════════════════════════════════ TESTS: REMOVING LIQUIDITY ═════════════════════════════════════════════
+
+    function testAdapterActionRemoveLiquidity() public {
+        checkAdapterActionRemoveLiquidity(address(router));
+    }
+
+    function testAdapterActionRemoveLiquidityUsingFlakyAdapter() public {
+        checkAdapterActionRemoveLiquidity(address(flakyAdapter));
+    }
+
+    function checkAdapterActionRemoveLiquidity(address routerAdapter) public {
+        // nUSD (0xFF) -> DAI (0) remove liquidity
+        uint256 amount = 10**18;
+        uint256 expectedAmountOut = nusdPool.calculateRemoveLiquidityOneToken(amount, 0);
+        bytes memory rawParams = abi.encode(
+            DefaultParams({
+                action: Action.RemoveLiquidity,
+                pool: address(nusdPool),
+                tokenIndexFrom: 0xFF,
+                tokenIndexTo: 0
+            })
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: address(dai),
+            minAmountOut: expectedAmountOut,
+            deadline: block.timestamp,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(nusd), spender: address(router), amount: amount});
+        vm.prank(user);
+        (address tokenOut, uint256 amountOut) = router.doSwap({
+            recipient: userRecipient,
+            tokenIn: address(nusd),
+            amountIn: amount,
+            query: query
+        });
+        assertEq(tokenOut, address(dai));
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(dai.balanceOf(address(userRecipient)), expectedAmountOut);
+    }
+
+    function testAdapterActionRemoveLiquidityRevertsWhenDeadlineExceeded() public {
+        checkAdapterActionRemoveLiquidityRevertsWhenDeadlineExceeded(address(router));
+    }
+
+    function testAdapterActionRemoveLiquidityRevertsWhenDeadlineExceededUsingFlakyAdapter() public {
+        checkAdapterActionRemoveLiquidityRevertsWhenDeadlineExceeded(address(flakyAdapter));
+    }
+
+    function checkAdapterActionRemoveLiquidityRevertsWhenDeadlineExceeded(address routerAdapter) public {
+        // nUSD (0xFF) -> DAI (0) remove liquidity
+        uint256 amount = 10**18;
+        bytes memory rawParams = abi.encode(
+            DefaultParams({
+                action: Action.RemoveLiquidity,
+                pool: address(nusdPool),
+                tokenIndexFrom: 0xFF,
+                tokenIndexTo: 0
+            })
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: address(dai),
+            minAmountOut: 0,
+            deadline: block.timestamp - 1,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(nusd), spender: address(router), amount: amount});
+        vm.expectRevert(DeadlineExceeded.selector);
+        vm.prank(user);
+        router.doSwap({recipient: userRecipient, tokenIn: address(nusd), amountIn: amount, query: query});
+    }
+
+    function testAdapterActionRemoveLiquidityRevertsWhenInsufficientOutputAmount() public {
+        checkAdapterActionRemoveLiquidityRevertsWhenInsufficientOutputAmount(address(router));
+    }
+
+    function testAdapterActionRemoveLiquidityRevertsWhenInsufficientOutputAmountUsingFlakyAdapter() public {
+        checkAdapterActionRemoveLiquidityRevertsWhenInsufficientOutputAmount(address(flakyAdapter));
+    }
+
+    function checkAdapterActionRemoveLiquidityRevertsWhenInsufficientOutputAmount(address routerAdapter) public {
+        // nUSD (0xFF) -> DAI (0) remove liquidity
+        uint256 amount = 10**18;
+        uint256 expectedAmountOut = nusdPool.calculateRemoveLiquidityOneToken(amount, 0);
+        bytes memory rawParams = abi.encode(
+            DefaultParams({
+                action: Action.RemoveLiquidity,
+                pool: address(nusdPool),
+                tokenIndexFrom: 0xFF,
+                tokenIndexTo: 0
+            })
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: address(dai),
+            minAmountOut: expectedAmountOut + 1,
+            deadline: block.timestamp,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(nusd), spender: address(router), amount: amount});
+        vm.expectRevert(InsufficientOutputAmount.selector);
+        vm.prank(user);
+        router.doSwap({recipient: userRecipient, tokenIn: address(nusd), amountIn: amount, query: query});
+    }
+
+    // ════════════════════════════════════════════ TESTS: ETH <> WETH ═════════════════════════════════════════════════
+
+    function testAdapterActionHandleEthWrap() public {
+        checkAdapterActionHandleEthWrap(address(router));
+    }
+
+    function testAdapterActionHandleEthWrapUsingFlakyAdapter() public {
+        checkAdapterActionHandleEthWrap(address(flakyAdapter));
+    }
+
+    function checkAdapterActionHandleEthWrap(address routerAdapter) public {
+        // Wrap native ETH into WETH
+        uint256 amount = 10**18;
+        bytes memory rawParams = abi.encode(
+            DefaultParams({action: Action.HandleEth, pool: address(0), tokenIndexFrom: 0xFF, tokenIndexTo: 0xFF})
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: address(weth),
+            minAmountOut: amount,
+            deadline: block.timestamp,
+            rawParams: rawParams
+        });
+        deal(user, amount);
+        vm.prank(user);
+        (address tokenOut, uint256 amountOut) = router.doSwap{value: amount}({
+            recipient: userRecipient,
+            tokenIn: ETH,
+            amountIn: amount,
+            query: query
+        });
+        assertEq(tokenOut, address(weth));
+        assertEq(amountOut, amount);
+        assertEq(weth.balanceOf(address(userRecipient)), amount);
+    }
+
+    function testAdapterActionHandleEthUnwrap() public {
+        checkAdapterActionHandleEthUnwrap(address(router));
+    }
+
+    function testAdapterActionHandleEthUnwrapUsingFlakyAdapter() public {
+        checkAdapterActionHandleEthUnwrap(address(flakyAdapter));
+    }
+
+    function checkAdapterActionHandleEthUnwrap(address routerAdapter) public {
+        // Unwrap WETH into native ETH
+        uint256 amount = 10**18;
+        bytes memory rawParams = abi.encode(
+            DefaultParams({action: Action.HandleEth, pool: address(0), tokenIndexFrom: 0xFF, tokenIndexTo: 0xFF})
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: ETH,
+            minAmountOut: amount,
+            deadline: block.timestamp,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(weth), spender: address(router), amount: amount});
+        vm.prank(user);
+        (address tokenOut, uint256 amountOut) = router.doSwap({
+            recipient: userRecipient,
+            tokenIn: address(weth),
+            amountIn: amount,
+            query: query
+        });
+        assertEq(tokenOut, ETH);
+        assertEq(amountOut, amount);
+        assertEq(address(userRecipient).balance, amount);
+    }
+
+    function testAdapterActionHandleEthRevertsWhenDeadlineExceeded() public {
+        checkAdapterActionHandleEthRevertsWhenDeadlineExceeded(address(router));
+    }
+
+    function testAdapterActionHandleEthRevertsWhenDeadlineExceededUsingFlakyAdapter() public {
+        checkAdapterActionHandleEthRevertsWhenDeadlineExceeded(address(flakyAdapter));
+    }
+
+    function checkAdapterActionHandleEthRevertsWhenDeadlineExceeded(address routerAdapter) public {
+        // Unwrap WETH into native ETH
+        uint256 amount = 10**18;
+        bytes memory rawParams = abi.encode(
+            DefaultParams({action: Action.HandleEth, pool: address(0), tokenIndexFrom: 0xFF, tokenIndexTo: 0xFF})
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: ETH,
+            minAmountOut: amount,
+            deadline: block.timestamp - 1,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(weth), spender: address(router), amount: amount});
+        vm.expectRevert(DeadlineExceeded.selector);
+        vm.prank(user);
+        router.doSwap({recipient: userRecipient, tokenIn: address(weth), amountIn: amount, query: query});
+    }
+
+    function testAdapterActionHandleEthRevertsWhenInsufficientOutputAmount() public {
+        checkAdapterActionHandleEthRevertsWhenInsufficientOutputAmount(address(router));
+    }
+
+    function testAdapterActionHandleEthRevertsWhenInsufficientOutputAmountUsingFlakyAdapter() public {
+        checkAdapterActionHandleEthRevertsWhenInsufficientOutputAmount(address(flakyAdapter));
+    }
+
+    function checkAdapterActionHandleEthRevertsWhenInsufficientOutputAmount(address routerAdapter) public {
+        // Unwrap WETH into native ETH
+        uint256 amount = 10**18;
+        bytes memory rawParams = abi.encode(
+            DefaultParams({action: Action.HandleEth, pool: address(0), tokenIndexFrom: 0xFF, tokenIndexTo: 0xFF})
+        );
+        SwapQuery memory query = SwapQuery({
+            routerAdapter: routerAdapter,
+            tokenOut: ETH,
+            minAmountOut: amount + 1,
+            deadline: block.timestamp,
+            rawParams: rawParams
+        });
+        mintToUserAndApprove({token: address(weth), spender: address(router), amount: amount});
+        vm.expectRevert(InsufficientOutputAmount.selector);
+        vm.prank(user);
+        router.doSwap({recipient: userRecipient, tokenIn: address(weth), amountIn: amount, query: query});
     }
 
     // ══════════════════════════════════════════════════ HELPERS ══════════════════════════════════════════════════════

--- a/test/router/adapters/DefaultAdapter.t.sol
+++ b/test/router/adapters/DefaultAdapter.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {DefaultAdapter} from "../../../contracts/router/adapters/DefaultAdapter.sol";
+import {Action, DefaultParams} from "../../../contracts/router/libs/Structs.sol";
+
+import {MockDefaultPool, MockDefaultExtendedPool} from "../mocks/MockDefaultExtendedPool.sol";
+import {MockERC20} from "../mocks/MockERC20.sol";
+import {MockWETH} from "../mocks/MockWETH.sol";
+
+import {IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/IERC20.sol";
+import {Test} from "forge-std/Test.sol";
+
+contract DefaultAdapterTest is Test {
+    address public constant ETH = address(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
+
+    MockDefaultPool public nethPool;
+    MockWETH public weth;
+    MockERC20 public neth;
+
+    MockDefaultExtendedPool public nusdPool;
+    MockERC20 public nusd;
+    MockERC20 public dai;
+    MockERC20 public usdc;
+    MockERC20 public usdt;
+
+    DefaultAdapter public adapter;
+
+    mapping(address => uint8) public tokenToIndex;
+
+    address public user;
+    address public userRecipient;
+
+    function setUp() public {
+        weth = new MockWETH();
+        neth = new MockERC20("nETH", 18);
+
+        dai = new MockERC20("DAI", 18);
+        usdc = new MockERC20("USDC", 6);
+        usdt = new MockERC20("USDT", 6);
+
+        adapter = new DefaultAdapter();
+        user = makeAddr("User");
+        userRecipient = makeAddr("Recipient");
+
+        {
+            address[] memory tokens = new address[](2);
+            tokens[0] = address(neth);
+            tokens[1] = address(weth);
+            nethPool = new MockDefaultPool(tokens);
+            tokenToIndex[address(neth)] = 0;
+            tokenToIndex[address(weth)] = 1;
+            tokenToIndex[ETH] = 1;
+            weth.mint(address(nethPool), 10 * 10**18);
+            neth.mint(address(nethPool), 10.5 * 10**18);
+        }
+
+        {
+            address[] memory tokens = new address[](3);
+            tokens[0] = address(dai);
+            tokens[1] = address(usdc);
+            tokens[2] = address(usdt);
+            nusdPool = new MockDefaultExtendedPool(tokens, "nUSD");
+            nusd = nusdPool.lpToken();
+            tokenToIndex[address(dai)] = 0;
+            tokenToIndex[address(usdc)] = 1;
+            tokenToIndex[address(usdt)] = 2;
+            tokenToIndex[address(nusd)] = 0xFF;
+            dai.mint(address(nusdPool), 1000 * 10**18);
+            usdc.mint(address(nusdPool), 1020 * 10**6);
+            usdt.mint(address(nusdPool), 1040 * 10**6);
+        }
+    }
+
+    function testAdapterActionSwapTokenToTokenDiffDecimals() public {
+        checkAdapterSwap(address(nusdPool), address(dai), 1 * 10**18, address(usdc));
+        checkAdapterSwap(address(nusdPool), address(usdc), 1 * 10**6, address(dai));
+    }
+
+    function testAdapterActionSwapTokenToTokenSameDecimals() public {
+        checkAdapterSwap(address(nusdPool), address(usdc), 1 * 10**6, address(usdt));
+        checkAdapterSwap(address(nusdPool), address(usdt), 1 * 10**6, address(usdc));
+    }
+
+    function testAdapterActionSwapTokenToTokenFromWETH() public {
+        checkAdapterSwap(address(nethPool), address(weth), 1 * 10**18, address(neth));
+    }
+
+    function testAdapterActionSwapTokenToTokenToWETH() public {
+        checkAdapterSwap(address(nethPool), address(neth), 1 * 10**18, address(weth));
+    }
+
+    function testAdapterActionSwapETHToToken() public {
+        checkAdapterSwap(address(nethPool), ETH, 1 * 10**18, address(neth));
+    }
+
+    function testAdapterActionSwapTokenToETH() public {
+        checkAdapterSwap(address(nethPool), address(neth), 1 * 10**18, ETH);
+    }
+
+    function checkAdapterSwap(
+        address pool,
+        address tokenIn,
+        uint256 amountIn,
+        address tokenOut
+    ) public {
+        // Test with external recipient
+        checkAdapterSwap(pool, tokenIn, amountIn, tokenOut, userRecipient);
+        // Test with self recipient
+        checkAdapterSwap(pool, tokenIn, amountIn, tokenOut, address(adapter));
+    }
+
+    function checkAdapterSwap(
+        address pool,
+        address tokenIn,
+        uint256 amountIn,
+        address tokenOut,
+        address recipient
+    ) public {
+        bytes memory rawParams = abi.encode(
+            DefaultParams({
+                action: Action.Swap,
+                pool: pool,
+                tokenIndexFrom: tokenToIndex[tokenIn],
+                tokenIndexTo: tokenToIndex[tokenOut]
+            })
+        );
+        uint256 expectedAmountOut = MockDefaultPool(pool).calculateSwap(
+            tokenToIndex[tokenIn],
+            tokenToIndex[tokenOut],
+            amountIn
+        );
+        // Mint test tokens to adapter
+        if (tokenIn != ETH) {
+            MockERC20(tokenIn).mint(address(adapter), amountIn);
+        } else {
+            deal(user, amountIn);
+        }
+        uint256 msgValue = tokenIn == ETH ? amountIn : 0;
+        vm.prank(user);
+        adapter.adapterSwap{value: msgValue}(recipient, tokenIn, amountIn, tokenOut, rawParams);
+        assertEq(balanceOf(tokenOut, recipient), expectedAmountOut);
+    }
+
+    function balanceOf(address token, address who) public view returns (uint256) {
+        if (token == ETH) {
+            return who.balance;
+        } else {
+            return IERC20(token).balanceOf(who);
+        }
+    }
+}

--- a/test/router/harnesses/ActionLibHarness.sol
+++ b/test/router/harnesses/ActionLibHarness.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {Action, ActionLib} from "../../../contracts/router/libs/Structs.sol";
+
+contract ActionLibHarness {
+    function allActions() public pure returns (uint256) {
+        uint256 result = ActionLib.allActions();
+        return result;
+    }
+
+    function isIncluded(Action action, uint256 actionMask) public pure returns (bool) {
+        bool result = ActionLib.isIncluded(action, actionMask);
+        return result;
+    }
+
+    function mask(Action action) public pure returns (uint256) {
+        uint256 result = ActionLib.mask(action);
+        return result;
+    }
+
+    function mask(Action a, Action b) public pure returns (uint256) {
+        uint256 result = ActionLib.mask(a, b);
+        return result;
+    }
+}

--- a/test/router/harnesses/FlakyAdapter.sol
+++ b/test/router/harnesses/FlakyAdapter.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {DefaultAdapter} from "../../../contracts/router/adapters/DefaultAdapter.sol";
+
+contract FlakyAdapter is DefaultAdapter {
+    function _adapterSwap(
+        address recipient,
+        address tokenIn,
+        uint256 amountIn,
+        address tokenOut,
+        bytes memory rawParams
+    ) internal virtual override returns (uint256 amountOut) {
+        // Return inflated amountOut
+        amountOut = super._adapterSwap(recipient, tokenIn, amountIn, tokenOut, rawParams) + 1;
+    }
+}

--- a/test/router/harnesses/UniversalTokenLibHarness.sol
+++ b/test/router/harnesses/UniversalTokenLibHarness.sol
@@ -15,4 +15,12 @@ contract UniversalTokenLibHarness {
     function ethAddress() public pure returns (address) {
         return UniversalTokenLib.ETH_ADDRESS;
     }
+
+    function universalBalanceOf(address token, address account) public view returns (uint256) {
+        return UniversalTokenLib.universalBalanceOf(token, account);
+    }
+
+    function assertIsContract(address token) public view {
+        UniversalTokenLib.assertIsContract(token);
+    }
 }

--- a/test/router/harnesses/UniversalTokenLibHarness.sol
+++ b/test/router/harnesses/UniversalTokenLibHarness.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {UniversalTokenLib} from "../../../contracts/router/libs/UniversalToken.sol";
+
+contract UniversalTokenLibHarness {
+    function universalTransfer(
+        address token,
+        address to,
+        uint256 value
+    ) public {
+        UniversalTokenLib.universalTransfer(token, to, value);
+    }
+
+    function ethAddress() public pure returns (address) {
+        return UniversalTokenLib.ETH_ADDRESS;
+    }
+}

--- a/test/router/libs/ActionLib.t.sol
+++ b/test/router/libs/ActionLib.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {Action, ActionLibHarness} from "../harnesses/ActionLibHarness.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+contract ActionLibraryTest is Test {
+    ActionLibHarness public libHarness;
+
+    uint256 public constant MAX_ACTION = uint8(type(Action).max) + 1;
+
+    function setUp() public {
+        libHarness = new ActionLibHarness();
+    }
+
+    function testAllActions() public {
+        uint256 allActions = libHarness.allActions();
+        for (uint8 i = 0; i < MAX_ACTION; i++) {
+            assertTrue(libHarness.isIncluded(Action(i), allActions));
+        }
+    }
+
+    function testIsIncluded(
+        bool swap,
+        bool addLiquidity,
+        bool removeLiquidity,
+        bool handleEth
+    ) public {
+        uint256 mask = 0;
+        if (swap) mask += 2**0;
+        if (addLiquidity) mask += 2**1;
+        if (removeLiquidity) mask += 2**2;
+        if (handleEth) mask += 2**3;
+        assertEq(libHarness.isIncluded(Action.Swap, mask), swap);
+        assertEq(libHarness.isIncluded(Action.AddLiquidity, mask), addLiquidity);
+        assertEq(libHarness.isIncluded(Action.RemoveLiquidity, mask), removeLiquidity);
+        assertEq(libHarness.isIncluded(Action.HandleEth, mask), handleEth);
+    }
+
+    function testMaskOneAction() public {
+        assertEq(libHarness.mask(Action.Swap), 2**0);
+        assertEq(libHarness.mask(Action.AddLiquidity), 2**1);
+        assertEq(libHarness.mask(Action.RemoveLiquidity), 2**2);
+        assertEq(libHarness.mask(Action.HandleEth), 2**3);
+    }
+
+    function testMaskTwoDifferentActions() public {
+        assertEq(libHarness.mask(Action.Swap, Action.AddLiquidity), 2**0 + 2**1);
+        assertEq(libHarness.mask(Action.Swap, Action.RemoveLiquidity), 2**0 + 2**2);
+        assertEq(libHarness.mask(Action.Swap, Action.HandleEth), 2**0 + 2**3);
+
+        assertEq(libHarness.mask(Action.AddLiquidity, Action.Swap), 2**1 + 2**0);
+        assertEq(libHarness.mask(Action.AddLiquidity, Action.RemoveLiquidity), 2**1 + 2**2);
+        assertEq(libHarness.mask(Action.AddLiquidity, Action.HandleEth), 2**1 + 2**3);
+
+        assertEq(libHarness.mask(Action.RemoveLiquidity, Action.Swap), 2**2 + 2**0);
+        assertEq(libHarness.mask(Action.RemoveLiquidity, Action.AddLiquidity), 2**2 + 2**1);
+        assertEq(libHarness.mask(Action.RemoveLiquidity, Action.HandleEth), 2**2 + 2**3);
+
+        assertEq(libHarness.mask(Action.HandleEth, Action.Swap), 2**3 + 2**0);
+        assertEq(libHarness.mask(Action.HandleEth, Action.AddLiquidity), 2**3 + 2**1);
+        assertEq(libHarness.mask(Action.HandleEth, Action.RemoveLiquidity), 2**3 + 2**2);
+    }
+
+    function testMaskTwoSameActions() public {
+        assertEq(libHarness.mask(Action.Swap, Action.Swap), 2**0);
+        assertEq(libHarness.mask(Action.AddLiquidity, Action.AddLiquidity), 2**1);
+        assertEq(libHarness.mask(Action.RemoveLiquidity, Action.RemoveLiquidity), 2**2);
+        assertEq(libHarness.mask(Action.HandleEth, Action.HandleEth), 2**3);
+    }
+}

--- a/test/router/libs/UniversalTokenLib.t.sol
+++ b/test/router/libs/UniversalTokenLib.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {UniversalTokenLibHarness} from "../harnesses/UniversalTokenLibHarness.sol";
+import {MockERC20} from "../mocks/MockERC20.sol";
+import {MockRevertingRecipient} from "../mocks/MockRevertingRecipient.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+contract UniversalTokenLibraryTest is Test {
+    UniversalTokenLibHarness public libHarness;
+    MockERC20 public token;
+    address public recipient;
+
+    function setUp() public {
+        libHarness = new UniversalTokenLibHarness();
+        token = new MockERC20("Mock", 18);
+        recipient = makeAddr("Recipient");
+    }
+
+    function testUniversalTransferToken() public {
+        uint256 amount = 12345;
+        token.mint(address(libHarness), amount);
+        libHarness.universalTransfer(address(token), recipient, amount);
+        assertEq(token.balanceOf(address(libHarness)), 0);
+        assertEq(token.balanceOf(address(recipient)), amount);
+    }
+
+    function testUniversalTransferTokenNoopWhenSameRecipient() public {
+        uint256 amount = 12345;
+        token.mint(address(libHarness), amount);
+        vm.mockCallRevert(
+            address(token),
+            abi.encodeWithSelector(token.transfer.selector, address(libHarness)),
+            "Disabled transfers to harness"
+        );
+        // Should not revert, as the transfer is a noop due to the same recipient
+        libHarness.universalTransfer(address(token), address(libHarness), amount);
+        assertEq(token.balanceOf(address(libHarness)), amount);
+        // Trying to transfer to the harness should still revert
+        token.mint(address(this), amount);
+        vm.expectRevert("Disabled transfers to harness");
+        token.transfer(address(libHarness), amount);
+    }
+
+    function testUniversalTransferETH() public {
+        uint256 amount = 12345;
+        deal(address(libHarness), amount);
+        libHarness.universalTransfer(libHarness.ethAddress(), recipient, amount);
+        assertEq(address(libHarness).balance, 0);
+        assertEq(address(recipient).balance, amount);
+    }
+
+    function testUniversalTransferETHNoopWhenSameRecipient() public {
+        uint256 amount = 12345;
+        deal(address(libHarness), amount);
+        // Should not revert, as the transfer is a noop due to the same recipient
+        libHarness.universalTransfer(libHarness.ethAddress(), address(libHarness), amount);
+        assertEq(address(libHarness).balance, amount);
+        // Simply sending ETH to the harness should still revert (no receive/fallback)
+        deal(address(this), amount);
+        (bool success, ) = address(libHarness).call{value: amount}("");
+        assertEq(success, false);
+    }
+
+    function testUniversalTransferETHRevertsWhenRecipientDeclined() public {
+        uint256 amount = 12345;
+        deal(address(libHarness), amount);
+        address eth = libHarness.ethAddress();
+        address revertingRecipient = address(new MockRevertingRecipient());
+        vm.expectRevert("ETH transfer failed");
+        libHarness.universalTransfer(eth, revertingRecipient, amount);
+    }
+
+    function testEthAddress() public {
+        // ETH address should have all bytes set to 0xEE
+        address ethAddress = libHarness.ethAddress();
+        for (uint256 i = 0; i < 20; i++) {
+            assertEq(uint8(bytes20(ethAddress)[i]), 0xEE);
+        }
+    }
+}

--- a/test/router/mocks/MockDefaultExtendedPool.sol
+++ b/test/router/mocks/MockDefaultExtendedPool.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IDefaultExtendedPool} from "../../../contracts/router/interfaces/IDefaultExtendedPool.sol";
+
+import {MockERC20} from "./MockERC20.sol";
+import {MockDefaultPool, IERC20, SafeERC20} from "./MockDefaultPool.sol";
+
+import {IERC20Metadata} from "@openzeppelin/contracts-4.5.0/token/ERC20/extensions/IERC20Metadata.sol";
+
+contract MockDefaultExtendedPool is MockDefaultPool, IDefaultExtendedPool {
+    using SafeERC20 for IERC20;
+
+    MockERC20 public lpToken;
+
+    constructor(address[] memory tokens, string memory lpTokenName) MockDefaultPool(tokens) {
+        lpToken = new MockERC20(lpTokenName, 18);
+    }
+
+    // ═══════════════════════════════════════════════ EXTENDED POOL ═══════════════════════════════════════════════════
+
+    /// @notice Very basic mock of the addLiquidity function: mints LP tokens at 1:1 basis.
+    function addLiquidity(
+        uint256[] calldata amounts,
+        uint256 minToMint,
+        uint256 deadline
+    ) external returns (uint256 minted) {
+        require(amounts.length == _tokens.length, "ExtendedPool: !length");
+        // solhint-disable-next-line not-rely-on-time
+        require(deadline >= block.timestamp, "ExtendedPool: !deadline");
+        for (uint256 i = 0; i < amounts.length; ++i) {
+            address token = _tokens[i];
+            IERC20(token).safeTransferFrom(msg.sender, address(this), amounts[i]);
+            minted += amounts[i] * 10**(18 - IERC20Metadata(token).decimals());
+        }
+        require(minted >= minToMint, "ExtendedPool: !minToMint");
+        lpToken.mint(msg.sender, minted);
+    }
+
+    ///  @notice Very basic mock of the removeLiquidityOneToken function: burns LP tokens at 1:1 basis.
+    function removeLiquidityOneToken(
+        uint256 lpTokenAmount,
+        uint8 tokenIndex,
+        uint256 minAmount,
+        uint256 deadline
+    ) external returns (uint256 tokenAmount) {
+        require(tokenIndex < _tokens.length, "ExtendedPool: !tokenIndex");
+        address token = _tokens[tokenIndex];
+        // solhint-disable-next-line not-rely-on-time
+        require(deadline >= block.timestamp, "ExtendedPool: !deadline");
+        IERC20(address(lpToken)).safeTransferFrom(msg.sender, address(this), lpTokenAmount);
+        lpToken.burn(address(this), lpTokenAmount);
+        tokenAmount = lpTokenAmount / 10**(18 - IERC20Metadata(token).decimals());
+        require(tokenAmount >= minAmount, "ExtendedPool: !minAmount");
+        require(IERC20(token).balanceOf(address(this)) >= tokenAmount, "ExtendedPool: !balance");
+        IERC20(token).safeTransfer(msg.sender, tokenAmount);
+    }
+
+    // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
+
+    function swapStorage()
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            address
+        )
+    {
+        return (0, 0, 0, 0, 0, 0, address(lpToken));
+    }
+
+    function calculateAddLiquidity(uint256[] calldata amounts) external view returns (uint256) {
+        require(amounts.length == _tokens.length, "ExtendedPool: !length");
+        uint256 minted;
+        for (uint256 i = 0; i < amounts.length; ++i) {
+            minted += amounts[i] * 10**(18 - IERC20Metadata(_tokens[i]).decimals());
+        }
+        return minted;
+    }
+
+    function calculateRemoveLiquidityOneToken(uint256 lpTokenAmount, uint8 tokenIndex) external view returns (uint256) {
+        require(tokenIndex < _tokens.length, "ExtendedPool: !tokenIndex");
+        return lpTokenAmount / 10**(18 - IERC20Metadata(_tokens[tokenIndex]).decimals());
+    }
+}

--- a/test/router/mocks/MockDefaultPool.sol
+++ b/test/router/mocks/MockDefaultPool.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IDefaultPool} from "../../../contracts/router/interfaces/IDefaultPool.sol";
+
+import {IERC20, SafeERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/utils/SafeERC20.sol";
+
+/// A simple lightweight mock of the Default pool contract for testing purposes.
+/// Note that the mock is using the UniSwap formula for price calculations. This is done to simplify the logic.
+/// Note there is no addLiquidity or removeLiquidity. This pool is using the whole balance of each token as liquidity.
+/// Mint of transfer test tokens to the pool address before using the pool.
+contract MockDefaultPool is IDefaultPool {
+    using SafeERC20 for IERC20;
+
+    address[] internal _tokens;
+    uint256 internal _coins;
+
+    // We don't expose paused() in this contract to test that LinkedPool could handle pools without this function.
+    bool internal _paused;
+
+    constructor(address[] memory tokens) {
+        _tokens = tokens;
+        _coins = tokens.length;
+    }
+
+    function swap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx,
+        uint256 minDy,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
+        if (_paused) revert("Siesta time");
+        amountOut = _calculateSwap(tokenIndexFrom, tokenIndexTo, dx);
+        require(amountOut >= minDy, "Insufficient output amount");
+        // solhint-disable-next-line not-rely-on-time
+        require(deadline >= block.timestamp, "Deadline expired");
+        IERC20(_getToken(tokenIndexFrom)).safeTransferFrom(msg.sender, address(this), dx);
+        IERC20(_getToken(tokenIndexTo)).safeTransfer(msg.sender, amountOut);
+    }
+
+    function calculateSwap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx
+    ) external view returns (uint256 amountOut) {
+        return _calculateSwap(tokenIndexFrom, tokenIndexTo, dx);
+    }
+
+    function getToken(uint8 index) external view returns (address token) {
+        return _getToken(index);
+    }
+
+    // ══════════════════════════════════════════════ INTERNAL VIEWS ═══════════════════════════════════════════════════
+
+    function _calculateSwap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx
+    ) internal view returns (uint256 amountOut) {
+        if (tokenIndexFrom == tokenIndexTo) return 0;
+        if (tokenIndexFrom >= _coins || tokenIndexTo >= _coins) return 0;
+        uint256 balanceFrom = _getBalance(_getToken(tokenIndexFrom));
+        uint256 balanceTo = _getBalance(_getToken(tokenIndexTo));
+        require(balanceFrom > 0 && balanceTo > 0, "No liquidity");
+        // Follow the Uniswap formula for calculating the amountOut
+        amountOut = (dx * balanceTo * 997) / (balanceFrom * 1000 + dx * 997);
+    }
+
+    function _getBalance(address token) internal view returns (uint256 balance) {
+        return IERC20(token).balanceOf(address(this));
+    }
+
+    function _getToken(uint8 index) internal view returns (address token) {
+        require(index < _coins, "Incorrect token index");
+        return _tokens[index];
+    }
+}

--- a/test/router/mocks/MockDefaultPool.sol
+++ b/test/router/mocks/MockDefaultPool.sol
@@ -58,8 +58,7 @@ contract MockDefaultPool is IDefaultPool {
         uint8 tokenIndexTo,
         uint256 dx
     ) internal view returns (uint256 amountOut) {
-        if (tokenIndexFrom == tokenIndexTo) return 0;
-        if (tokenIndexFrom >= _coins || tokenIndexTo >= _coins) return 0;
+        require(tokenIndexFrom != tokenIndexTo, "Token indexes are equal");
         uint256 balanceFrom = _getBalance(_getToken(tokenIndexFrom));
         uint256 balanceTo = _getBalance(_getToken(tokenIndexTo));
         require(balanceFrom > 0 && balanceTo > 0, "No liquidity");

--- a/test/router/mocks/MockERC20.sol
+++ b/test/router/mocks/MockERC20.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {ERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    uint8 private _decimals;
+
+    constructor(string memory name_, uint8 decimals_) ERC20(name_, name_) {
+        _decimals = decimals_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+
+    function burn(address account, uint256 amount) external {
+        _burn(account, amount);
+    }
+
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
+    }
+}

--- a/test/router/mocks/MockRevertingRecipient.sol
+++ b/test/router/mocks/MockRevertingRecipient.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+contract MockRevertingRecipient {
+    receive() external payable {
+        revert("GM");
+    }
+}

--- a/test/router/mocks/MockWETH.sol
+++ b/test/router/mocks/MockWETH.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IWETH9} from "../../../contracts/router/interfaces/IWETH9.sol";
+
+import {CommonBase} from "forge-std/Base.sol";
+import {ERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/ERC20.sol";
+
+contract MockWETH is CommonBase, ERC20, IWETH9 {
+    constructor() ERC20("Mock WETH", "Mock WETH") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+        // Make sure ETH reserves are sufficient
+        uint256 newBalance = address(this).balance + amount;
+        vm.deal(address(this), newBalance);
+    }
+
+    function burn(address from, uint256 amount) external {
+        _burn(from, amount);
+        uint256 newBalance = address(this).balance - amount;
+        vm.deal(address(this), newBalance);
+    }
+
+    function deposit() external payable {
+        _mint(msg.sender, msg.value);
+    }
+
+    function withdraw(uint256 wad) external {
+        _burn(msg.sender, wad);
+        payable(msg.sender).transfer(wad);
+    }
+}


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

This PR introduces two base contracts that will be used for future Router contracts, such as `SynapseCCTPRouter` and `SynapseRouterV2`.

### `DefaultAdapter`
`DefaultAdapter` implements functionality of a "default" Router adapter. The adapters are used to perform an origin swap in the Router contract using following workflow:
- Prepare to perform an action
  - If adapter needs to perform an action with the ERC20 token, this token is transferred into the adapter contract first (and `msg.value=0` is used).
  - If adapter needs to perform an action with native gas, it is attached using non-zero `msg.value` for the following call.
- Perform the action:
  - `IRouterAdapter.adapterSwap(recipient, tokenIn, amountIn, tokenOut, rawParams)` is called
    - `recipient`: the address that will receive the final token.
    - `tokenIn`: token to start from (`ETH_ADDRESS=0xee...ee` is used for native gas).
    - `amountIn`: amount of tokens/ETH to start with.
    - `tokenOut`: token to end with
    - `rawParams`: encoded instructions for the action to perform.

`DefaultAdapter` covers following functionality:
- Swapping tokens using pools with `IDefaultPool` interface.
- Adding liquidity in a form of a single token to a pool with `IDefaultPool` interface.
- Removing liquidity in a form of a single token from a pool with `IDefaultPool` interface.
- Wrapping/unwrapping ETH into WETH.

> `DefaultAdapter` also supports more complex workflows like "wrap ETH in WETH" + "swap WETH", or "swap token for WETH" + "unwrap WETH"

### `DefaultRouter`

`DefaultRouter` inherits from `DefaultAdapter` and provides some common tools for all future Router contracts:

- `_pullToken()`: pulls the required token straight to the specified recipient.
- `_doSwap()`: performs a "swap" from one token to another using a specified adapter (which could be either the Router itself, or an external Router Adapter).
> "swap" in this context just means that the initial token (or native ETH) is taken from user, and the end token (or native ETH) is transferred to recipient. In practice this is achieved by using any of the supported `DefaultAdapter` actions, or any actions that an external Router Adapter can implement.

## Final thoughts

This is mostly a port of 0.6 contracts (which are already in prod) with better abstraction layers:

- [SynapseAdapter](https://github.com/synapsecns/synapse-contracts/blob/87556309c5a74b57e7f983b79445c68d376c41c5/contracts/bridge/router/SynapseAdapter.sol)
- [SynapseRouter](https://github.com/synapsecns/synapse-contracts/blob/87556309c5a74b57e7f983b79445c68d376c41c5/contracts/bridge/router/SynapseRouter.sol)

## Checklist

- [x] New Contracts have been tested
- [x] Lint has been run
- [x] I have checked my code and corrected any misspellings
