### PR TITLE
Feat: `addLiquidity()` calculator for Default Pools

### DIFF
--- a/contracts/router/interfaces/IDefaultExtendedPool.sol
+++ b/contracts/router/interfaces/IDefaultExtendedPool.sol
@@ -19,6 +19,10 @@ interface IDefaultExtendedPool is IDefaultPool {
 
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
 
+    function getAPrecise() external view returns (uint256);
+
+    function getTokenBalance(uint8 index) external view returns (uint256);
+
     function swapStorage()
         external
         view

--- a/contracts/router/interfaces/IDefaultPoolCalc.sol
+++ b/contracts/router/interfaces/IDefaultPoolCalc.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface IDefaultPoolCalc {
+    /// @notice Calculates the EXACT amount of LP tokens received for a given amount of tokens deposited
+    /// into a DefaultPool.
+    /// @param pool         Address of the DefaultPool.
+    /// @param amounts      Amounts of tokens to deposit.
+    /// @return amountOut   Amount of LP tokens received.
+    function calculateAddLiquidity(address pool, uint256[] memory amounts) external view returns (uint256 amountOut);
+}

--- a/contracts/router/quoter/DefaultPoolCalc.sol
+++ b/contracts/router/quoter/DefaultPoolCalc.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IDefaultPoolCalc} from "../interfaces/IDefaultPoolCalc.sol";
+import {IDefaultExtendedPool} from "../interfaces/IDefaultExtendedPool.sol";
+
+import {IERC20Metadata} from "@openzeppelin/contracts-4.5.0/token/ERC20/extensions/IERC20Metadata.sol";
+
+/// @notice DefaultPoolCalc is a contract that calculates the amount of LP tokens received
+/// for a given amount of tokens deposited into a DefaultPool. This is implemented
+/// because the StableSwap pool contract does not expose a function to calculate the EXACT amount,
+/// only the ESTIMATED amount: `calculateTokenAmount()`.
+contract DefaultPoolCalc is IDefaultPoolCalc {
+    // Struct storing variables used in calculations in the
+    // {add,remove}Liquidity functions to avoid stack too deep errors
+    struct ManageLiquidityInfo {
+        uint256 d0;
+        uint256 d1;
+        uint256 preciseA;
+        uint256 totalSupply;
+        uint256[] balances;
+        uint256[] multipliers;
+    }
+
+    uint256 internal constant A_PRECISION = 100;
+    uint256 internal constant FEE_DENOMINATOR = 10**10;
+
+    // Copied from the Saddle repo with state changes omitted: https://github.com/saddle-finance/saddle-contract/
+    // blob/5d538c47115c29990dea5aa8af679bd024c82e35/contracts/SwapUtilsV2.sol#L717
+
+    /// @inheritdoc IDefaultPoolCalc
+    function calculateAddLiquidity(address pool, uint256[] memory amounts) external view returns (uint256 amountOut) {
+        uint256 numTokens = amounts.length;
+        // Verify that `numTokens >= pool.tokens.length`
+        _verifyTokensAmount(pool, numTokens);
+        (, , , , uint256 swapFee, , address lpToken) = IDefaultExtendedPool(pool).swapStorage();
+        // current state
+        ManageLiquidityInfo memory v = ManageLiquidityInfo({
+            d0: 0,
+            d1: 0,
+            preciseA: IDefaultExtendedPool(pool).getAPrecise(),
+            totalSupply: IERC20Metadata(lpToken).totalSupply(),
+            balances: new uint256[](numTokens),
+            multipliers: new uint256[](numTokens)
+        });
+        uint256[] memory newBalances = new uint256[](numTokens);
+        // If `numTokens < pool.tokens.length`, the loop will revert
+        for (uint256 i = 0; i < numTokens; ++i) {
+            address token = IDefaultExtendedPool(pool).getToken(uint8(i));
+            v.balances[i] = IDefaultExtendedPool(pool).getTokenBalance(uint8(i));
+            newBalances[i] = v.balances[i] + amounts[i];
+            v.multipliers[i] = 10**(18 - IERC20Metadata(token).decimals());
+        }
+        // At this point we verified that `numTokens == pool.tokens.length`
+        if (v.totalSupply != 0) {
+            v.d0 = _getD(_xp(v.balances, v.multipliers), v.preciseA);
+        } else {
+            for (uint256 i = 0; i < numTokens; ++i) {
+                require(amounts[i] > 0, "Must supply all tokens in pool");
+            }
+        }
+
+        // invariant after change
+        v.d1 = _getD(_xp(newBalances, v.multipliers), v.preciseA);
+        require(v.d1 > v.d0, "D should increase");
+
+        if (v.totalSupply == 0) {
+            return v.d1;
+        } else {
+            uint256 feePerToken = _feePerToken(swapFee, numTokens);
+            for (uint256 i = 0; i < numTokens; ++i) {
+                uint256 idealBalance = (v.d1 * v.balances[i]) / v.d0;
+                uint256 fees = (feePerToken * _difference(idealBalance, newBalances[i])) / FEE_DENOMINATOR;
+                newBalances[i] -= fees;
+            }
+            v.d1 = _getD(_xp(newBalances, v.multipliers), v.preciseA);
+            return ((v.d1 - v.d0) * v.totalSupply) / v.d0;
+        }
+    }
+
+    /// @dev Verifies that the given pool has AT MOST `numTokens` tokens.
+    function _verifyTokensAmount(address pool, uint256 numTokens) internal view {
+        // Getting token with index == amount should always revert
+        try IDefaultExtendedPool(pool).getToken(uint8(numTokens)) returns (address) {
+            revert("Incorrect tokens amount");
+        } catch {} // solhint-disable-line no-empty-blocks
+    }
+
+    // ═════════════════════════════════════════════ STABLE SWAP MATH ══════════════════════════════════════════════════
+
+    // Copied from https://github.com/saddle-finance/saddle-contract/blob/master/contracts/SwapUtilsV2.sol
+
+    /// @dev Returns abs(a-b).
+    function _difference(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a > b ? a - b : b - a;
+    }
+
+    /**
+     * @notice Get D, the StableSwap invariant, based on a set of balances and a particular A.
+     * @param xp a precision-adjusted set of pool balances. Array should be the same cardinality
+     * as the pool.
+     * @param a the amplification coefficient * n * (n - 1) in A_PRECISION.
+     * See the StableSwap paper for details
+     * @return the invariant, at the precision of the pool
+     */
+    function _getD(uint256[] memory xp, uint256 a) internal pure returns (uint256) {
+        uint256 numTokens = xp.length;
+        uint256 s;
+        for (uint256 i = 0; i < numTokens; i++) {
+            s = s + xp[i];
+        }
+        if (s == 0) {
+            return 0;
+        }
+
+        uint256 prevD;
+        uint256 d = s;
+        uint256 nA = a * numTokens;
+
+        for (uint256 i = 0; i < 256; i++) {
+            uint256 dP = d;
+            for (uint256 j = 0; j < numTokens; j++) {
+                dP = (dP * d) / (xp[j] * numTokens);
+                // If we were to protect the division loss we would have to keep the denominator separate
+                // and divide at the end. However this leads to overflow with large numTokens or/and D.
+                // dP = dP * D * D * D * ... overflow!
+            }
+            prevD = d;
+            d =
+                ((((nA * s) / A_PRECISION) + (dP * numTokens)) * d) /
+                ((((nA - A_PRECISION) * d) / A_PRECISION) + ((numTokens + 1) * dP));
+
+            if (_difference(d, prevD) <= 1) {
+                return d;
+            }
+        }
+
+        // Convergence should occur in 4 loops or less. If this is reached, there may be something wrong
+        // with the pool. If this were to occur repeatedly, LPs should withdraw via `removeLiquidity()`
+        // function which does not rely on D.
+        revert("D does not converge");
+    }
+
+    /**
+     * @notice internal helper function to calculate fee per token multiplier used in
+     * swap fee calculations
+     * @param swapFee swap fee for the tokens
+     * @param numTokens number of tokens pooled
+     */
+    function _feePerToken(uint256 swapFee, uint256 numTokens) internal pure returns (uint256) {
+        return ((swapFee * numTokens) / ((numTokens - 1) * 4));
+    }
+
+    /**
+     * @notice Given a set of balances and precision multipliers, return the
+     * precision-adjusted balances.
+     *
+     * @param balances an array of token balances, in their native precisions.
+     * These should generally correspond with pooled tokens.
+     *
+     * @param precisionMultipliers an array of multipliers, corresponding to
+     * the amounts in the balances array. When multiplied together they
+     * should yield amounts at the pool's precision.
+     *
+     * @return an array of amounts "scaled" to the pool's precision
+     */
+    function _xp(uint256[] memory balances, uint256[] memory precisionMultipliers)
+        internal
+        pure
+        returns (uint256[] memory)
+    {
+        uint256 numTokens = balances.length;
+        require(numTokens == precisionMultipliers.length, "Balances must match multipliers");
+        uint256[] memory xp = new uint256[](numTokens);
+        for (uint256 i = 0; i < numTokens; i++) {
+            xp[i] = balances[i] * precisionMultipliers[i];
+        }
+        return xp;
+    }
+}

--- a/test/router/mocks/MockDefaultExtendedPool.sol
+++ b/test/router/mocks/MockDefaultExtendedPool.sol
@@ -58,6 +58,10 @@ contract MockDefaultExtendedPool is MockDefaultPool, IDefaultExtendedPool {
 
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
 
+    function getAPrecise() external view returns (uint256) {}
+
+    function getTokenBalance(uint8 index) external view returns (uint256) {}
+
     function swapStorage()
         external
         view

--- a/test/router/quoter/DefaultPoolCalc.t.sol
+++ b/test/router/quoter/DefaultPoolCalc.t.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IDefaultExtendedPool} from "../../../contracts/router/interfaces/IDefaultExtendedPool.sol";
+import {DefaultPoolCalc} from "../../../contracts/router/quoter/DefaultPoolCalc.sol";
+
+import {SafeERC20, IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/utils/SafeERC20.sol";
+import {console2, Test} from "forge-std/Test.sol";
+
+// solhint-disable func-name-mixedcase
+contract DefaultPoolCalcTestFork is Test {
+    using SafeERC20 for IERC20;
+
+    string public ethRPC;
+    DefaultPoolCalc public calc;
+    address public user;
+
+    // Quite important pool, isn't it?
+    address public constant POOL = 0x1116898DdA4015eD8dDefb84b6e8Bc24528Af2d8;
+    address public constant LP_TOKEN = 0x1B84765dE8B7566e4cEAF4D0fD3c5aF52D3DdE4F;
+    address public constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address public constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+
+    // Maximum amount for tests before decimals
+    uint256 public constant MIN_ADD_AMOUNT = 10;
+    uint256 public constant MAX_AMOUNT = 10**9;
+
+    // 2023-05-20
+    uint256 public constant BLOCK_NUMBER_RECENT = 17_300_000;
+
+    // Block when the pool was created
+    uint256 public constant BLOCK_NUMBER_POOL_EMPTY = 13033711;
+
+    function setUp() public {
+        user = makeAddr("User");
+        ethRPC = vm.envString("rpc_mainnet");
+        calc = new DefaultPoolCalc();
+        vm.makePersistent(address(calc));
+        vm.createSelectFork(ethRPC, BLOCK_NUMBER_RECENT);
+
+        vm.label(POOL, "Pool");
+        vm.label(LP_TOKEN, "LP_TOKEN");
+        vm.label(DAI, "DAI");
+        vm.label(USDC, "USDC");
+        vm.label(USDT, "USDT");
+    }
+
+    function testCalculateAddLiquidity(uint256[3] memory amounts_) public {
+        uint256[] memory amounts = castArray(amounts_);
+        boundTokenAmounts(amounts);
+        vm.assume(amounts[0] > 0 || amounts[1] > 0 || amounts[2] > 0);
+        checkAddLiquidityQuote(amounts);
+    }
+
+    function testCalculateAddLiquidityRevertsWhenArrayTooShort() public {
+        uint256[] memory amounts = new uint256[](2);
+        vm.expectRevert("Incorrect tokens amount");
+        calc.calculateAddLiquidity(POOL, amounts);
+    }
+
+    function testCalculateAddLiquidityRevertsWhenArrayTooLong() public {
+        uint256[] memory amounts = new uint256[](4);
+        vm.expectRevert("Out of range");
+        calc.calculateAddLiquidity(POOL, amounts);
+    }
+
+    function testCalculateAddLiquidityWhenPoolEmpty(uint256 amount, uint256[3] memory amounts_) public {
+        amount = bound(amount, MIN_ADD_AMOUNT, MAX_AMOUNT);
+        // limit the initial pool offset to 10% so that StableSwap Math converges
+        uint256 amountMin = (amount * 9) / 10;
+        uint256 amountMax = (amount * 11) / 10;
+        amounts_[0] = bound(amounts_[0], amountMin * 10**18, amountMax * 10**18);
+        amounts_[1] = bound(amounts_[1], amountMin * 10**6, amountMax * 10**6);
+        amounts_[2] = bound(amounts_[2], amountMin * 10**6, amountMax * 10**6);
+        uint256[] memory amounts = castArray(amounts_);
+        vm.createSelectFork(ethRPC, BLOCK_NUMBER_POOL_EMPTY);
+        checkAddLiquidityQuote(amounts);
+    }
+
+    function testCalculateAddLiquidityWhenPoolEmptyRevertsWhenZeroAmount() public {
+        vm.createSelectFork(ethRPC, BLOCK_NUMBER_POOL_EMPTY);
+        uint256[] memory amounts = new uint256[](3);
+        // Iterate over all from [0,0,0] to [1,1,0]
+        for (uint256 mask = 0; mask < 7; ++mask) {
+            amounts[0] = (mask & 1) * 10**18;
+            amounts[1] = ((mask >> 1) & 1) * 10**6;
+            amounts[2] = ((mask >> 2) & 1) * 10**6;
+            vm.expectRevert("Must supply all tokens in pool");
+            calc.calculateAddLiquidity(POOL, amounts);
+        }
+    }
+
+    function checkAddLiquidityQuote(uint256[] memory amounts) public {
+        uint256 amountOut = calc.calculateAddLiquidity(POOL, amounts);
+        prepareTokens(amounts);
+        if (amountOut == 0) vm.expectRevert("LPToken: cannot mint 0");
+        vm.prank(user);
+        IDefaultExtendedPool(POOL).addLiquidity(amounts, 0, type(uint256).max);
+        assertEq(IERC20(LP_TOKEN).balanceOf(user), amountOut);
+    }
+
+    function prepareTokens(uint256[] memory amounts) public {
+        deal(DAI, user, amounts[0]);
+        deal(USDC, user, amounts[1]);
+        deal(USDT, user, amounts[2]);
+        vm.startPrank(user);
+        IERC20(DAI).safeApprove(POOL, amounts[0]);
+        IERC20(USDC).safeApprove(POOL, amounts[1]);
+        IERC20(USDT).safeApprove(POOL, amounts[2]);
+    }
+
+    function boundTokenAmounts(uint256[] memory amounts) public pure {
+        amounts[0] = amounts[0] % (MAX_AMOUNT * 10**18);
+        amounts[1] = amounts[1] % (MAX_AMOUNT * 10**6);
+        amounts[2] = amounts[2] % (MAX_AMOUNT * 10**6);
+    }
+
+    function castArray(uint256[3] memory amounts) public pure returns (uint256[] memory casted) {
+        casted = new uint256[](3);
+        casted[0] = amounts[0];
+        casted[1] = amounts[1];
+        casted[2] = amounts[2];
+    }
+}


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

Isolated from #249 for the sake of keeping the PRs smaller.

Adds `DefaultPoolCalc`, which exposes a single function for quoting the amount of LP tokens obtained after addining liquidity to the pool. This function is not exposed in the pool (contrary to quotes for removing liquidity). The use cases:

- `SynapseRouter` periphery will be using this to get `DAI/USDC/USDT -> nUSD` quotes on Mainnet.
- SDK/UI could use this to provide accurate quotes for adding liquidity on other chains.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
