### PR TITLE
Deploy: avax uniswap v3 module

### DIFF
--- a/contracts/router/interfaces/uniswap/ISwapRouter02.sol
+++ b/contracts/router/interfaces/uniswap/ISwapRouter02.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+// For some reason deadline field is missing in Avalanche's SwapRouter02
+struct ExactInputSingleParams {
+    address tokenIn;
+    address tokenOut;
+    uint24 fee;
+    address recipient;
+    uint256 amountIn;
+    uint256 amountOutMinimum;
+    uint160 sqrtPriceLimitX96;
+}
+
+interface ISwapRouter02 {
+    function exactInputSingle(ExactInputSingleParams memory params) external payable returns (uint256 amountOut);
+}

--- a/contracts/router/modules/pool/uniswap/UniswapV3SR02Module.sol
+++ b/contracts/router/modules/pool/uniswap/UniswapV3SR02Module.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IndexedToken, IPoolModule} from "../../../interfaces/IPoolModule.sol";
+import {IUniswapV3Pair} from "../../../interfaces/uniswap/IUniswapV3Pair.sol";
+import {ExactInputSingleParams, ISwapRouter02} from "../../../interfaces/uniswap/ISwapRouter02.sol";
+// prettier-ignore
+import {
+    QuoteExactInputSingleParams, IUniswapV3StaticQuoter
+} from "../../../interfaces/uniswap/IUniswapV3StaticQuoter.sol";
+import {UniversalTokenLib} from "../../../libs/UniversalToken.sol";
+import {OnlyDelegateCall} from "../OnlyDelegateCall.sol";
+
+/// @notice This is implemented in a separate contract, as the ExactInputSingleParams struct
+/// is different between all chains and Avalanche (no deadline field on Avalanche).
+/// Reasons for this remain a mystery.
+contract UniswapV3SR02Module is OnlyDelegateCall, IPoolModule {
+    using UniversalTokenLib for address;
+
+    /// These need to be immutable in order to be accessed via delegatecall
+    ISwapRouter02 public immutable uniswapV3SwapRouter02;
+    IUniswapV3StaticQuoter public immutable uniswapV3StaticQuoter;
+
+    constructor(address uniswapV3SwapRouter02_, address uniswapV3StaticQuoter_) {
+        uniswapV3SwapRouter02 = ISwapRouter02(uniswapV3SwapRouter02_);
+        uniswapV3StaticQuoter = IUniswapV3StaticQuoter(uniswapV3StaticQuoter_);
+    }
+
+    /// @inheritdoc IPoolModule
+    function poolSwap(
+        address pool,
+        IndexedToken memory tokenFrom,
+        IndexedToken memory tokenTo,
+        uint256 amountIn
+    ) external returns (uint256 amountOut) {
+        // This function should be only called via delegatecall
+        assertDelegateCall();
+        address tokenIn = tokenFrom.token;
+        tokenIn.universalApproveInfinity(address(uniswapV3SwapRouter02), amountIn);
+        // Prepare Uniswap Router params for the swap, see for reference:
+        // https://docs.uniswap.org/contracts/v3/guides/swaps/single-swaps#swap-input-parameters
+        // We set `amountOutMinimum` to 0, as the slippage checks are done outside of Pool Module
+        // We set `sqrtPriceLimitX96` to 0, as we don't want to limit the price (same reason as above)
+        ExactInputSingleParams memory params = ExactInputSingleParams({
+            tokenIn: tokenIn,
+            tokenOut: tokenTo.token,
+            fee: IUniswapV3Pair(pool).fee(),
+            recipient: address(this),
+            amountIn: amountIn,
+            amountOutMinimum: 0,
+            sqrtPriceLimitX96: 0
+        });
+        // Swap the tokens, we can trust Uniswap Router to return the correct amountOut
+        amountOut = uniswapV3SwapRouter02.exactInputSingle(params);
+    }
+
+    // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
+
+    /// @inheritdoc IPoolModule
+    function getPoolQuote(
+        address pool,
+        IndexedToken memory tokenFrom,
+        IndexedToken memory tokenTo,
+        uint256 amountIn,
+        bool // probePaused
+    ) external view returns (uint256 amountOut) {
+        // We are ignoring the probePaused flag because Uniswap pools cannot be paused
+        // See `poolSwap()` for more details on the parameters
+        QuoteExactInputSingleParams memory params = QuoteExactInputSingleParams({
+            tokenIn: tokenFrom.token,
+            tokenOut: tokenTo.token,
+            amountIn: amountIn,
+            fee: IUniswapV3Pair(pool).fee(),
+            sqrtPriceLimitX96: 0
+        });
+        amountOut = uniswapV3StaticQuoter.quoteExactInputSingle(params);
+    }
+
+    /// @inheritdoc IPoolModule
+    function getPoolTokens(address pool) external view returns (address[] memory tokens) {
+        // Uniswap pools always have exactly 2 tokens
+        tokens = new address[](2);
+        tokens[0] = IUniswapV3Pair(pool).token0();
+        tokens[1] = IUniswapV3Pair(pool).token1();
+    }
+}

--- a/deployments/avalanche/UniswapV3SR02Module.json
+++ b/deployments/avalanche/UniswapV3SR02Module.json
@@ -1,0 +1,188 @@
+{
+  "address": "0xFB8e926b8380E6eb45B98d64f2B3074EFfC6372F",
+  "constructorArgs": "0x000000000000000000000000bb00ff08d01d300023c629e8ffffcb65a5a578ce000000000000000000000000c15804984e3e77b7f8a60e4553e2289c5fdeae8b",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "uniswapV3SwapRouter02_",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "uniswapV3StaticQuoter_",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint8",
+              "name": "index",
+              "type": "uint8"
+            },
+            {
+              "internalType": "address",
+              "name": "token",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct IndexedToken",
+          "name": "tokenFrom",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint8",
+              "name": "index",
+              "type": "uint8"
+            },
+            {
+              "internalType": "address",
+              "name": "token",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct IndexedToken",
+          "name": "tokenTo",
+          "type": "tuple"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "name": "getPoolQuote",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolTokens",
+      "outputs": [
+        {
+          "internalType": "address[]",
+          "name": "tokens",
+          "type": "address[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint8",
+              "name": "index",
+              "type": "uint8"
+            },
+            {
+              "internalType": "address",
+              "name": "token",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct IndexedToken",
+          "name": "tokenFrom",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint8",
+              "name": "index",
+              "type": "uint8"
+            },
+            {
+              "internalType": "address",
+              "name": "token",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct IndexedToken",
+          "name": "tokenTo",
+          "type": "tuple"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "poolSwap",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "uniswapV3StaticQuoter",
+      "outputs": [
+        {
+          "internalType": "contract IUniswapV3StaticQuoter",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "uniswapV3SwapRouter02",
+      "outputs": [
+        {
+          "internalType": "contract ISwapRouter02",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/script/configs/avalanche/UniswapV3SR02Module.dc.json
+++ b/script/configs/avalanche/UniswapV3SR02Module.dc.json
@@ -1,0 +1,4 @@
+{
+  "uniswapV3SwapRouter02": "0xbb00FF08d01D300023C629E8fFfFcb65A5a578cE",
+  "uniswapV3StaticQuoter": "0xc15804984E3e77B7f8A60E4553e2289c5fdeAe8B"
+}

--- a/script/router/modules/pool/uniswap/DeployUniswapV3SR02Module.s.sol
+++ b/script/router/modules/pool/uniswap/DeployUniswapV3SR02Module.s.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {UniswapV3SR02Module} from "../../../../../contracts/router/modules/pool/uniswap/UniswapV3SR02Module.sol";
+
+import {BasicSynapseScript} from "../../../../templates/BasicSynapse.s.sol";
+
+import {stdJson} from "forge-std/Script.sol";
+
+contract DeployUniswapV3SR02Module is BasicSynapseScript {
+    using stdJson for string;
+
+    string public constant UNI_V3_SR02_MODULE = "UniswapV3SR02Module";
+
+    address public swapRouter02;
+    address public staticQuoter;
+
+    function run() external {
+        // Setup the BasicSynapseScript
+        setUp();
+        vm.startBroadcast();
+        readConfig();
+        // Use `deployUniswapV3SR02Module` as callback to deploy the contract
+        address module = deployAndSave({contractName: UNI_V3_SR02_MODULE, deployContract: deployUniswapV3SR02Module});
+        vm.stopBroadcast();
+        // Verify the module was deployed correctly
+        require(address(UniswapV3SR02Module(module).uniswapV3SwapRouter02()) == swapRouter02, "!swapRouter02");
+        require(address(UniswapV3SR02Module(module).uniswapV3StaticQuoter()) == staticQuoter, "!staticQuoter");
+    }
+
+    function readConfig() internal {
+        string memory config = getDeployConfig(UNI_V3_SR02_MODULE);
+        swapRouter02 = config.readAddress(".uniswapV3SwapRouter02");
+        staticQuoter = config.readAddress(".uniswapV3StaticQuoter");
+    }
+
+    /// @notice Callback function to deploy the UniswapV3SR02Module contract.
+    /// Must follow this signature for the deploy script to work:
+    /// `deployContract() internal returns (address deployedAt, bytes memory constructorArgs)`
+    function deployUniswapV3SR02Module() internal returns (address deployedAt, bytes memory constructorArgs) {
+        deployedAt = address(new UniswapV3SR02Module(swapRouter02, staticQuoter));
+        constructorArgs = abi.encode(swapRouter02, staticQuoter);
+    }
+}

--- a/test/router/modules/pool/LinkedPoolUniswapV3SR02ModuleAvaxUSDC.t.sol
+++ b/test/router/modules/pool/LinkedPoolUniswapV3SR02ModuleAvaxUSDC.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {LinkedPoolIntegrationTest} from "./LinkedPoolIntegration.t.sol";
+
+import {UniswapV3SR02Module} from "../../../../contracts/router/modules/pool/uniswap/UniswapV3SR02Module.sol";
+
+contract LinkedPoolUniswapV3SR02ModuleAvaxUSDCTestFork is LinkedPoolIntegrationTest {
+    string private constant AVAX_ENV_RPC = "AVALANCHE_API";
+    // 2023-09-05
+    uint256 public constant AVAX_BLOCK_NUMBER = 34800000;
+
+    // Uniswap V3 SwapRouter02 on Avalanche
+    address public constant UNI_V3_SWAP_ROUTER_02 = 0xbb00FF08d01D300023C629E8fFfFcb65A5a578cE;
+
+    // Eden's Uniswap V3 Static Quoter on Avalanche
+    address public constant UNI_V3_STATIC_QUOTER = 0xc15804984E3e77B7f8A60E4553e2289c5fdeAe8B;
+
+    // Uniswap V3 USDC/USDT pool on Avalanche
+    address public constant UNI_V3_USDC_POOL = 0x804226cA4EDb38e7eF56D16d16E92dc3223347A0;
+
+    // Native USDC on Avalanche
+    address public constant USDC = 0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E;
+    // Native USDT on Avalanche
+    address public constant USDT = 0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7;
+
+    UniswapV3SR02Module public uniswapV3SR02Module;
+
+    constructor() LinkedPoolIntegrationTest(AVAX_ENV_RPC, AVAX_BLOCK_NUMBER) {}
+
+    function afterBlockchainForked() public override {
+        uniswapV3SR02Module = new UniswapV3SR02Module(UNI_V3_SWAP_ROUTER_02, UNI_V3_STATIC_QUOTER);
+    }
+
+    function addExpectedTokens() public override {
+        // Expected order of tokens:
+        // 0: USDC
+        // 1: USDT
+        addExpectedToken(USDC, "USDC");
+        addExpectedToken(USDT, "USDT");
+    }
+
+    function addPools() public override {
+        addPool({
+            poolName: "USDC/USDT",
+            nodeIndex: 0,
+            pool: UNI_V3_USDC_POOL,
+            poolModule: address(uniswapV3SR02Module)
+        });
+    }
+}

--- a/test/router/modules/pool/uniswap/UniswapV3SR02ModuleAvax.t.sol
+++ b/test/router/modules/pool/uniswap/UniswapV3SR02ModuleAvax.t.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+
+import {LinkedPool} from "../../../../../contracts/router/LinkedPool.sol";
+import {IndexedToken, UniswapV3SR02Module} from "../../../../../contracts/router/modules/pool/uniswap/UniswapV3SR02Module.sol";
+
+import {IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/IERC20.sol";
+
+contract UniswapV3SR02ModuleAvaxTestFork is Test {
+    LinkedPool public linkedPool;
+    UniswapV3SR02Module public uniswapV3SR02Module;
+
+    // 2023-09-05
+    uint256 public constant AVAX_BLOCK_NUMBER = 34800000;
+
+    // Uniswap V3 SwapRouter02 on Avalanche
+    address public constant UNI_V3_SWAP_ROUTER_02 = 0xbb00FF08d01D300023C629E8fFfFcb65A5a578cE;
+
+    // Eden's Uniswap V3 Static Quoter on Avalanche
+    address public constant UNI_V3_STATIC_QUOTER = 0xc15804984E3e77B7f8A60E4553e2289c5fdeAe8B;
+
+    // Uniswap V3 USDC/USDT pool on Avalanche
+    address public constant UNI_V3_USDC_POOL = 0x804226cA4EDb38e7eF56D16d16E92dc3223347A0;
+
+    // Native USDT on Avalanche
+    address public constant USDT = 0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7;
+
+    // Native USDC on Avalanche
+    address public constant USDC = 0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E;
+
+    address public user;
+
+    function setUp() public {
+        string memory avaxRPC = vm.envString("AVALANCHE_API");
+        vm.createSelectFork(avaxRPC, AVAX_BLOCK_NUMBER);
+
+        uniswapV3SR02Module = new UniswapV3SR02Module(UNI_V3_SWAP_ROUTER_02, UNI_V3_STATIC_QUOTER);
+        linkedPool = new LinkedPool(USDC, address(this));
+        user = makeAddr("User");
+
+        vm.label(UNI_V3_SWAP_ROUTER_02, "UniswapV3SwapRouter02");
+        vm.label(UNI_V3_STATIC_QUOTER, "UniswapV3StaticQuoter");
+        vm.label(UNI_V3_USDC_POOL, "UniswapV3USDCPool");
+        vm.label(USDT, "USDT");
+        vm.label(USDC, "USDC");
+    }
+
+    // ═══════════════════════════════════════════════ TESTS: VIEWS ════════════════════════════════════════════════════
+
+    function testGetPoolTokens() public {
+        address[] memory tokens = uniswapV3SR02Module.getPoolTokens(UNI_V3_USDC_POOL);
+        assertEq(tokens.length, 2);
+        // USDT address is lexically smaller than USDC address
+        assertEq(tokens[0], USDT);
+        assertEq(tokens[1], USDC);
+    }
+
+    // ══════════════════════════════════════════════ TESTS: ADD POOL ══════════════════════════════════════════════════
+
+    function addPool() public {
+        linkedPool.addPool({nodeIndex: 0, pool: UNI_V3_USDC_POOL, poolModule: address(uniswapV3SR02Module)});
+    }
+
+    function testAddPool() public {
+        addPool();
+        assertEq(linkedPool.getToken(0), USDC);
+        assertEq(linkedPool.getToken(1), USDT);
+    }
+
+    // ════════════════════════════════════════════════ TESTS: SWAP ════════════════════════════════════════════════════
+
+    function swap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 amount
+    ) public returns (uint256 amountOut) {
+        vm.prank(user);
+        amountOut = linkedPool.swap({
+            nodeIndexFrom: tokenIndexFrom,
+            nodeIndexTo: tokenIndexTo,
+            dx: amount,
+            minDy: 0,
+            deadline: type(uint256).max
+        });
+    }
+
+    function testSwapFromUSDCtoUSDT() public {
+        addPool();
+        uint256 amount = 100 * 10**6;
+        prepareUser(USDC, amount);
+        uint256 expectedAmountOut = linkedPool.calculateSwap({nodeIndexFrom: 0, nodeIndexTo: 1, dx: amount});
+        uint256 amountOut = swap({tokenIndexFrom: 0, tokenIndexTo: 1, amount: amount});
+        assertGt(amountOut, 0);
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(IERC20(USDC).balanceOf(user), 0);
+        assertEq(IERC20(USDT).balanceOf(user), amountOut);
+    }
+
+    function testSwapFromUSDTtoUSDC() public {
+        addPool();
+        uint256 amount = 100 * 10**6;
+        prepareUser(USDT, amount);
+        uint256 expectedAmountOut = linkedPool.calculateSwap({nodeIndexFrom: 1, nodeIndexTo: 0, dx: amount});
+        uint256 amountOut = swap({tokenIndexFrom: 1, tokenIndexTo: 0, amount: amount});
+        assertGt(amountOut, 0);
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(IERC20(USDT).balanceOf(user), 0);
+        assertEq(IERC20(USDC).balanceOf(user), amountOut);
+    }
+
+    function testPoolSwapRevertsWhenDirectCall() public {
+        vm.expectRevert("Not a delegate call");
+        uniswapV3SR02Module.poolSwap({
+            pool: UNI_V3_USDC_POOL,
+            tokenFrom: IndexedToken({index: 0, token: USDC}),
+            tokenTo: IndexedToken({index: 1, token: USDT}),
+            amountIn: 100 * 10**6
+        });
+    }
+
+    function prepareUser(address token, uint256 amount) public {
+        deal(token, user, amount);
+        vm.prank(user);
+        IERC20(token).approve(address(linkedPool), amount);
+    }
+}


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

Adds a slightly modified version of `UniswapV3Module` tailored for Avalanche Uniswap Router deployment:
https://gov.uniswap.org/t/deploy-uniswap-v3-on-avalanche/20587/18
https://snowtrace.io/address/0xbb00FF08d01D300023C629E8fFfFcb65A5a578cE

Caused by difference between Avalanche deployment and the other ones:

Everywhere else:
https://github.com/Uniswap/v3-periphery/blob/b13f9d9d9868b98b765c4f1d8d7f486b00b22488/contracts/interfaces/ISwapRouter.sol#L10-L19

Avalanche:
https://github.com/Uniswap/swap-router-contracts/blob/c696aada49b33c8e764e6f0bd0a0a56bd8aa455f/contracts/interfaces/IV3SwapRouter.sol#L10-L18

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings
