### PR TITLE
Add pausable state for sending tokens via CCTP

### DIFF
--- a/test/cctp/SynapseCCTP.t.sol
+++ b/test/cctp/SynapseCCTP.t.sol
@@ -70,6 +70,22 @@ contract SynapseCCTPTest is BaseCCTPTest {
         assertEq(cctpSetups[DOMAIN_ETH].mintBurnToken.balanceOf(user), 0);
     }
 
+    function testSendCircleTokenBaseRequestRevertsWhenPaused() public {
+        pauseSending(DOMAIN_ETH);
+        uint256 amount = 10**8;
+        prepareUser(DOMAIN_ETH, amount);
+        vm.expectRevert("Pausable: paused");
+        vm.prank(user);
+        synapseCCTPs[DOMAIN_ETH].sendCircleToken({
+            recipient: recipient,
+            chainId: CHAINID_AVAX,
+            burnToken: address(cctpSetups[DOMAIN_ETH].mintBurnToken),
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_BASE,
+            swapParams: ""
+        });
+    }
+
     function testSendCircleTokenSwapRequest() public {
         uint256 amount = 10**8;
         prepareUser(DOMAIN_ETH, amount);
@@ -87,6 +103,28 @@ contract SynapseCCTPTest is BaseCCTPTest {
             swapParams: swapParams
         });
         assertEq(cctpSetups[DOMAIN_ETH].mintBurnToken.balanceOf(user), 0);
+    }
+
+    function testSendCircleTokenSwapRequestRevertsWhenPaused() public {
+        pauseSending(DOMAIN_ETH);
+        uint256 amount = 10**8;
+        prepareUser(DOMAIN_ETH, amount);
+        bytes memory swapParams = RequestLib.formatSwapParams({
+            tokenIndexFrom: 0,
+            tokenIndexTo: 1,
+            deadline: 4321,
+            minAmountOut: 9876543210
+        });
+        vm.expectRevert("Pausable: paused");
+        vm.prank(user);
+        synapseCCTPs[DOMAIN_ETH].sendCircleToken({
+            recipient: recipient,
+            chainId: CHAINID_AVAX,
+            burnToken: address(cctpSetups[DOMAIN_ETH].mintBurnToken),
+            amount: amount,
+            requestVersion: RequestLib.REQUEST_SWAP,
+            swapParams: swapParams
+        });
     }
 
     function testSendCircleTokenRevertsWhenRemoteDeploymentNotSet() public {

--- a/test/cctp/SynapseCCTP.t.sol
+++ b/test/cctp/SynapseCCTP.t.sol
@@ -866,6 +866,35 @@ contract SynapseCCTPTest is BaseCCTPTest {
         synapseCCTPs[DOMAIN_ETH].setCircleTokenPool(address(0), address(42));
     }
 
+    // ═══════════════════════════════════════════ TESTS: PAUSE TOGGLING ═══════════════════════════════════════════════
+
+    function testPauseByOwner() public {
+        pauseSending(DOMAIN_ETH);
+        assertTrue(synapseCCTPs[DOMAIN_ETH].paused());
+    }
+
+    function testPauseRevertsWhenCallerNotOwner(address caller) public {
+        vm.assume(caller != owner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(caller);
+        synapseCCTPs[DOMAIN_ETH].pauseSending();
+    }
+
+    function testUnpauseByOwner() public {
+        pauseSending(DOMAIN_ETH);
+        vm.prank(owner);
+        synapseCCTPs[DOMAIN_ETH].unpauseSending();
+        assertFalse(synapseCCTPs[DOMAIN_ETH].paused());
+    }
+
+    function testUnpauseRevertsWhenCallerNotOwner(address caller) public {
+        pauseSending(DOMAIN_ETH);
+        vm.assume(caller != owner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(caller);
+        synapseCCTPs[DOMAIN_ETH].unpauseSending();
+    }
+
     // ══════════════════════════════════════════════════ HELPERS ══════════════════════════════════════════════════════
 
     function checkRequestSent(
@@ -1021,5 +1050,10 @@ contract SynapseCCTPTest is BaseCCTPTest {
         setup.mintBurnToken.mintPublic(user, amount);
         vm.prank(user);
         setup.mintBurnToken.approve(address(synapseCCTPs[originDomain]), amount);
+    }
+
+    function pauseSending(uint32 domain) public {
+        vm.prank(owner);
+        synapseCCTPs[domain].pauseSending();
     }
 }


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

Adds the ability to pause sending tokens via Circle CCTP. The ability to relay pending transactions is not affected, so even in the paused state all the pending ones could be resolved.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
