### PR TITLE
Chore: auto save deployments in `run.sh`

### DIFF
--- a/script/run.sh
+++ b/script/run.sh
@@ -37,9 +37,15 @@ if [[ "$@" == *"--broadcast"* ]] && [[ "$@" != *"--verify"* ]] && [ "$IS_DEPLOYM
     echo -e "${YELLOW}Deploy script: adding --verify for the broadcasting${NC}"
     set -- "$@" "--verify"
 fi
-# Preserve the quotes in the options, useful for --sig "function(arguments)"
-# https://stackoverflow.com/questions/10835933/how-can-i-preserve-quotes-in-printing-a-bash-scripts-arguments
-FORGE_OPTIONS=${*@Q}
+# Wrap the options in quotes except ones starting with -
+FORGE_OPTIONS=""
+for arg in "$@"; do
+    if [[ "$arg" == "-"* ]]; then
+        FORGE_OPTIONS="$FORGE_OPTIONS $arg"
+    else
+        FORGE_OPTIONS="$FORGE_OPTIONS \"$arg\""
+    fi
+done
 
 # Fetch the RPC URL for the chain from .env
 source .env

--- a/script/run.sh
+++ b/script/run.sh
@@ -14,6 +14,7 @@
 # Colors
 RED="\033[0;31m"
 GREEN="\033[0;32m"
+YELLOW="\033[0;33m"
 NC="\033[0m" # No Color
 
 # Fetch the script path, chain name, keystore env name
@@ -26,8 +27,16 @@ if [ -z "$SCRIPT_PATH" ] || [ -z "$CHAIN_NAME" ] || [ -z "$WALLET_ENV_NAME" ]; t
     echo -e "${RED}Usage: ./script/run.sh <path/to/script.s.sol> <chainName> <walletName> [<options...>]${NC}"
     exit 1
 fi
+# Figure out if this is a deployment script: check if the script file name starts with "Deploy"
+IS_DEPLOYMENT_SCRIPT=$(basename $SCRIPT_PATH | grep -c "^Deploy")
 # Shift the arguments to pass the rest to `forge script`
 shift 3
+# Check if --broadcast option is passed without --verify for a deployment script
+if [[ "$@" == *"--broadcast"* ]] && [[ "$@" != *"--verify"* ]] && [ "$IS_DEPLOYMENT_SCRIPT" == "1" ]; then
+    # Add --verify option
+    echo -e "${YELLOW}Deploy script: adding --verify for the broadcasting${NC}"
+    set -- "$@" "--verify"
+fi
 # Preserve the quotes in the options, useful for --sig "function(arguments)"
 # https://stackoverflow.com/questions/10835933/how-can-i-preserve-quotes-in-printing-a-bash-scripts-arguments
 FORGE_OPTIONS=${*@Q}

--- a/script/run.sh
+++ b/script/run.sh
@@ -27,12 +27,17 @@ if [ -z "$SCRIPT_PATH" ] || [ -z "$CHAIN_NAME" ] || [ -z "$WALLET_ENV_NAME" ]; t
     echo -e "${RED}Usage: ./script/run.sh <path/to/script.s.sol> <chainName> <walletName> [<options...>]${NC}"
     exit 1
 fi
-# Figure out if this is a deployment script: check if the script file name starts with "Deploy"
-IS_DEPLOYMENT_SCRIPT=$(basename $SCRIPT_PATH | grep -c "^Deploy")
 # Shift the arguments to pass the rest to `forge script`
 shift 3
-# Check if --broadcast option is passed without --verify for a deployment script
-if [[ "$@" == *"--broadcast"* ]] && [[ "$@" != *"--verify"* ]] && [ "$IS_DEPLOYMENT_SCRIPT" == "1" ]; then
+# Figure out if this is a broadcasted deployment script:
+# 1. Check if the script file name starts with "Deploy"
+IS_DEPLOY_SCRIPT=$(basename $SCRIPT_PATH | grep -c "^Deploy")
+# 2. Check if --broadcast option is passed
+IS_BROADCASTED=$(echo "$@" | grep -c "\-\-broadcast")
+# 3. Multiply the two
+IS_BROADCASTED_DEPLOYMENT=$((IS_BROADCASTED * IS_DEPLOY_SCRIPT))
+# Check if --verify is not passed for the broadcasted deployment script
+if [ "$IS_BROADCASTED_DEPLOYMENT" == "1" ] && [[ "$@" != *"--verify"* ]]; then
     # Add --verify option
     echo -e "${YELLOW}Deploy script: adding --verify for the broadcasting${NC}"
     set -- "$@" "--verify"


### PR DESCRIPTION

## Description

Following improvements to `run.sh` have been made:
- Options that start with `-` or `--` are passed to `forge script` without double quotes.
- Every forge script with file name `Deploy*` is now considered a _deployment script_.
- `--verify` option is added for _deployment scripts_ that are broadcasted.
- A `save-deployment.sh` script run after every broadcasted _deployment script_ to save the fresh deployment artifacts from `.deployments` to `deployments`.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Introduced a broadcasted deployment script functionality. This allows for more efficient and reliable deployment processes.
- Improvement: Enhanced the script's readability and user interaction with the addition of color-coded text.
- Improvement: Optimized the construction of `FORGE_OPTIONS` for better handling of command-line options.
- New Feature: Added a verification step in the deployment process to ensure the accuracy and success of deployments.
- New Feature: The system now saves new deployments automatically, reducing manual work and potential errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->