### PR TITLE
Fix: events and errors in `LinkedPool`

### DIFF
--- a/contracts/router/LinkedPool.sol
+++ b/contracts/router/LinkedPool.sol
@@ -50,9 +50,8 @@ contract LinkedPool is TokenTree, Ownable, ILinkedPool {
         uint256 nodeIndex,
         address pool,
         address poolModule
-    ) external onlyOwner {
+    ) external onlyOwner checkIndex(nodeIndex) {
         require(pool != address(0), "Pool address can't be zero");
-        // This will revert if index is out of range, see TokenTree._addPool()
         _addPool(nodeIndex, pool, poolModule);
     }
 

--- a/contracts/router/tree/TokenTree.sol
+++ b/contracts/router/tree/TokenTree.sol
@@ -115,11 +115,12 @@ abstract contract TokenTree {
 
     /// @dev Adds a pool having `N` pool tokens to the tree by adding `N-1` new nodes
     /// as the children of the given node. Given node needs to represent a token from the pool.
+    /// Note: assumes that nodeIndex is valid, and that pool is not a zero address.
     function _addPool(
         uint256 nodeIndex,
         address pool,
         address poolModule
-    ) internal checkIndex(nodeIndex) {
+    ) internal {
         Node memory node = _nodes[nodeIndex];
         if (poolModule == address(0)) poolModule = address(this);
         (bool wasAdded, uint8 poolIndex) = (false, _poolMap[pool].index);

--- a/contracts/router/tree/TokenTree.sol
+++ b/contracts/router/tree/TokenTree.sol
@@ -26,6 +26,7 @@ abstract contract TokenTree {
     error TokenTree__NodeTokenNotInPool();
     error TokenTree__PoolAlreadyAttached();
     error TokenTree__PoolAlreadyOnRootPath();
+    error TokenTree__SwapPoolUsedTwice(address pool);
     error TokenTree__TooManyNodes();
     error TokenTree__TooManyPools();
     error TokenTree__UnknownPool();
@@ -363,13 +364,11 @@ abstract contract TokenTree {
         uint256 nodeIndexTo,
         uint256 amountIn
     ) internal returns (uint256 visitedPoolsMask_, uint256 amountOut) {
-        if (visitedPoolsMask & (1 << poolIndex) != 0) {
-            // If we already used this pool on the path, we can't use it again.
-            revert("Can't use same pool twice");
-        }
+        address pool = _pools[poolIndex];
+        // If we already used this pool on the path, we can't use it again.
+        if (visitedPoolsMask & (1 << poolIndex) != 0) revert TokenTree__SwapPoolUsedTwice(pool);
         // Mark the pool as visited
         visitedPoolsMask_ = visitedPoolsMask | (1 << poolIndex);
-        address pool = _pools[poolIndex];
         amountOut = _poolSwap(_poolMap[pool].module, pool, nodeIndexFrom, nodeIndexTo, amountIn);
     }
 

--- a/contracts/router/tree/TokenTree.sol
+++ b/contracts/router/tree/TokenTree.sol
@@ -97,6 +97,11 @@ abstract contract TokenTree {
         _pools.push(address(0));
     }
 
+    modifier checkIndex(uint256 nodeIndex) {
+        require(nodeIndex < _nodes.length, "Out of range");
+        _;
+    }
+
     // ══════════════════════════════════════════════ INTERNAL LOGIC ═══════════════════════════════════════════════════
 
     /// @dev Adds a pool having `N` pool tokens to the tree by adding `N-1` new nodes
@@ -105,8 +110,7 @@ abstract contract TokenTree {
         uint256 nodeIndex,
         address pool,
         address poolModule
-    ) internal {
-        require(nodeIndex < _nodes.length, "Out of range");
+    ) internal checkIndex(nodeIndex) {
         Node memory node = _nodes[nodeIndex];
         if (poolModule == address(0)) poolModule = address(this);
         (bool wasAdded, uint8 poolIndex) = (false, _poolMap[pool].index);

--- a/contracts/router/tree/TokenTree.sol
+++ b/contracts/router/tree/TokenTree.sol
@@ -104,10 +104,10 @@ abstract contract TokenTree {
     // ════════════════════════════════════════════════ CONSTRUCTOR ════════════════════════════════════════════════════
 
     constructor(address bridgeToken) {
-        // The root node is always the bridge token
-        _addNode({token: bridgeToken, depth: 0, poolIndex: 0, rootPathParent: 0});
         // Push the empty pool so that `poolIndex` for non-root nodes is never 0
         _pools.push(address(0));
+        // The root node is always the bridge token
+        _addNode({token: bridgeToken, depth: 0, poolIndex: 0, rootPathParent: 0});
     }
 
     modifier checkIndex(uint256 nodeIndex) {

--- a/test/router/LinkedPool.t.sol
+++ b/test/router/LinkedPool.t.sol
@@ -234,7 +234,7 @@ contract LinkedPoolTest is Test {
 
     function test_addPool_revert_emptyPoolAddress() public {
         complexSetup();
-        vm.expectRevert("Pool address can't be zero");
+        vm.expectRevert(LinkedPool.LinkedPool__EmptyPoolAddress.selector);
         vm.prank(owner);
         linkedPool.addPool(0, address(0), address(0));
     }
@@ -318,7 +318,7 @@ contract LinkedPoolTest is Test {
         complexSetup();
         uint256 tokensAmount = linkedPool.tokenNodesAmount();
         for (uint8 i = 0; i < tokensAmount; ++i) {
-            vm.expectRevert("Swap not supported");
+            vm.expectRevert(abi.encodeWithSelector(LinkedPool.LinkedPool__EqualSwapIndexes.selector, i));
             linkedPool.swap(i, i, 10**18, 0, type(uint256).max);
         }
     }
@@ -340,7 +340,9 @@ contract LinkedPoolTest is Test {
         complexSetup();
         uint8 tokensAmount = uint8(linkedPool.tokenNodesAmount());
         for (uint8 i = 0; i < tokensAmount; ++i) {
-            vm.expectRevert("Deadline not met");
+            vm.expectRevert(
+                abi.encodeWithSelector(LinkedPool.LinkedPool__DeadlineExceeded.selector, currentTime, currentTime - 1)
+            );
             linkedPool.swap(i, (i + 1) % tokensAmount, 10**18, 0, currentTime - 1);
         }
     }
@@ -350,7 +352,7 @@ contract LinkedPoolTest is Test {
         uint256 amountIn = 10**18;
         uint256 amountOut = linkedPool.calculateSwap(0, 1, amountIn);
         prepareUser(address(bridgeToken), amountIn);
-        vm.expectRevert("Swap didn't result in min tokens");
+        vm.expectRevert(abi.encodeWithSelector(LinkedPool.LinkedPool__MinDyNotMet.selector, amountOut, amountOut + 1));
         vm.prank(user);
         linkedPool.swap(0, 1, amountIn, amountOut + 1, type(uint256).max);
     }

--- a/test/router/LinkedPool.t.sol
+++ b/test/router/LinkedPool.t.sol
@@ -327,9 +327,9 @@ contract LinkedPoolTest is Test {
         complexSetup();
         uint8 tokensAmount = uint8(linkedPool.tokenNodesAmount());
         for (uint8 i = 0; i < tokensAmount; ++i) {
-            vm.expectRevert("Swap not supported");
+            vm.expectRevert("Out of range");
             linkedPool.swap(i, tokensAmount, 10**18, 0, type(uint256).max);
-            vm.expectRevert("Swap not supported");
+            vm.expectRevert("Out of range");
             linkedPool.swap(tokensAmount, i, 10**18, 0, type(uint256).max);
         }
     }

--- a/test/router/LinkedPool.t.sol
+++ b/test/router/LinkedPool.t.sol
@@ -1023,7 +1023,9 @@ contract LinkedPoolTest is Test {
         address tokenOut = linkedPool.getToken(tokenTo);
         uint256 amountOut = linkedPool.calculateSwap(tokenFrom, tokenTo, amountIn);
         vm.prank(user);
-        if (amountOut == 0) vm.expectRevert("Can't use same pool twice");
+        if (amountOut == 0) {
+            vm.expectRevert(abi.encodeWithSelector(TokenTree.TokenTree__SwapPoolUsedTwice.selector, pool123));
+        }
         linkedPool.swap(tokenFrom, tokenTo, amountIn, amountOut, block.timestamp);
         if (amountOut > 0) {
             if (tokenIn != tokenOut) assertEq(MockERC20(tokenIn).balanceOf(user), 0);

--- a/test/router/LinkedPoolModule.t.sol
+++ b/test/router/LinkedPoolModule.t.sol
@@ -15,23 +15,6 @@ contract LinkedPoolModuleTest is LinkedPoolTest {
         super.setUp();
     }
 
-    function test_swap_revert_poolPaused() public override {
-        complexSetup();
-        // Pause poolB01
-        poolB01.setPaused(true);
-        uint8 tokenFrom = 3;
-        uint8 tokenTo = 7;
-        uint256 amount = 100;
-        // This goes through the paused pool
-        address tokenIn = linkedPool.getToken(tokenFrom);
-        uint256 amountIn = amount * (10**MockERC20(tokenIn).decimals());
-        prepareUser(tokenIn, amountIn);
-        // Expect revert message for failed swap delegated to a pool module
-        vm.expectRevert("Swap failed");
-        vm.prank(user);
-        linkedPool.swap(tokenFrom, tokenTo, amountIn, 0, type(uint256).max);
-    }
-
     // ═════════════════════════════════════════ UPDATE POOL MODULE TESTS ══════════════════════════════════════════════
 
     function test_updatePoolModule() public {

--- a/test/router/LinkedPoolModule.t.sol
+++ b/test/router/LinkedPoolModule.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import {MockERC20, LinkedPoolTest} from "./LinkedPool.t.sol";
+import {MockERC20, LinkedPoolTest, TokenTree} from "./LinkedPool.t.sol";
 
 import {MockPoolModule} from "../mocks/MockPoolModule.sol";
 
@@ -47,7 +47,7 @@ contract LinkedPoolModuleTest is LinkedPoolTest {
             abi.encodeWithSelector(MockPoolModule.getPoolTokens.selector, poolB2),
             abi.encode(wrongTokensList)
         );
-        vm.expectRevert("Different token lists");
+        vm.expectRevert(TokenTree.TokenTree__DifferentTokenLists.selector);
         vm.prank(owner);
         linkedPool.updatePoolModule(address(poolB2), newPoolModule);
     }
@@ -65,7 +65,7 @@ contract LinkedPoolModuleTest is LinkedPoolTest {
             abi.encodeWithSelector(MockPoolModule.getPoolTokens.selector, poolB2),
             abi.encode(wrongTokensList)
         );
-        vm.expectRevert("Different token lists");
+        vm.expectRevert(TokenTree.TokenTree__DifferentTokenLists.selector);
         vm.prank(owner);
         linkedPool.updatePoolModule(address(poolB2), newPoolModule);
     }
@@ -82,7 +82,7 @@ contract LinkedPoolModuleTest is LinkedPoolTest {
             abi.encodeWithSelector(MockPoolModule.getPoolTokens.selector, poolB2),
             abi.encode(wrongTokensList)
         );
-        vm.expectRevert("Different token lists");
+        vm.expectRevert(TokenTree.TokenTree__DifferentTokenLists.selector);
         vm.prank(owner);
         linkedPool.updatePoolModule(address(poolB2), newPoolModule);
     }
@@ -99,7 +99,7 @@ contract LinkedPoolModuleTest is LinkedPoolTest {
             abi.encodeWithSelector(MockPoolModule.getPoolTokens.selector, poolB2),
             abi.encode(wrongTokensList)
         );
-        vm.expectRevert("Different token lists");
+        vm.expectRevert(TokenTree.TokenTree__DifferentTokenLists.selector);
         vm.prank(owner);
         linkedPool.updatePoolModule(address(poolB2), newPoolModule);
     }
@@ -116,7 +116,7 @@ contract LinkedPoolModuleTest is LinkedPoolTest {
             abi.encodeWithSelector(MockPoolModule.getPoolTokens.selector, poolB2),
             abi.encode(wrongTokensList)
         );
-        vm.expectRevert("Different token lists");
+        vm.expectRevert(TokenTree.TokenTree__DifferentTokenLists.selector);
         vm.prank(owner);
         linkedPool.updatePoolModule(address(poolB2), newPoolModule);
     }

--- a/test/router/LinkedPoolModule.t.sol
+++ b/test/router/LinkedPoolModule.t.sol
@@ -9,6 +9,8 @@ import {MockPoolModule} from "../mocks/MockPoolModule.sol";
 contract LinkedPoolModuleTest is LinkedPoolTest {
     address public newPoolModule;
 
+    event PoolModuleUpdated(address pool, address oldPoolModule, address newPoolModule);
+
     function setUp() public virtual override {
         poolModule = address(new MockPoolModule());
         newPoolModule = address(new MockPoolModule());
@@ -26,6 +28,18 @@ contract LinkedPoolModuleTest is LinkedPoolTest {
         assertEq(linkedPool.getPoolModule(address(poolB2)), newPoolModule);
         // Check that pool02 has old pool module
         assertEq(linkedPool.getPoolModule(address(pool02)), poolModule);
+    }
+
+    function test_updatePoolModule_emitsEvent() public {
+        // Setup with two pools: poolB2 and pool02
+        compactSetup();
+        vm.expectEmit();
+        emit PoolModuleUpdated(address(poolB2), poolModule, newPoolModule);
+        vm.recordLogs();
+        vm.prank(owner);
+        linkedPool.updatePoolModule(address(poolB2), newPoolModule);
+        // Should be exactly one event
+        assertEq(vm.getRecordedLogs().length, 1);
     }
 
     function test_updatePoolModule_revert_callerNotOwner(address caller) public {


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

To simplify the LinkedPool management:

- **Fix:** error thrown by pool modules is now bubbled (only applies for "external liquidity" such as GMX) to get more clarity around what caused the revert.
- **Fix**: events are now emitted on managements actions (add pool, update pool module).
- Chore: introduced `checkIndex` modifier to increase readbility.
- Chore: replaced string error messages with contract-specific custom errors.

https://github.com/synapsecns/synapse-contracts/blob/86fe0ceaf781a33072139e334e15f376249af743/contracts/router/LinkedPool.sol#L86

vs

https://github.com/synapsecns/synapse-contracts/blob/720eb37327526f8209efd0989a816b724f7e7ea1/contracts/router/LinkedPool.sol#L83

## Checklist

- [x] New Contracts have been tested
- [x] Lint has been run
- [x] I have checked my code and corrected any misspellings
