### PR TITLE
Fix: transfer ownership in `LinkedPool` constructor

### DIFF
--- a/contracts/router/LinkedPool.sol
+++ b/contracts/router/LinkedPool.sol
@@ -39,8 +39,9 @@ contract LinkedPool is TokenTree, Ownable, ILinkedPool {
     /// @notice Replicates signature of `TokenSwap` event from Default Pools.
     event TokenSwap(address indexed buyer, uint256 tokensSold, uint256 tokensBought, uint128 soldId, uint128 boughtId);
 
-    // solhint-disable-next-line no-empty-blocks
-    constructor(address bridgeToken) TokenTree(bridgeToken) {}
+    constructor(address bridgeToken, address owner_) TokenTree(bridgeToken) {
+        transferOwnership(owner_);
+    }
 
     // ═════════════════════════════════════════════════ EXTERNAL ══════════════════════════════════════════════════════
 

--- a/test/bridge/router/parityBoth/QuoterV2WithLinkedPoolSetup.t.sol
+++ b/test/bridge/router/parityBoth/QuoterV2WithLinkedPoolSetup.t.sol
@@ -18,8 +18,8 @@ abstract contract QuoterV2WithLinkedPoolSetup is Test {
         if (tokenToLinkedPool[bridgeToken] != address(0)) {
             return tokenToLinkedPool[bridgeToken];
         }
-        // Deploy 0.8 LinkedPool contract: new LinkedPool(bridgeToken)
-        linkedPool = deployCode("LinkedPool.sol", abi.encode(bridgeToken));
+        // Deploy 0.8 LinkedPool contract: new LinkedPool(bridgeToken, address(this))
+        linkedPool = deployCode("LinkedPool.sol", abi.encode(bridgeToken, address(this)));
         string memory symbol = ERC20(bridgeToken).symbol();
         vm.label(linkedPool, string(abi.encodePacked("LinkedPool[", symbol, "]")));
         // Add pool to LinkedPool

--- a/test/bridge/router/parityLinkedPool/LinkedPoolSetup.t.sol
+++ b/test/bridge/router/parityLinkedPool/LinkedPoolSetup.t.sol
@@ -19,8 +19,8 @@ abstract contract LinkedPoolSetup is Test {
     mapping(address => address) internal tokenToLinkedPool;
 
     function deployLinkedPool(address bridgeToken, address pool) public returns (address linkedPool) {
-        // Deploy 0.8 LinkedPool contract: new LinkedPool(bridgeToken)
-        linkedPool = deployCode("LinkedPool.sol", abi.encode(bridgeToken));
+        // Deploy 0.8 LinkedPool contract: new LinkedPool(bridgeToken, address(this))
+        linkedPool = deployCode("LinkedPool.sol", abi.encode(bridgeToken, address(this)));
         vm.label(linkedPool, "LinkedPool");
         // Add pool to LinkedPool
         ILinkedPool(linkedPool).addPool(0, pool, address(0));

--- a/test/router/LinkedPool.t.sol
+++ b/test/router/LinkedPool.t.sol
@@ -117,8 +117,7 @@ contract LinkedPoolTest is Test {
     }
 
     function simpleSetup() public {
-        linkedPool = new LinkedPool(address(bridgeToken));
-        linkedPool.transferOwnership(owner);
+        linkedPool = new LinkedPool(address(bridgeToken), owner);
     }
 
     function test_simpleSetup() public {
@@ -126,6 +125,11 @@ contract LinkedPoolTest is Test {
         assertEq(linkedPool.getToken(0), address(bridgeToken));
         assertEq(linkedPool.owner(), owner);
         assertEq(linkedPool.tokenNodesAmount(), 1);
+    }
+
+    function test_constructor_reverts_whenEmptyOwner() public {
+        vm.expectRevert("Ownable: new owner is the zero address");
+        linkedPool = new LinkedPool(address(bridgeToken), address(0));
     }
 
     function addPool(uint256 nodeIndex, address poolAddress) public {
@@ -218,7 +222,7 @@ contract LinkedPoolTest is Test {
     function test_constructor_emitsTokenNodeAdded() public {
         vm.expectEmit();
         emit TokenNodeAdded({childIndex: 0, token: address(bridgeToken), parentPool: address(0)});
-        linkedPool = new LinkedPool(address(bridgeToken));
+        linkedPool = new LinkedPool(address(bridgeToken), owner);
     }
 
     // Tests that add pool that wasn't previously added

--- a/test/router/modules/pool/LinkedPoolIntegration.t.sol
+++ b/test/router/modules/pool/LinkedPoolIntegration.t.sol
@@ -57,7 +57,7 @@ abstract contract LinkedPoolIntegrationTest is Test {
 
     function deployLinkedPool() public virtual {
         require(expectedTokens.length > 0, "No tokens provided");
-        linkedPool = new LinkedPool(expectedTokens[0]);
+        linkedPool = new LinkedPool(expectedTokens[0], address(this));
     }
 
     function addPools() public virtual;

--- a/test/router/modules/pool/curve/CurveV1ModuleArb.t.sol
+++ b/test/router/modules/pool/curve/CurveV1ModuleArb.t.sol
@@ -31,7 +31,7 @@ contract CurveV1ModuleArbTestFork is Test {
         vm.createSelectFork(arbRPC, ARB_BLOCK_NUMBER);
 
         curveV1Module = new CurveV1Module();
-        linkedPool = new LinkedPool(USDC_E);
+        linkedPool = new LinkedPool(USDC_E, address(this));
         user = makeAddr("User");
 
         vm.label(CURVE_V1_2POOL, "CurveV12Pool");

--- a/test/router/modules/pool/dss/DssPsmModule.t.sol
+++ b/test/router/modules/pool/dss/DssPsmModule.t.sol
@@ -31,7 +31,7 @@ contract DssPsmModuleEthTestFork is Test {
         vm.createSelectFork(ethRPC, ETH_BLOCK_NUMBER);
 
         dssPsmModule = new DssPsmModule();
-        linkedPool = new LinkedPool(DAI);
+        linkedPool = new LinkedPool(DAI, address(this));
         user = makeAddr("User");
 
         vm.label(DSS_PSM, "DssPsm");

--- a/test/router/modules/pool/gmx/GMXV1ModuleArb.t.sol
+++ b/test/router/modules/pool/gmx/GMXV1ModuleArb.t.sol
@@ -62,7 +62,7 @@ contract GMXV1ModuleArbTestFork is Test {
         vm.createSelectFork(arbRPC, ARB_BLOCK_NUMBER);
 
         gmxV1Module = new GMXV1StableArbitrumModule(GMX_V1_ROUTER, GMX_V1_READER);
-        linkedPool = new LinkedPool(USDC_E);
+        linkedPool = new LinkedPool(USDC_E, address(this));
         user = makeAddr("User");
 
         vm.label(GMX_V1_ROUTER, "GMXV1Router");

--- a/test/router/modules/pool/uniswap/UniswapV3ModuleArb.t.sol
+++ b/test/router/modules/pool/uniswap/UniswapV3ModuleArb.t.sol
@@ -37,7 +37,7 @@ contract UniswapV3ModuleArbTestFork is Test {
         vm.createSelectFork(arbRPC, ARB_BLOCK_NUMBER);
 
         uniswapV3Module = new UniswapV3Module(UNI_V3_ROUTER, UNI_V3_STATIC_QUOTER);
-        linkedPool = new LinkedPool(USDC);
+        linkedPool = new LinkedPool(USDC, address(this));
         user = makeAddr("User");
 
         vm.label(UNI_V3_ROUTER, "UniswapV3Router");

--- a/test/router/modules/pool/velodrome/VelodromeV2ModuleOpt.t.sol
+++ b/test/router/modules/pool/velodrome/VelodromeV2ModuleOpt.t.sol
@@ -34,7 +34,7 @@ contract VelodromeV2ModuleOptTestFork is Test {
         vm.createSelectFork(optRPC, OPT_BLOCK_NUMBER);
 
         velodromeV2Module = new VelodromeV2Module(VEL_V2_ROUTER);
-        linkedPool = new LinkedPool(OP);
+        linkedPool = new LinkedPool(OP, address(this));
         user = makeAddr("User");
 
         vm.label(VEL_V2_OPUSDC_POOL, "VelodromeV2OPUSDCPool");

--- a/test/utils/PoolUtils08.sol
+++ b/test/utils/PoolUtils08.sol
@@ -254,7 +254,7 @@ contract PoolUtils08 is Test {
         address pool,
         address poolModule
     ) public returns (address linkedPool) {
-        LinkedPool linkedPool_ = new LinkedPool(bridgeToken);
+        LinkedPool linkedPool_ = new LinkedPool(bridgeToken, address(this));
         linkedPool_.addPool(0, pool, poolModule);
         linkedPool = address(linkedPool_);
         vm.label(linkedPool, string.concat("LinkedPool [", IERC20Metadata(bridgeToken).symbol(), "]"));


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

This fix allows to deploy `LinkedPool` contract with owner other than `msg.sender`. This enables future factory deployments of `LinkedPool` contracts.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
