### PR TITLE
Feat: bridge module for `SynapseCCTP`

### DIFF
--- a/contracts/router/modules/bridge/SynapseCCTPModule.sol
+++ b/contracts/router/modules/bridge/SynapseCCTPModule.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {OnlyDelegateCall} from "../pool/OnlyDelegateCall.sol";
+import {IBridgeModule} from "../../interfaces/IBridgeModule.sol";
+import {BridgeToken, SwapQuery} from "../../libs/Structs.sol";
+
+import {ISynapseCCTP} from "../../../cctp/interfaces/ISynapseCCTP.sol";
+import {ISynapseCCTPFees} from "../../../cctp/interfaces/ISynapseCCTPFees.sol";
+
+contract SynapseCCTPModule is OnlyDelegateCall, IBridgeModule {
+    /// These need to be immutable in order to be accessed via delegatecall
+    address public immutable synapseCCTP;
+
+    constructor(address synapseCCTP_) {
+        synapseCCTP = synapseCCTP_;
+    }
+
+    /// @inheritdoc IBridgeModule
+    function delegateBridge(
+        address to,
+        uint256 chainId,
+        address token,
+        uint256 amount,
+        SwapQuery memory destQuery
+    ) external payable {
+        assertDelegateCall();
+    }
+
+    // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
+
+    /// @inheritdoc IBridgeModule
+    function getMaxBridgedAmount(address token) external view returns (uint256 amount) {}
+
+    /// @inheritdoc IBridgeModule
+    function calculateFeeAmount(
+        address token,
+        uint256 amount,
+        bool isSwap
+    ) external view returns (uint256 fee) {}
+
+    /// @inheritdoc IBridgeModule
+    function getBridgeTokens() external view returns (BridgeToken[] memory bridgeTokens) {}
+
+    /// @inheritdoc IBridgeModule
+    function symbolToToken(string memory symbol) external view returns (address token) {}
+
+    /// @inheritdoc IBridgeModule
+    function tokenToSymbol(address token) external view returns (string memory symbol) {}
+
+    /// @inheritdoc IBridgeModule
+    function tokenToActionMask(address token) external view returns (uint256 actionMask) {}
+}

--- a/contracts/router/modules/bridge/SynapseCCTPModule.sol
+++ b/contracts/router/modules/bridge/SynapseCCTPModule.sol
@@ -120,6 +120,10 @@ contract SynapseCCTPModule is OnlyDelegateCall, IBridgeModule {
         DefaultParams memory params = abi.decode(destQuery.rawParams, (DefaultParams));
         // Actions other than swap are not supported for Circle tokens on the destination chain
         if (params.action != Action.Swap) revert SynapseCCTPModule__UnsupportedAction(params.action);
+        // Don't allow having the same token index for `tokenIndexFrom` and `tokenIndexTo`
+        if (params.tokenIndexFrom == params.tokenIndexTo) {
+            revert SynapseCCTPModule__EqualSwapIndexes(params.tokenIndexFrom);
+        }
         requestVersion = RequestLib.REQUEST_SWAP;
         swapParams = RequestLib.formatSwapParams({
             tokenIndexFrom: params.tokenIndexFrom,

--- a/contracts/router/modules/bridge/SynapseCCTPModule.sol
+++ b/contracts/router/modules/bridge/SynapseCCTPModule.sol
@@ -15,6 +15,7 @@ import {ITokenMinter} from "../../../cctp/interfaces/ITokenMinter.sol";
 contract SynapseCCTPModule is OnlyDelegateCall, IBridgeModule {
     using UniversalTokenLib for address;
 
+    error SynapseCCTPModule__EqualSwapIndexes(uint8 index);
     error SynapseCCTPModule__UnsupportedAction(Action action);
     error SynapseCCTPModule__UnsupportedToken(address token);
 

--- a/contracts/router/modules/bridge/SynapseCCTPModule.sol
+++ b/contracts/router/modules/bridge/SynapseCCTPModule.sol
@@ -3,12 +3,16 @@ pragma solidity 0.8.17;
 
 import {OnlyDelegateCall} from "../pool/OnlyDelegateCall.sol";
 import {IBridgeModule} from "../../interfaces/IBridgeModule.sol";
-import {BridgeToken, SwapQuery} from "../../libs/Structs.sol";
+import {IPausable} from "../../interfaces/IPausable.sol";
+import {Action, BridgeToken, SwapQuery} from "../../libs/Structs.sol";
 
 import {ISynapseCCTP} from "../../../cctp/interfaces/ISynapseCCTP.sol";
 import {ISynapseCCTPFees} from "../../../cctp/interfaces/ISynapseCCTPFees.sol";
+import {ITokenMinter} from "../../../cctp/interfaces/ITokenMinter.sol";
 
 contract SynapseCCTPModule is OnlyDelegateCall, IBridgeModule {
+    error SynapseCCTPModule__UnsupportedToken(address token);
+
     /// These need to be immutable in order to be accessed via delegatecall
     address public immutable synapseCCTP;
 
@@ -30,24 +34,56 @@ contract SynapseCCTPModule is OnlyDelegateCall, IBridgeModule {
     // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
 
     /// @inheritdoc IBridgeModule
-    function getMaxBridgedAmount(address token) external view returns (uint256 amount) {}
+    function getMaxBridgedAmount(address token) external view returns (uint256 amount) {
+        // Return 0 if the token is not supported
+        if (!_isSupported(token)) return 0;
+        // Check if it is possible to send Circle tokens (it is always possible to receive them though).
+        if (IPausable(synapseCCTP).paused()) return 0;
+        // Get the TokenMinter contract that is used to mint Circle tokens
+        address tokenMinter = ISynapseCCTP(synapseCCTP).tokenMessenger().localMinter();
+        // Maximal amount of tokens that can be bridged is determined by the burn limits per message
+        return ITokenMinter(tokenMinter).burnLimitsPerMessage(token);
+    }
 
     /// @inheritdoc IBridgeModule
     function calculateFeeAmount(
         address token,
         uint256 amount,
         bool isSwap
-    ) external view returns (uint256 fee) {}
+    ) external view returns (uint256 fee) {
+        // Revert if the token is not supported rather than returning 0 fee to avoid confusion
+        if (!_isSupported(token)) revert SynapseCCTPModule__UnsupportedToken(token);
+        return ISynapseCCTPFees(synapseCCTP).calculateFeeAmount(token, amount, isSwap);
+    }
 
     /// @inheritdoc IBridgeModule
-    function getBridgeTokens() external view returns (BridgeToken[] memory bridgeTokens) {}
+    function getBridgeTokens() external view returns (BridgeToken[] memory bridgeTokens) {
+        return ISynapseCCTPFees(synapseCCTP).getBridgeTokens();
+    }
 
     /// @inheritdoc IBridgeModule
-    function symbolToToken(string memory symbol) external view returns (address token) {}
+    function symbolToToken(string memory symbol) external view returns (address token) {
+        return ISynapseCCTPFees(synapseCCTP).symbolToToken(symbol);
+    }
 
     /// @inheritdoc IBridgeModule
-    function tokenToSymbol(address token) external view returns (string memory symbol) {}
+    function tokenToSymbol(address token) external view returns (string memory symbol) {
+        return ISynapseCCTPFees(synapseCCTP).tokenToSymbol(token);
+    }
 
     /// @inheritdoc IBridgeModule
-    function tokenToActionMask(address token) external view returns (uint256 actionMask) {}
+    function tokenToActionMask(address token) external view returns (uint256 actionMask) {
+        // Return empty mask if the token is not supported
+        if (!_isSupported(token)) return 0;
+        // SynapseCCTP only supports Action.Swap
+        return Action.Swap.mask();
+    }
+
+    // ══════════════════════════════════════════════ INTERNAL LOGIC ═══════════════════════════════════════════════════
+
+    /// @dev Checks if a token is supported by SynapseCCTP.
+    function _isSupported(address token) internal view returns (bool) {
+        // Token is supported if the symbol is not empty
+        return bytes(ISynapseCCTPFees(synapseCCTP).tokenToSymbol(token)).length > 0;
+    }
 }

--- a/test/router/modules/bridge/DelegateCaller.sol
+++ b/test/router/modules/bridge/DelegateCaller.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {Address} from "@openzeppelin/contracts-4.5.0/utils/Address.sol";
+
+contract DelegateCaller {
+    using Address for address;
+
+    function performDelegateCall(address target, bytes memory data) external payable {
+        target.functionDelegateCall(data);
+    }
+}

--- a/test/router/modules/bridge/SynapseCCTPModule.t.sol
+++ b/test/router/modules/bridge/SynapseCCTPModule.t.sol
@@ -297,6 +297,19 @@ contract SynapseCCTPModuleTest is BaseCCTPTest {
         performDelegateCall(payload);
     }
 
+    function testDelegateBridgeRevertsWhenAdapterAndEmptyParams() public {
+        SwapQuery memory destQuery = SwapQuery({
+            routerAdapter: address(delegateCaller),
+            tokenOut: address(0),
+            minAmountOut: 0,
+            deadline: 0,
+            rawParams: ""
+        });
+        bytes memory payload = getModulePayload({bridgeToken: token, destQuery: destQuery});
+        vm.expectRevert(SynapseCCTPModule.SynapseCCTPModule__NoParamsFound.selector);
+        performDelegateCall(payload);
+    }
+
     // ═══════════════════════════════════════════════ TESTS: VIEWS ════════════════════════════════════════════════════
 
     function testGetMaxBridgedAmountReturnsMaxBurnAmountForSupportedToken() public {

--- a/test/router/modules/bridge/SynapseCCTPModule.t.sol
+++ b/test/router/modules/bridge/SynapseCCTPModule.t.sol
@@ -275,6 +275,28 @@ contract SynapseCCTPModuleTest is BaseCCTPTest {
         performDelegateCall(payload);
     }
 
+    function testDelegateBridgeRevertsWhenSwapWithEqualIndexes() public {
+        SwapQuery memory destQuery = SwapQuery({
+            routerAdapter: address(delegateCaller),
+            tokenOut: TOKEN_OUT,
+            minAmountOut: MIN_AMOUNT_OUT,
+            deadline: DEADLINE,
+            rawParams: abi.encode(
+                DefaultParams({
+                    action: Action.Swap,
+                    pool: POOL,
+                    tokenIndexFrom: TOKEN_INDEX_FROM,
+                    tokenIndexTo: TOKEN_INDEX_FROM
+                })
+            )
+        });
+        bytes memory payload = getModulePayload({bridgeToken: token, destQuery: destQuery});
+        vm.expectRevert(
+            abi.encodeWithSelector(SynapseCCTPModule.SynapseCCTPModule__EqualSwapIndexes.selector, TOKEN_INDEX_FROM)
+        );
+        performDelegateCall(payload);
+    }
+
     // ═══════════════════════════════════════════════ TESTS: VIEWS ════════════════════════════════════════════════════
 
     function testGetMaxBridgedAmountReturnsMaxBurnAmountForSupportedToken() public {

--- a/test/router/modules/bridge/SynapseCCTPModule.t.sol
+++ b/test/router/modules/bridge/SynapseCCTPModule.t.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+// prettier-ignore
+import {
+    Action,
+    BridgeToken,
+    DefaultParams,
+    SwapQuery,
+    SynapseCCTPModule
+} from "../../../../contracts/router/modules/bridge/SynapseCCTPModule.sol";
+import {SynapseCCTP} from "../../../../contracts/cctp/SynapseCCTP.sol";
+
+import {BaseCCTPTest} from "../../../cctp/BaseCCTP.t.sol";
+import {DelegateCaller} from "./DelegateCaller.sol";
+
+contract SynapseCCTPModuleTest is BaseCCTPTest {
+    // 1M USDC
+    uint256 public constant MAX_BURN_AMOUNT = 10**6 * 10**6;
+    string public constant SYMBOL_USDC = "CCTP.MockC";
+
+    SynapseCCTP public synapseCCTP;
+    address public token;
+    address public unknownToken;
+
+    SynapseCCTPModule public module;
+    DelegateCaller public delegateCaller;
+
+    function setUp() public virtual override {
+        super.setUp();
+        setBurnLimitPerMessage(DOMAIN_ETH);
+
+        synapseCCTP = synapseCCTPs[DOMAIN_ETH];
+        token = address(cctpSetups[DOMAIN_ETH].mintBurnToken);
+        // Use "MockT" token as the unknown token
+        unknownToken = address(poolSetups[DOMAIN_ETH].token);
+
+        delegateCaller = new DelegateCaller();
+        module = new SynapseCCTPModule(address(synapseCCTP));
+    }
+
+    function setBurnLimitPerMessage(uint32 domain) public {
+        cctpSetups[domain].tokenMinter.setBurnLimitPerMessage(
+            address(cctpSetups[domain].mintBurnToken),
+            MAX_BURN_AMOUNT
+        );
+    }
+
+    function testConstructor() public {
+        assertEq(module.synapseCCTP(), address(synapseCCTP));
+    }
+
+    // ═══════════════════════════════════════════════ TESTS: VIEWS ════════════════════════════════════════════════════
+
+    function testGetMaxBridgedAmountReturnsMaxBurnAmountForSupportedToken() public {
+        assertEq(module.getMaxBridgedAmount(token), MAX_BURN_AMOUNT);
+    }
+
+    function testGetMaxBridgedAmountReturnsZeroForUnsupportedToken() public {
+        assertEq(module.getMaxBridgedAmount(unknownToken), 0);
+    }
+
+    // uint128 to prevent multiplication overflow in tests
+    function testCalculateFeeAmountWhenSwap(uint128 amount) public {
+        uint256 expectedFee = synapseCCTP.calculateFeeAmount(token, amount, true);
+        assertEq(module.calculateFeeAmount(token, amount, true), expectedFee);
+    }
+
+    // uint128 to prevent multiplication overflow in tests
+    function testCalculateFeeAmountWhenNoSwap(uint128 amount) public {
+        uint256 expectedFee = synapseCCTP.calculateFeeAmount(token, amount, false);
+        assertEq(module.calculateFeeAmount(token, amount, false), expectedFee);
+    }
+
+    function testCalculateFeeAmountRevertsForUnsupportedToken() public {
+        bytes memory expectedError = abi.encodeWithSelector(
+            SynapseCCTPModule.SynapseCCTPModule__UnsupportedToken.selector,
+            unknownToken
+        );
+        vm.expectRevert(expectedError);
+        module.calculateFeeAmount(unknownToken, 0, false);
+        vm.expectRevert(expectedError);
+        module.calculateFeeAmount(unknownToken, 0, true);
+    }
+
+    function testGetBridgeTokens() public {
+        BridgeToken[] memory bridgeTokens = module.getBridgeTokens();
+        assertEq(bridgeTokens.length, 1);
+        assertEq(bridgeTokens[0].symbol, SYMBOL_USDC);
+        assertEq(bridgeTokens[0].token, token);
+    }
+
+    function testGetBridgeTokensWhenZeroTokens() public {
+        address cctpOwner = synapseCCTP.owner();
+        vm.prank(cctpOwner);
+        synapseCCTP.removeToken(token);
+        BridgeToken[] memory bridgeTokens = module.getBridgeTokens();
+        assertEq(bridgeTokens.length, 0);
+    }
+
+    function testSymbolToToken() public {
+        assertEq(module.symbolToToken(SYMBOL_USDC), token);
+    }
+
+    function testSymbolToTokenReturnsZeroForUnknownSymbol() public {
+        assertEq(module.symbolToToken("MockT"), address(0));
+    }
+
+    function testTokenToSymbol() public {
+        assertEq(module.tokenToSymbol(token), SYMBOL_USDC);
+    }
+
+    function testTokenToSymbolReturnsEmptyStringForUnknownToken() public {
+        assertEq(module.tokenToSymbol(unknownToken), "");
+    }
+
+    function testTokenToActionMask() public {
+        uint256 expectedMask = 1 << uint256(Action.Swap);
+        assertEq(module.tokenToActionMask(token), expectedMask);
+    }
+
+    function testTokenToActionMaskReturnsZeroForUnknownToken() public {
+        assertEq(module.tokenToActionMask(unknownToken), 0);
+    }
+}

--- a/test/router/modules/bridge/SynapseCCTPModule.t.sol
+++ b/test/router/modules/bridge/SynapseCCTPModule.t.sol
@@ -281,6 +281,13 @@ contract SynapseCCTPModuleTest is BaseCCTPTest {
         assertEq(module.getMaxBridgedAmount(token), MAX_BURN_AMOUNT);
     }
 
+    function testGetMaxBridgedAmountReturnsZeroWhenSendingPaused() public {
+        address cctpOwner = synapseCCTP.owner();
+        vm.prank(cctpOwner);
+        synapseCCTP.pauseSending();
+        assertEq(module.getMaxBridgedAmount(token), 0);
+    }
+
     function testGetMaxBridgedAmountReturnsZeroForUnsupportedToken() public {
         assertEq(module.getMaxBridgedAmount(unknownToken), 0);
     }

--- a/test/router/modules/bridge/SynapseCCTPModule.t.sol
+++ b/test/router/modules/bridge/SynapseCCTPModule.t.sol
@@ -11,13 +11,25 @@ import {
 } from "../../../../contracts/router/modules/bridge/SynapseCCTPModule.sol";
 import {SynapseCCTP} from "../../../../contracts/cctp/SynapseCCTP.sol";
 
-import {BaseCCTPTest} from "../../../cctp/BaseCCTP.t.sol";
+import {BaseCCTPTest, MockERC20, RequestLib} from "../../../cctp/BaseCCTP.t.sol";
 import {DelegateCaller} from "./DelegateCaller.sol";
 
 contract SynapseCCTPModuleTest is BaseCCTPTest {
     // 1M USDC
     uint256 public constant MAX_BURN_AMOUNT = 10**6 * 10**6;
     string public constant SYMBOL_USDC = "CCTP.MockC";
+    // Fake different values for bridging
+    address public constant TO = address(10);
+    uint256 public constant AMOUNT = 1 ether;
+    uint256 public constant MSG_VALUE = 2 ether;
+    // Fake values for SwapQuery
+    address public constant TOKEN_OUT = address(20);
+    uint256 public constant MIN_AMOUNT_OUT = 30;
+    uint256 public constant DEADLINE = 40;
+    // Fake values for DefaultParams
+    address public constant POOL = address(50);
+    uint8 public constant TOKEN_INDEX_FROM = 60;
+    uint8 public constant TOKEN_INDEX_TO = 70;
 
     SynapseCCTP public synapseCCTP;
     address public token;
@@ -25,6 +37,8 @@ contract SynapseCCTPModuleTest is BaseCCTPTest {
 
     SynapseCCTPModule public module;
     DelegateCaller public delegateCaller;
+
+    bool public attachEther;
 
     function setUp() public virtual override {
         super.setUp();
@@ -37,6 +51,9 @@ contract SynapseCCTPModuleTest is BaseCCTPTest {
 
         delegateCaller = new DelegateCaller();
         module = new SynapseCCTPModule(address(synapseCCTP));
+
+        deal(address(this), MSG_VALUE);
+        cctpSetups[DOMAIN_ETH].mintBurnToken.mintPublic(address(delegateCaller), AMOUNT);
     }
 
     function setBurnLimitPerMessage(uint32 domain) public {
@@ -48,6 +65,123 @@ contract SynapseCCTPModuleTest is BaseCCTPTest {
 
     function testConstructor() public {
         assertEq(module.synapseCCTP(), address(synapseCCTP));
+    }
+
+    // ══════════════════════════════════════════════ TESTS: BRIDGING ══════════════════════════════════════════════════
+
+    function testDelegateBridgeRevertsWhenDirectCall() public {
+        SwapQuery memory emptyQuery;
+        vm.expectRevert("Not a delegate call");
+        module.delegateBridge(address(0), 0, address(0), 0, emptyQuery);
+    }
+
+    function verifyTokenBalance() public virtual {
+        assertEq(MockERC20(token).balanceOf(address(delegateCaller)), 0);
+        assertEq(MockERC20(token).balanceOf(address(synapseCCTP)), 0);
+    }
+
+    function performDelegateCall(bytes memory payload) public {
+        if (attachEther) {
+            delegateCaller.performDelegateCall{value: MSG_VALUE}(address(module), payload);
+        } else {
+            delegateCaller.performDelegateCall(address(module), payload);
+        }
+    }
+
+    // Flow for all delegateBridge tests:
+    // - Tokens were minted to `delegateCaller` contract in setUp(), which is mock for SynapseRouterV2
+    // - `delegateCaller` issues a delegate call to `module.delegateBridge()` which should initiate the bridging
+    // module.delegateBridge(address to, uint256 chainId, address token, uint256 AMOUNT, SwapQuery memory destQuery)
+
+    function getModulePayload(bool isBaseRequest) public view returns (bytes memory payload) {
+        SwapQuery memory destQuery;
+        if (!isBaseRequest) {
+            destQuery = SwapQuery({
+                routerAdapter: address(delegateCaller),
+                tokenOut: TOKEN_OUT,
+                minAmountOut: MIN_AMOUNT_OUT,
+                deadline: DEADLINE,
+                rawParams: abi.encode(
+                    DefaultParams({
+                        action: Action.Swap,
+                        pool: POOL,
+                        tokenIndexFrom: TOKEN_INDEX_FROM,
+                        tokenIndexTo: TOKEN_INDEX_TO
+                    })
+                )
+            });
+        }
+        payload = abi.encodeWithSelector(module.delegateBridge.selector, TO, CHAINID_AVAX, token, AMOUNT, destQuery);
+    }
+
+    function expectSynapseCCTPEvent(bool isBaseRequest) public {
+        uint32 requestVersion = isBaseRequest ? RequestLib.REQUEST_BASE : RequestLib.REQUEST_SWAP;
+        bytes memory swapParams = isBaseRequest
+            ? bytes("")
+            : RequestLib.formatSwapParams({
+                tokenIndexFrom: TOKEN_INDEX_FROM,
+                tokenIndexTo: TOKEN_INDEX_TO,
+                deadline: DEADLINE,
+                minAmountOut: MIN_AMOUNT_OUT
+            });
+        uint64 nonce = cctpSetups[DOMAIN_ETH].messageTransmitter.nextAvailableNonce();
+        bytes memory expectedRequest = RequestLib.formatRequest({
+            requestVersion: requestVersion,
+            baseRequest: RequestLib.formatBaseRequest({
+                originDomain: DOMAIN_ETH,
+                nonce: nonce,
+                originBurnToken: token,
+                amount: AMOUNT,
+                recipient: TO
+            }),
+            swapParams: swapParams
+        });
+        bytes32 expectedRequestID = getExpectedrequestID({
+            originDomain: DOMAIN_ETH,
+            destinationDomain: DOMAIN_AVAX,
+            finalRecipient: TO,
+            originBurnToken: token,
+            amount: AMOUNT,
+            requestVersion: requestVersion,
+            swapParams: swapParams
+        });
+        vm.expectEmit(address(synapseCCTP));
+        emit CircleRequestSent({
+            chainId: CHAINID_AVAX,
+            sender: msg.sender,
+            nonce: nonce,
+            token: token,
+            amount: AMOUNT,
+            requestVersion: requestVersion,
+            formattedRequest: expectedRequest,
+            requestID: expectedRequestID
+        });
+    }
+
+    function testDelegateBridgeBaseRequest() public {
+        bytes memory payload = getModulePayload({isBaseRequest: true});
+        expectSynapseCCTPEvent({isBaseRequest: true});
+        performDelegateCall(payload);
+        verifyTokenBalance();
+    }
+
+    function testDelegateBridgeSwapRequest() public {
+        bytes memory payload = getModulePayload({isBaseRequest: false});
+        expectSynapseCCTPEvent({isBaseRequest: false});
+        performDelegateCall(payload);
+        verifyTokenBalance();
+    }
+
+    // ═══════════════════════════════════ TESTS: BRIDGING (WITH ETHER ATTACHED) ═══════════════════════════════════════
+
+    function testDelegateBridgeBaseRequestWithEther() public {
+        attachEther = true;
+        testDelegateBridgeBaseRequest();
+    }
+
+    function testDelegateBridgeSwapRequestWithEther() public {
+        attachEther = true;
+        testDelegateBridgeSwapRequest();
     }
 
     // ═══════════════════════════════════════════════ TESTS: VIEWS ════════════════════════════════════════════════════


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

Adds a Bridge Module for `SynapseCCTP` contract to be used with new `SynapseRouterV2` contract. 
- It is using `SynapseCCTP` to get the supported tokens configuration.
- Older deployment of `SynapseCCTPRouter` is ignored, and its logic is reimplemented in the module.

Leaving links for reference:
- https://github.com/synapsecns/synapse-contracts/blob/master/contracts/cctp/SynapseCCTP.sol
- https://github.com/synapsecns/synapse-contracts/blob/master/contracts/cctp/fees/SynapseCCTPFees.sol

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
