### PR TITLE
Feat: Synapse create3 factory

### DIFF
--- a/contracts/create3/SynapseCreate3Factory.sol
+++ b/contracts/create3/SynapseCreate3Factory.sol
@@ -12,6 +12,7 @@ import {Address} from "@openzeppelin/contracts-4.5.0/utils/Address.sol";
 /// @notice This contract provides a way to deploy contracts to the deterministic address, which
 /// doesn't depend on the creation code (aka EIP-3171, aka "CREATE3").
 /// Every deployer has access to their unique address deployment space of 2**96 addresses.
+/// This is achieved by forcing the first 20 bytes of the deployment salt to be equal to the deployer's address.
 contract SynapseCreate3Factory is ISynapseCreate3Factory {
     using Address for address;
 
@@ -44,6 +45,8 @@ contract SynapseCreate3Factory is ISynapseCreate3Factory {
         deployedAt = Create3Lib.create3(salt, creationCode, msg.value);
         // Perform initialization call if needed
         if (initData.length != 0) {
+            // Using OZ library here to bubble up the revert reason, if it exists.
+            // If it does not, the error will be "SynapseCreate3Factory__InitCallFailed()"
             deployedAt.functionCall(initData, string(_INIT_CALL_FAILED_SELECTOR));
         }
     }

--- a/contracts/create3/SynapseCreate3Factory.sol
+++ b/contracts/create3/SynapseCreate3Factory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
+import {Create3Lib} from "./libs/Create3.sol";
 import {ISynapseCreate3Factory} from "./interfaces/ISynapseCreate3Factory.sol";
 
 /// @title Synapse Create3 Contract Factory
@@ -10,13 +11,30 @@ import {ISynapseCreate3Factory} from "./interfaces/ISynapseCreate3Factory.sol";
 /// doesn't depend on the creation code (aka EIP-3171, aka "CREATE3").
 /// Every deployer has access to their unique address deployment space of 2**96 addresses.
 contract SynapseCreate3Factory is ISynapseCreate3Factory {
+    error SynapseCreate3Factory__UnauthorizedDeployer(address deployer, address authorized);
+
+    /// @dev Modifier to check that the first 20 bytes of the salt are equal to the caller's address.
+    /// This is used to prevent unauthorized deploys.
+    /// Note: unlike ImmutableCreate2Factory, this check could NOT be bypassed by setting
+    /// the first 20 bytes of the salt to zero. This is done to prevent the inevitable footguns,
+    /// as unlike create2, the resulting address does not depend on the creation code.
+    modifier containsCaller(bytes32 salt) {
+        address authorized = address(bytes20(salt));
+        if (authorized != msg.sender) {
+            revert SynapseCreate3Factory__UnauthorizedDeployer(msg.sender, authorized);
+        }
+        _;
+    }
+
     /// @inheritdoc ISynapseCreate3Factory
     function safeCreate3(
         bytes32 salt,
         bytes memory creationCode,
         bytes memory initData
-    ) external payable returns (address deployedAt) {}
+    ) external payable containsCaller(salt) returns (address deployedAt) {}
 
     /// @inheritdoc ISynapseCreate3Factory
-    function predictAddress(bytes32 salt) external view returns (address) {}
+    function predictAddress(bytes32 salt) external view returns (address) {
+        return Create3Lib.predictAddress(salt);
+    }
 }

--- a/contracts/create3/SynapseCreate3Factory.sol
+++ b/contracts/create3/SynapseCreate3Factory.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.17;
 import {Create3Lib} from "./libs/Create3.sol";
 import {ISynapseCreate3Factory} from "./interfaces/ISynapseCreate3Factory.sol";
 
+import {Address} from "@openzeppelin/contracts-4.5.0/utils/Address.sol";
+
 /// @title Synapse Create3 Contract Factory
 /// @author Synapse contributors
 /// @author Modified from 0age (https://github.com/0age/metamorphic/blob/master/contracts/ImmutableCreate2Factory.sol)
@@ -11,7 +13,13 @@ import {ISynapseCreate3Factory} from "./interfaces/ISynapseCreate3Factory.sol";
 /// doesn't depend on the creation code (aka EIP-3171, aka "CREATE3").
 /// Every deployer has access to their unique address deployment space of 2**96 addresses.
 contract SynapseCreate3Factory is ISynapseCreate3Factory {
+    using Address for address;
+
+    error SynapseCreate3Factory__InitCallFailed();
     error SynapseCreate3Factory__UnauthorizedDeployer(address deployer, address authorized);
+
+    /// @dev keccak256("SynapseCreate3Factory__InitCallFailed()")[:4]
+    bytes private constant _INIT_CALL_FAILED_SELECTOR = hex"ac2e37b3";
 
     /// @dev Modifier to check that the first 20 bytes of the salt are equal to the caller's address.
     /// This is used to prevent unauthorized deploys.
@@ -31,7 +39,14 @@ contract SynapseCreate3Factory is ISynapseCreate3Factory {
         bytes32 salt,
         bytes memory creationCode,
         bytes memory initData
-    ) external payable containsCaller(salt) returns (address deployedAt) {}
+    ) external payable containsCaller(salt) returns (address deployedAt) {
+        // Deploy a contract using create3 library, forwarding all msg.value
+        deployedAt = Create3Lib.create3(salt, creationCode, msg.value);
+        // Perform initialization call if needed
+        if (initData.length != 0) {
+            deployedAt.functionCall(initData, string(_INIT_CALL_FAILED_SELECTOR));
+        }
+    }
 
     /// @inheritdoc ISynapseCreate3Factory
     function predictAddress(bytes32 salt) external view returns (address) {

--- a/contracts/create3/SynapseCreate3Factory.sol
+++ b/contracts/create3/SynapseCreate3Factory.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {ISynapseCreate3Factory} from "./interfaces/ISynapseCreate3Factory.sol";
+
+/// @title Synapse Create3 Contract Factory
+/// @author Synapse contributors
+/// @author Modified from 0age (https://github.com/0age/metamorphic/blob/master/contracts/ImmutableCreate2Factory.sol)
+/// @notice This contract provides a way to deploy contracts to the deterministic address, which
+/// doesn't depend on the creation code (aka EIP-3171, aka "CREATE3").
+/// Every deployer has access to their unique address deployment space of 2**96 addresses.
+contract SynapseCreate3Factory is ISynapseCreate3Factory {
+    /// @inheritdoc ISynapseCreate3Factory
+    function safeCreate3(
+        bytes32 salt,
+        bytes memory creationCode,
+        bytes memory initData
+    ) external payable returns (address deployedAt) {}
+
+    /// @inheritdoc ISynapseCreate3Factory
+    function predictAddress(bytes32 salt) external view returns (address) {}
+}

--- a/contracts/create3/interfaces/ISynapseCreate3Factory.sol
+++ b/contracts/create3/interfaces/ISynapseCreate3Factory.sol
@@ -10,6 +10,7 @@ interface ISynapseCreate3Factory {
     /// addresses for each deployer.
     /// - Function is payable and all value is forwarded to the contract constructor.
     /// - If `initData` is non-empty, it will be used to perform an initialization call to the deployed contract.
+    /// This could be used to call the contract initializer atomically with the deployment to prevent front-running.
     /// @dev The execution will be reverted in either of the following cases:
     /// - First 20 bytes of the salt are not equal to the deployer's address.
     /// - Salt has been used before (meaning the address associated with the salt is already occupied).

--- a/contracts/create3/interfaces/ISynapseCreate3Factory.sol
+++ b/contracts/create3/interfaces/ISynapseCreate3Factory.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface ISynapseCreate3Factory {
+    /// @notice Deploys a contract EIP-3171 style with an optional initialization call.
+    /// The deployed contract address depends only on the provided salt and the address of the factory contract,
+    /// and does NOT depend on the creation code or the data for the initialization call.
+    /// - In order to prevent unauthorized deploys, the first 20 bytes of the salt
+    /// must be equal to the deployer's address. The remaining 12 bytes could be arbitrary, leaving 2**96 possible
+    /// addresses for each deployer.
+    /// - Function is payable and all value is forwarded to the contract constructor.
+    /// - If `initData` is non-empty, it will be used to perform an initialization call to the deployed contract.
+    /// @dev The execution will be reverted in either of the following cases:
+    /// - First 20 bytes of the salt are not equal to the deployer's address.
+    /// - Salt has been used before (meaning the address associated with the salt is already occupied).
+    /// - Contract creation fails, in which case a generic error is thrown, regardless of the reason.
+    /// - Initialization call fails, in which case the error is bubbled up. A generic error will be thrown, if
+    /// initialization call reverts silently.
+    /// @param salt         Salt for the contract deployment. Must contain the deployer's address as the first 20 bytes.
+    /// @param creationCode Creation code of the contract to deploy. This is usually the
+    ///                     bytecode of the contract, followed by the ABI-encoded constructor arguments.
+    /// @param initData     Data to be used for an initialization call to the deployed contract.
+    ///                     Empty, if no initialization call is needed.
+    /// @return deployedAt  Address of the deployed contract.
+    function safeCreate3(
+        bytes32 salt,
+        bytes memory creationCode,
+        bytes memory initData
+    ) external payable returns (address deployedAt);
+
+    /// @notice Predicts the address of the final contract deployed using `safeCreate3`.
+    /// Note: accepts any salt, but for deployment to succeed, the first 20 bytes of the salt
+    /// must be equal to the deployer's address.
+    /// @param salt     Salt for the contract deployment. Must contain the deployer's address as the first 20 bytes.
+    /// @return Address of the contract deployed using `safeCreate3`.
+    function predictAddress(bytes32 salt) external view returns (address);
+}

--- a/contracts/create3/libs/Create3.sol
+++ b/contracts/create3/libs/Create3.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// Library for deploying contracts to the deterministic address irrespective
+/// of the contract code or the constructor arguments.
+/// Slightly modified version of 0xSequence Create3.sol:
+/// https://github.com/0xsequence/create3/blob/master/contracts/Create3.sol
+/// # Proxy Deployer Bytecode
+/// No modifications from the original, just the visualization is changed.
+/// - Proxy Deployer is a minimal contract that uses the passed calldata to deploy
+/// the final contract using `CREATE` opcode.
+/// - The resulting contract address depends on the Proxy Deployer address and its nonce,
+/// and doesn't depend on the final contract code or the constructor arguments.
+/// - Proxy Deployer itself is deployed using `CREATE2` opcode, therefore its address
+/// can be calculated deterministically.
+/// - This allows to deploy contracts to the deterministic address irrespective
+/// of the contract code or the constructor arguments.
+/// ## Bytecode Table
+/// | Pos  | OP   | OP + Args | Description    | S2  | S1  | S0   |
+/// | ---- | ---- | --------- | -------------- | --- | --- | ---- |
+/// | 0x00 | 0x36 | 0x36      | calldatasize   |     |     | cds  |
+/// | 0x01 | 0x3d | 0x3d      | returndatasize |     | 0   | cds  |
+/// | 0x02 | 0x3d | 0x3d      | returndatasize | 0   | 0   | cds  |
+/// | 0x03 | 0x37 | 0x37      | calldatacopy   |     |     |      |
+/// | 0x04 | 0x36 | 0x36      | calldatasize   |     |     | cds  |
+/// | 0x05 | 0x3d | 0x3d      | returndatasize |     | 0   | cds  |
+/// | 0x06 | 0x34 | 0x34      | callvalue      | val | 0   | cds  |
+/// | 0x07 | 0xf0 | 0xf0      | create         |     |     | addr |
+/// > - Opcode + Args refers to the bytecode of the opcode and its arguments (if there are any).
+/// > - Stack View (S2..S0) is shown after the execution of the opcode.
+/// > - The stack elements are shown from top to bottom.
+/// > Opcodes are typically dealing with the top stack elements, so they are shown first.
+/// > - `cds` refers to the calldata size.
+/// > - `rds` refers to the returndata size (which is zero before the first external call).
+/// > - `val` refers to the provided `msg.value`.
+/// > - `addr` refers to the address of the deployed contract.
+/// ## Bytecode Explanation
+/// - `0x00..0x02` - Prepare the stack for the `calldatacopy` operation.
+/// - `0x03` - Copy the calldata (the creation code of the final contract) to memory.
+/// - `0x04..0x06` - Prepare the stack for the `create` operation.
+/// - `0x07` - Deploy the final contract using `CREATE` opcode.
+/// ## Init Code Table
+/// | Pos  | OP   | OP + Args | Description    | S1  | S0       |
+/// | ---- | ---- | --------- | -------------- | --- | -------- |
+/// | 0x00 | 0x67 | 0x67XXXX  | push8 bytecode |     | bytecode |
+/// | 0x09 | 0x3d | 0x3d      | returndatasize | 0   | bytecode |
+/// | 0x0a | 0x52 | 0x52      | mstore         |     |          |
+/// | 0x0b | 0x60 | 0x6008    | push1 0x08     |     | 8        |
+/// | 0x0d | 0x60 | 0x6018    | push1 0x18     | 24  | 8        |
+/// | 0x0f | 0xf3 | 0xf3      | return         |     |          |
+/// > Init Code is executed when a contract is deployed. The returned value is saved as the contract code.
+/// > Therefore, the init code is constructed in such a way that it returns the Proxy Deployer bytecode.
+/// ## Init Code Explanation
+/// - `0x00..0x08` - Push the Proxy Deployer bytecode onto the stack.
+/// - `0x09` - Push zero onto the stack.
+/// - `0x0a` - Store the Proxy Deployer bytecode at memory position 0.
+/// > Pushed value has only lower 8 bytes set, because the Proxy Deployer bytecode is 8 bytes long.
+/// > Therefore, the memory offset is actually 32-8=24 bytes.
+/// - `0x0b..0x0c` - Push the length of the Proxy Deployer bytecode onto the stack.
+/// - `0x0d..0x0c` - Push the memory position of the Proxy Deployer bytecode onto the stack.
+/// - `0x0f` - Return the Proxy Deployer bytecode.
+library Create3Lib {
+
+}

--- a/test/create3/SynapseCreate3Factory.t.sol
+++ b/test/create3/SynapseCreate3Factory.t.sol
@@ -14,9 +14,6 @@ contract SynapseCreate3FactoryTest is Test {
     address public initializableReference;
     address public revertingReference;
 
-    uint256 public msgValue;
-    bytes public initData;
-
     function setUp() public {
         factory = new SynapseCreate3Factory();
         deployer = makeAddr("Deployer");
@@ -24,36 +21,48 @@ contract SynapseCreate3FactoryTest is Test {
         revertingReference = address(new RevertingContract());
     }
 
-    function testSafeCreate3DeploysContract(bytes12 saltSuffix) public returns (address deployedAddress) {
-        bytes32 salt = constructSalt(deployer, saltSuffix);
-        address predictedAddress = factory.predictAddress(salt);
-        // Deploy contract, use msgValue and initData, which are both empty by default
+    function getSaltAndAddress(bytes12 saltSuffix) public view returns (bytes32 salt, address predictedAddress) {
+        salt = constructSalt(deployer, saltSuffix);
+        predictedAddress = factory.predictAddress(salt);
+    }
+
+    function safeCreate3(
+        bytes32 salt,
+        bytes memory creationCode,
+        bytes memory initData,
+        uint256 msgValue
+    ) public returns (address deployedAddress) {
+        deal(deployer, msgValue);
         vm.prank(deployer);
-        deployedAddress = factory.safeCreate3{value: msgValue}(
-            salt,
-            type(InitializableContract).creationCode,
-            initData
-        );
+        return factory.safeCreate3{value: msgValue}(salt, creationCode, initData);
+    }
+
+    function testSafeCreate3DeploysContract(bytes12 saltSuffix) public {
+        (bytes32 salt, address predictedAddress) = getSaltAndAddress(saltSuffix);
+        address deployedAddress = safeCreate3(salt, type(InitializableContract).creationCode, "", 0);
+        // Checks
         assertEq(predictedAddress, deployedAddress);
+        assertEq(address(deployedAddress).balance, 0);
         assertEq(deployedAddress.code, initializableReference.code);
     }
 
-    function testSafeCreate3DeploysContractWithEther(bytes12 saltSuffix, uint256 value)
-        public
-        returns (address deployedAddress)
-    {
-        deal(deployer, value);
-        msgValue = value;
-        deployedAddress = testSafeCreate3DeploysContract(saltSuffix);
+    function testSafeCreate3DeploysContractWithEther(bytes12 saltSuffix, uint256 value) public {
+        (bytes32 salt, address predictedAddress) = getSaltAndAddress(saltSuffix);
+        address deployedAddress = safeCreate3(salt, type(InitializableContract).creationCode, "", value);
+        // Checks
+        assertEq(predictedAddress, deployedAddress);
         assertEq(address(deployedAddress).balance, value);
+        assertEq(deployedAddress.code, initializableReference.code);
     }
 
-    function testSafeCreate3DeploysContractWithInitData(bytes12 saltSuffix, uint256 argValue)
-        public
-        returns (address deployedAddress)
-    {
-        initData = abi.encodeWithSelector(InitializableContract.setValue.selector, argValue);
-        deployedAddress = testSafeCreate3DeploysContract(saltSuffix);
+    function testSafeCreate3DeploysContractWithInitData(bytes12 saltSuffix, uint256 argValue) public {
+        bytes memory initData = abi.encodeWithSelector(InitializableContract.setValue.selector, argValue);
+        (bytes32 salt, address predictedAddress) = getSaltAndAddress(saltSuffix);
+        address deployedAddress = safeCreate3(salt, type(InitializableContract).creationCode, initData, 0);
+        // Checks
+        assertEq(predictedAddress, deployedAddress);
+        assertEq(address(deployedAddress).balance, 0);
+        assertEq(deployedAddress.code, initializableReference.code);
         assertEq(InitializableContract(deployedAddress).value(), argValue);
     }
 
@@ -62,8 +71,13 @@ contract SynapseCreate3FactoryTest is Test {
         uint256 value,
         uint256 argValue
     ) public {
-        initData = abi.encodeWithSelector(InitializableContract.setValue.selector, argValue);
-        address deployedAddress = testSafeCreate3DeploysContractWithEther(saltSuffix, value);
+        bytes memory initData = abi.encodeWithSelector(InitializableContract.setValue.selector, argValue);
+        (bytes32 salt, address predictedAddress) = getSaltAndAddress(saltSuffix);
+        address deployedAddress = safeCreate3(salt, type(InitializableContract).creationCode, initData, value);
+        // Checks
+        assertEq(predictedAddress, deployedAddress);
+        assertEq(address(deployedAddress).balance, value);
+        assertEq(deployedAddress.code, initializableReference.code);
         assertEq(InitializableContract(deployedAddress).value(), argValue);
     }
 
@@ -79,8 +93,7 @@ contract SynapseCreate3FactoryTest is Test {
                 address(bytes20(salt))
             )
         );
-        vm.prank(deployer);
-        factory.safeCreate3(salt, type(InitializableContract).creationCode, "");
+        safeCreate3(salt, type(InitializableContract).creationCode, "", 0);
     }
 
     function testSafeCreate3RevertsWhenSaltHasSingleBitSwitched(bytes12 saltSuffix) public {
@@ -98,8 +111,7 @@ contract SynapseCreate3FactoryTest is Test {
                     address(bytes20(incorrectSalt))
                 )
             );
-            vm.prank(deployer);
-            factory.safeCreate3(incorrectSalt, type(InitializableContract).creationCode, "");
+            safeCreate3(incorrectSalt, type(InitializableContract).creationCode, "", 0);
         }
     }
 
@@ -112,8 +124,7 @@ contract SynapseCreate3FactoryTest is Test {
         address occupied = factory.safeCreate3(salt, type(InitializableContract).creationCode, "");
         // Try to deploy another contract with the same salt
         vm.expectRevert(abi.encodeWithSelector(Create3Lib.Create3__DeploymentAlreadyExists.selector, occupied));
-        vm.prank(deployer);
-        factory.safeCreate3(salt, type(RevertingContract).creationCode, "");
+        safeCreate3(salt, type(RevertingContract).creationCode, "", 0);
     }
 
     function testSafeCreate3AnotherDeployerUsedSaltSuffix(bytes12 saltSuffix) public {
@@ -129,53 +140,46 @@ contract SynapseCreate3FactoryTest is Test {
     // ══════════════════════════════════════════════ TESTS: REVERTS ═══════════════════════════════════════════════════
 
     function testSafeCreate3RevertsWhenConstructorRevertsSilently() public {
-        deal(deployer, 1);
         bytes32 salt = constructSalt(deployer, 0);
         vm.expectRevert(Create3Lib.Create3__DeploymentFailed.selector);
         // Make the deployment fail y providing Ether to non-payable constructor
-        vm.prank(deployer);
-        factory.safeCreate3{value: 1}(salt, type(RevertingContract).creationCode, "");
+        safeCreate3(salt, type(RevertingContract).creationCode, "", 1);
     }
 
     // Revert message is NOT bubbled up
     function testSafeCreate3RevertsWhenConstructorRevertsWithMessage() public {
         bytes32 salt = constructSalt(deployer, 0);
         vm.expectRevert(Create3Lib.Create3__DeploymentFailed.selector);
-        vm.prank(deployer);
-        factory.safeCreate3(salt, type(RevertingConstructorContract).creationCode, "");
+        safeCreate3(salt, type(RevertingConstructorContract).creationCode, "", 0);
     }
 
     function testSafeCreate3RevertsBubbleErrorWhenInitCallRevertsWithCustomError() public {
         bytes32 salt = constructSalt(deployer, 0);
-        initData = abi.encodeWithSelector(RevertingContract.revertWithNoArgError.selector);
+        bytes memory initData = abi.encodeWithSelector(RevertingContract.revertWithNoArgError.selector);
         vm.expectRevert(RevertingContract.NoArgError.selector);
-        vm.prank(deployer);
-        factory.safeCreate3(salt, type(RevertingContract).creationCode, initData);
+        safeCreate3(salt, type(RevertingContract).creationCode, initData, 0);
     }
 
     function testSafeCreate3RevertsBubbleErrorWhenInitCallRevertsWithCustomErrorWithArgs() public {
         bytes32 salt = constructSalt(deployer, 0);
         uint256 argValue = 42;
-        initData = abi.encodeWithSelector(RevertingContract.revertWithOneArgError.selector, argValue);
+        bytes memory initData = abi.encodeWithSelector(RevertingContract.revertWithOneArgError.selector, argValue);
         vm.expectRevert(abi.encodeWithSelector(RevertingContract.OneArgError.selector, argValue));
-        vm.prank(deployer);
-        factory.safeCreate3(salt, type(RevertingContract).creationCode, initData);
+        safeCreate3(salt, type(RevertingContract).creationCode, initData, 0);
     }
 
     function testSafeCreate3RevertsBubbleErrorWhenInitCallRevertsWithMessage() public {
         bytes32 salt = constructSalt(deployer, 0);
-        initData = abi.encodeWithSelector(RevertingContract.revertWithMessage.selector);
+        bytes memory initData = abi.encodeWithSelector(RevertingContract.revertWithMessage.selector);
         vm.expectRevert("Revert: GM");
-        vm.prank(deployer);
-        factory.safeCreate3(salt, type(RevertingContract).creationCode, initData);
+        safeCreate3(salt, type(RevertingContract).creationCode, initData, 0);
     }
 
     function testSafeCreate3RevertsWhenInitCallRevertsSilently() public {
         bytes32 salt = constructSalt(deployer, 0);
-        initData = abi.encodeWithSelector(RevertingContract.revertNoReason.selector);
+        bytes memory initData = abi.encodeWithSelector(RevertingContract.revertNoReason.selector);
         vm.expectRevert(SynapseCreate3Factory.SynapseCreate3Factory__InitCallFailed.selector);
-        vm.prank(deployer);
-        factory.safeCreate3(salt, type(RevertingContract).creationCode, initData);
+        safeCreate3(salt, type(RevertingContract).creationCode, initData, 0);
     }
 
     // ══════════════════════════════════════════════════ HELPERS ══════════════════════════════════════════════════════

--- a/test/create3/SynapseCreate3Factory.t.sol
+++ b/test/create3/SynapseCreate3Factory.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import {SynapseCreate3Factory} from "../../contracts/create3/SynapseCreate3Factory.sol";
+import {Create3Lib, SynapseCreate3Factory} from "../../contracts/create3/SynapseCreate3Factory.sol";
 import {InitializableContract} from "./mocks/InitializableContract.sol";
 import {RevertingContract} from "./mocks/RevertingContract.sol";
 
@@ -24,8 +24,8 @@ contract SynapseCreate3FactoryTest is Test {
         revertingReference = address(new RevertingContract());
     }
 
-    function testSafeCreate3DeploysContract(bytes12 shortSalt) public returns (address deployedAddress) {
-        bytes32 salt = constructSalt(deployer, shortSalt);
+    function testSafeCreate3DeploysContract(bytes12 saltSuffix) public returns (address deployedAddress) {
+        bytes32 salt = constructSalt(deployer, saltSuffix);
         address predictedAddress = factory.predictAddress(salt);
         // Deploy contract, use msgValue and initData, which are both empty by default
         vm.prank(deployer);
@@ -38,32 +38,32 @@ contract SynapseCreate3FactoryTest is Test {
         assertEq(deployedAddress.code, initializableReference.code);
     }
 
-    function testSafeCreate3DeploysContractWithEther(bytes12 shortSalt, uint256 value)
+    function testSafeCreate3DeploysContractWithEther(bytes12 saltSuffix, uint256 value)
         public
         returns (address deployedAddress)
     {
         deal(deployer, value);
         msgValue = value;
-        deployedAddress = testSafeCreate3DeploysContract(shortSalt);
+        deployedAddress = testSafeCreate3DeploysContract(saltSuffix);
         assertEq(address(deployedAddress).balance, value);
     }
 
-    function testSafeCreate3DeploysContractWithInitData(bytes12 shortSalt, uint256 argValue)
+    function testSafeCreate3DeploysContractWithInitData(bytes12 saltSuffix, uint256 argValue)
         public
         returns (address deployedAddress)
     {
         initData = abi.encodeWithSelector(InitializableContract.setValue.selector, argValue);
-        deployedAddress = testSafeCreate3DeploysContract(shortSalt);
+        deployedAddress = testSafeCreate3DeploysContract(saltSuffix);
         assertEq(InitializableContract(deployedAddress).value(), argValue);
     }
 
     function testSafeCreate3DeploysContractWithEtherAndInitData(
-        bytes12 shortSalt,
+        bytes12 saltSuffix,
         uint256 value,
         uint256 argValue
     ) public {
         initData = abi.encodeWithSelector(InitializableContract.setValue.selector, argValue);
-        address deployedAddress = testSafeCreate3DeploysContractWithEther(shortSalt, value);
+        address deployedAddress = testSafeCreate3DeploysContractWithEther(saltSuffix, value);
         assertEq(InitializableContract(deployedAddress).value(), argValue);
     }
 
@@ -83,8 +83,8 @@ contract SynapseCreate3FactoryTest is Test {
         factory.safeCreate3(salt, type(InitializableContract).creationCode, "");
     }
 
-    function testSafeCreate3RevertsWhenSaltHasSingleBitSwitched(bytes12 shortSalt) public {
-        bytes32 correctSalt = constructSalt(deployer, shortSalt);
+    function testSafeCreate3RevertsWhenSaltHasSingleBitSwitched(bytes12 saltSuffix) public {
+        bytes32 correctSalt = constructSalt(deployer, saltSuffix);
         bytes32 one = bytes32(uint256(1));
         // Iterate over all 160 highest bits of the salt
         for (uint256 i = 0; i < 160; ++i) {
@@ -101,6 +101,29 @@ contract SynapseCreate3FactoryTest is Test {
             vm.prank(deployer);
             factory.safeCreate3(incorrectSalt, type(InitializableContract).creationCode, "");
         }
+    }
+
+    // ═════════════════════════════════════════════ TESTS: SALT REUSE ═════════════════════════════════════════════════
+
+    function testSafeCreate3RevertsWhenSaltReused(bytes12 saltSuffix) public {
+        bytes32 salt = constructSalt(deployer, saltSuffix);
+        // Deploy contract with the salt
+        vm.prank(deployer);
+        address occupied = factory.safeCreate3(salt, type(InitializableContract).creationCode, "");
+        // Try to deploy another contract with the same salt
+        vm.expectRevert(abi.encodeWithSelector(Create3Lib.Create3__DeploymentAlreadyExists.selector, occupied));
+        vm.prank(deployer);
+        factory.safeCreate3(salt, type(RevertingContract).creationCode, "");
+    }
+
+    function testSafeCreate3AnotherDeployerUsedSaltSuffix(bytes12 saltSuffix) public {
+        // Deploy contract using another deployer, but the same salt suffix
+        address anotherDeployer = makeAddr("Another deployer");
+        bytes32 anotherSalt = constructSalt(anotherDeployer, saltSuffix);
+        vm.prank(anotherDeployer);
+        factory.safeCreate3(anotherSalt, type(InitializableContract).creationCode, "");
+        // Should be able to use the same suffix with the original deployer
+        testSafeCreate3DeploysContract(saltSuffix);
     }
 
     // ══════════════════════════════════════════════ TESTS: REVERTS ═══════════════════════════════════════════════════
@@ -140,9 +163,9 @@ contract SynapseCreate3FactoryTest is Test {
 
     // ══════════════════════════════════════════════════ HELPERS ══════════════════════════════════════════════════════
 
-    function constructSalt(address caller, bytes12 shortSalt) public pure returns (bytes32 salt) {
-        // Lowest 12 bytes are the "short salt"
-        salt = bytes32(uint256(uint96(shortSalt)));
+    function constructSalt(address caller, bytes12 saltSuffix) public pure returns (bytes32 salt) {
+        // Lowest 12 bytes are the "salt suffix"
+        salt = bytes32(uint256(uint96(saltSuffix)));
         // Highest 20 bytes are the caller
         salt |= bytes32(uint256(uint160(caller)) << 96);
     }

--- a/test/create3/SynapseCreate3Factory.t.sol
+++ b/test/create3/SynapseCreate3Factory.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {SynapseCreate3Factory} from "../../contracts/create3/SynapseCreate3Factory.sol";
+import {InitializableContract} from "./mocks/InitializableContract.sol";
+
+import {console, Test} from "forge-std/Test.sol";
+
+contract SynapseCreate3FactoryTest is Test {
+    SynapseCreate3Factory public factory;
+    address public deployer;
+
+    address public initializableReference;
+
+    uint256 public msgValue;
+    bytes public initData;
+
+    function setUp() public {
+        factory = new SynapseCreate3Factory();
+        deployer = makeAddr("Deployer");
+        initializableReference = address(new InitializableContract());
+    }
+
+    function testSafeCreate3DeploysContract(bytes12 shortSalt) public returns (address deployedAddress) {
+        bytes32 salt = constructSalt(deployer, shortSalt);
+        address predictedAddress = factory.predictAddress(salt);
+        // Deploy contract, use msgValue and initData, which are both empty by default
+        vm.prank(deployer);
+        deployedAddress = factory.safeCreate3{value: msgValue}(
+            salt,
+            type(InitializableContract).creationCode,
+            initData
+        );
+        assertEq(predictedAddress, deployedAddress);
+        assertEq(deployedAddress.code, initializableReference.code);
+    }
+
+    function testSafeCreate3DeploysContractWithEther(bytes12 shortSalt, uint256 value)
+        public
+        returns (address deployedAddress)
+    {
+        deal(deployer, value);
+        msgValue = value;
+        deployedAddress = testSafeCreate3DeploysContract(shortSalt);
+        assertEq(address(deployedAddress).balance, value);
+    }
+
+    function testSafeCreate3DeploysContractWithInitData(bytes12 shortSalt, uint256 argValue)
+        public
+        returns (address deployedAddress)
+    {
+        initData = abi.encodeWithSelector(InitializableContract.setValue.selector, argValue);
+        deployedAddress = testSafeCreate3DeploysContract(shortSalt);
+        assertEq(InitializableContract(deployedAddress).value(), argValue);
+    }
+
+    function testSafeCreate3DeploysContractWithEtherAndInitData(
+        bytes12 shortSalt,
+        uint256 value,
+        uint256 argValue
+    ) public {
+        initData = abi.encodeWithSelector(InitializableContract.setValue.selector, argValue);
+        address deployedAddress = testSafeCreate3DeploysContractWithEther(shortSalt, value);
+        assertEq(InitializableContract(deployedAddress).value(), argValue);
+    }
+
+    // ══════════════════════════════════════════════════ HELPERS ══════════════════════════════════════════════════════
+
+    function constructSalt(address caller, bytes12 shortSalt) public pure returns (bytes32 salt) {
+        // Lowest 12 bytes are the "short salt"
+        salt = bytes32(uint256(uint96(shortSalt)));
+        // Highest 20 bytes are the caller
+        salt |= bytes32(uint256(uint160(caller)) << 96);
+    }
+}

--- a/test/create3/harnesses/Create3LibHarness.sol
+++ b/test/create3/harnesses/Create3LibHarness.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {Create3Lib} from "../../../contracts/create3/libs/Create3.sol";
+
+contract Create3LibHarness {
+    function create3(
+        bytes32 salt,
+        bytes memory creationCode,
+        uint256 value
+    ) external payable returns (address) {
+        return Create3Lib.create3(salt, creationCode, value);
+    }
+
+    function predictAddress(bytes32 salt) external view returns (address) {
+        return Create3Lib.predictAddress(salt);
+    }
+}

--- a/test/create3/libs/Create3Lib.t.sol
+++ b/test/create3/libs/Create3Lib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import {Create3LibHarness} from "../harnesses/Create3LibHarness.sol";
+import {Create3Lib, Create3LibHarness} from "../harnesses/Create3LibHarness.sol";
 import {SimpleContract, SimpleArgContract} from "../mocks/SimpleContracts.sol";
 
 import {Test} from "forge-std/Test.sol";
@@ -51,5 +51,61 @@ contract Create3LibraryTest is Test {
         assertEq(predictedAddress, deployedAddress);
         assertEq(deployedAddress.code, simpleArgReference.code);
         assertEq(SimpleArgContract(deployedAddress).arg(), arg);
+    }
+
+    function testCreate3RevertsWhenDeploymentExists() public {
+        bytes32 salt = "Very random salt";
+        address predictedAddress = create3LibHarness.predictAddress(salt);
+        // Put some nonsense bytecode at the predicted address
+        vm.etch(predictedAddress, "Mocked existing contract bytecode");
+        vm.expectRevert(abi.encodeWithSelector(Create3Lib.Create3__DeploymentAlreadyExists.selector, predictedAddress));
+        create3LibHarness.create3(salt, type(SimpleContract).creationCode, 0);
+    }
+
+    function testCreate3RevertsWhenSaltReusedDifferentContract() public {
+        bytes32 salt = "Not so very random salt";
+        bytes memory creationCode = abi.encodePacked(type(SimpleArgContract).creationCode, abi.encode(69));
+        address occupied = create3LibHarness.create3(salt, creationCode, 0);
+        // Deploying a different contract with the same salt should fail
+        vm.expectRevert(abi.encodeWithSelector(Create3Lib.Create3__DeploymentAlreadyExists.selector, occupied));
+        create3LibHarness.create3(salt, type(SimpleContract).creationCode, 0);
+    }
+
+    function testCreate3RevertsWhenSaltReusedSameContract() public {
+        bytes32 salt = "Quite random salt";
+        address occupied = create3LibHarness.create3(salt, type(SimpleContract).creationCode, 0);
+        // Deploying the same contract with the same salt should fail
+        vm.expectRevert(abi.encodeWithSelector(Create3Lib.Create3__DeploymentAlreadyExists.selector, occupied));
+        create3LibHarness.create3(salt, type(SimpleContract).creationCode, 0);
+    }
+
+    function testCreate3RevertsWhenProxyDeployerDeploymentFails() public {
+        bytes32 salt = "Is this random?";
+        // Make the deployment of proxy deployer fail by putting some nonsense bytecode at the proxy address
+        address proxy = address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            bytes1(0xff),
+                            address(create3LibHarness),
+                            salt,
+                            Create3Lib.DEPLOYER_INIT_CODE_HASH
+                        )
+                    )
+                )
+            )
+        );
+        vm.etch(proxy, "Mocked existing proxy bytecode");
+        vm.expectRevert(abi.encodeWithSelector(Create3Lib.Create3__ProxyDeployerDeploymentFailed.selector));
+        create3LibHarness.create3(salt, type(SimpleContract).creationCode, 0);
+    }
+
+    function testCreate3RevertsWhenFinalDeploymentFails() public {
+        bytes32 salt = "The saltiest salt";
+        // Make the final deployment fail by not providing enough arguments to the constructor
+        vm.expectRevert(abi.encodeWithSelector(Create3Lib.Create3__DeploymentFailed.selector));
+        // should be abi.encodePacked(type(SimpleArgContract).creationCode, abi.encode(42))
+        create3LibHarness.create3(salt, type(SimpleArgContract).creationCode, 0);
     }
 }

--- a/test/create3/libs/Create3Lib.t.sol
+++ b/test/create3/libs/Create3Lib.t.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {Create3LibHarness} from "../harnesses/Create3LibHarness.sol";
+import {SimpleContract, SimpleArgContract} from "../mocks/SimpleContracts.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+contract Create3LibraryTest is Test {
+    Create3LibHarness public create3LibHarness;
+
+    address public simpleReference;
+    address public simpleArgReference;
+
+    function setUp() public {
+        create3LibHarness = new Create3LibHarness();
+        simpleReference = address(new SimpleContract());
+        simpleArgReference = address(new SimpleArgContract(42));
+    }
+
+    function testCreate3NoArgs(bytes32 salt) public {
+        address predictedAddress = create3LibHarness.predictAddress(salt);
+        address deployedAddress = create3LibHarness.create3(salt, type(SimpleContract).creationCode, 0);
+        assertEq(predictedAddress, deployedAddress);
+        assertEq(deployedAddress.code, simpleReference.code);
+    }
+
+    function testCreate3WithEther(
+        bytes32 salt,
+        uint256 totalValue,
+        uint256 forwardedValue
+    ) public {
+        deal(address(this), totalValue);
+        forwardedValue = bound(forwardedValue, 0, totalValue);
+        address predictedAddress = create3LibHarness.predictAddress(salt);
+        // Use different ether values for constructor and msg.value for testing
+        address deployedAddress = create3LibHarness.create3{value: totalValue}(
+            salt,
+            type(SimpleContract).creationCode,
+            forwardedValue
+        );
+        assertEq(predictedAddress, deployedAddress);
+        assertEq(deployedAddress.code, simpleReference.code);
+        assertEq(address(deployedAddress).balance, forwardedValue);
+    }
+
+    function testCreate3WithArgs(bytes32 salt, uint256 arg) public {
+        address predictedAddress = create3LibHarness.predictAddress(salt);
+        bytes memory creationCode = abi.encodePacked(type(SimpleArgContract).creationCode, abi.encode(arg));
+        address deployedAddress = create3LibHarness.create3(salt, creationCode, 0);
+        assertEq(predictedAddress, deployedAddress);
+        assertEq(deployedAddress.code, simpleArgReference.code);
+        assertEq(SimpleArgContract(deployedAddress).arg(), arg);
+    }
+}

--- a/test/create3/mocks/InitializableContract.sol
+++ b/test/create3/mocks/InitializableContract.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+contract InitializableContract {
+    uint256 public value;
+
+    constructor() payable {}
+
+    function setValue(uint256 value_) external {
+        value = value_;
+    }
+}

--- a/test/create3/mocks/RevertingContract.sol
+++ b/test/create3/mocks/RevertingContract.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+contract RevertingContract {
+    error NoArgError();
+    error OneArgError(uint256 arg);
+
+    function revertNoReason() external pure {
+        revert();
+    }
+
+    function revertWithMessage() external pure {
+        revert("Revert: GM");
+    }
+
+    function revertWithNoArgError() external pure {
+        revert NoArgError();
+    }
+
+    function revertWithOneArgError(uint256 arg) external pure {
+        revert OneArgError(arg);
+    }
+}

--- a/test/create3/mocks/RevertingContracts.sol
+++ b/test/create3/mocks/RevertingContracts.sol
@@ -21,3 +21,9 @@ contract RevertingContract {
         revert OneArgError(arg);
     }
 }
+
+contract RevertingConstructorContract {
+    constructor() {
+        revert("Revert: GM");
+    }
+}

--- a/test/create3/mocks/SimpleContracts.sol
+++ b/test/create3/mocks/SimpleContracts.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+contract SimpleContract {
+    constructor() payable {}
+}
+
+contract SimpleArgContract {
+    uint256 public arg;
+
+    constructor(uint256 arg_) {
+        arg = arg_;
+    }
+}


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

Adds a Create3 Factory, that allows to deploy arbitrary bytecode on a deterministic address, that does not change, when the bytecode of the contract changes.

Could be used for user-facing contracts that could benefit from having the same address on different chains, even though they have different constructor arguments.

Note: the deployed contract must not use `msg.sender` in the constructor, as if will not be the deployer's EOA. For instance, if the contract is `Ownable`, it must consume `newOwner` as the constructor argument and transfer ownership there.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
