### PR TITLE
Fix: linked pool swap event

### DIFF
--- a/contracts/router/LinkedPool.sol
+++ b/contracts/router/LinkedPool.sol
@@ -29,6 +29,9 @@ contract LinkedPool is TokenTree, Ownable, ILinkedPool {
     using SafeERC20 for IERC20;
     using UniversalTokenLib for address;
 
+    /// @notice Replicates signature of `TokenSwap` event from Default Pools.
+    event TokenSwap(address indexed buyer, uint256 tokensSold, uint256 tokensBought, uint128 soldId, uint128 boughtId);
+
     // solhint-disable-next-line no-empty-blocks
     constructor(address bridgeToken) TokenTree(bridgeToken) {}
 
@@ -80,6 +83,8 @@ contract LinkedPool is TokenTree, Ownable, ILinkedPool {
         require(amountOut >= minDy, "Swap didn't result in min tokens");
         // Transfer the tokens to the user
         IERC20(_nodes[nodeIndexTo].token).safeTransfer(msg.sender, amountOut);
+        // Emit the event
+        emit TokenSwap(msg.sender, dx, amountOut, nodeIndexFrom, nodeIndexTo);
     }
 
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════

--- a/test/router/LinkedPool.t.sol
+++ b/test/router/LinkedPool.t.sol
@@ -10,6 +10,8 @@ import {Test} from "forge-std/Test.sol";
 
 // solhint-disable func-name-mixedcase
 contract LinkedPoolTest is Test {
+    event TokenSwap(address indexed buyer, uint256 tokensSold, uint256 tokensBought, uint128 soldId, uint128 boughtId);
+
     uint256 public maskOnlySwap = Action.Swap.mask();
     uint256 public maskNoSwaps = type(uint256).max ^ Action.Swap.mask();
 
@@ -817,6 +819,9 @@ contract LinkedPoolTest is Test {
         prepareUser(tokenIn, amountIn);
         address tokenOut = linkedPool.getToken(tokenTo);
         uint256 amountOut = linkedPool.calculateSwap(tokenFrom, tokenTo, amountIn);
+        // Expect a TokenSwap event
+        vm.expectEmit();
+        emit TokenSwap(user, amountIn, amountOut, tokenFrom, tokenTo);
         vm.prank(user);
         linkedPool.swap(tokenFrom, tokenTo, amountIn, amountOut, block.timestamp);
         if (tokenIn != tokenOut) assertEq(MockERC20(tokenIn).balanceOf(user), 0);


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

Added a `TokenSwap` event to `LinkedPool` contract, which replicates a post-swap event from the default pools. Would be useful for indexing, as the underlying pools in `LinkedPool` might emit different types of events post swaps.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
