### PR TITLE
Feat: algebra module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,7 @@ AVALANCHE_API=https://api.avax.network/ext/bc/C/rpc
 AVALANCHE_ETHERSCAN_URL=https://api.snowtrace.io/api
 AVALANCHE_ETHERSCAN_KEY=PasteYourOwnKeyPlease
 # Base
-BASE_API=https://mainnet.base.org
+BASE_API=https://base.llamarpc.com
 BASE_ETHERSCAN_URL=https://api.basescan.org/api
 BASE_ETHERSCAN_KEY=PasteYourOwnKeyPlease
 # Boba

--- a/contracts/router/interfaces/algebra/AlgebraStructs.sol
+++ b/contracts/router/interfaces/algebra/AlgebraStructs.sol
@@ -8,12 +8,12 @@ struct ExactInputSingleParams {
     uint256 deadline;
     uint256 amountIn;
     uint256 amountOutMinimum;
-    uint160 sqrtPriceLimitX96;
+    uint160 limitSqrtPrice;
 }
 
 struct QuoteExactInputSingleParams {
     address tokenIn;
     address tokenOut;
     uint256 amountIn;
-    uint160 sqrtPriceLimitX96;
+    uint160 limitSqrtPrice;
 }

--- a/contracts/router/interfaces/algebra/AlgebraStructs.sol
+++ b/contracts/router/interfaces/algebra/AlgebraStructs.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.17;
+
+struct ExactInputSingleParams {
+    address tokenIn;
+    address tokenOut;
+    address recipient;
+    uint256 deadline;
+    uint256 amountIn;
+    uint256 amountOutMinimum;
+    uint160 sqrtPriceLimitX96;
+}
+
+struct QuoteExactInputSingleParams {
+    address tokenIn;
+    address tokenOut;
+    uint256 amountIn;
+    uint160 sqrtPriceLimitX96;
+}

--- a/contracts/router/interfaces/algebra/IAlgebraPool.sol
+++ b/contracts/router/interfaces/algebra/IAlgebraPool.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.17;
+
+interface IAlgebraPool {
+    function globalState()
+        external
+        view
+        returns (
+            uint160,
+            int24,
+            uint16 fee,
+            uint16,
+            uint8,
+            uint8,
+            bool
+        );
+
+    function token0() external view returns (address);
+
+    function token1() external view returns (address);
+}

--- a/contracts/router/interfaces/algebra/IAlgebraPool.sol
+++ b/contracts/router/interfaces/algebra/IAlgebraPool.sol
@@ -2,19 +2,6 @@
 pragma solidity 0.8.17;
 
 interface IAlgebraPool {
-    function globalState()
-        external
-        view
-        returns (
-            uint160,
-            int24,
-            uint16 fee,
-            uint16,
-            uint8,
-            uint8,
-            bool
-        );
-
     function token0() external view returns (address);
 
     function token1() external view returns (address);

--- a/contracts/router/interfaces/algebra/IAlgebraRouter.sol
+++ b/contracts/router/interfaces/algebra/IAlgebraRouter.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.17;
+
+import {ExactInputSingleParams} from "./AlgebraStructs.sol";
+
+interface IAlgebraRouter {
+    function exactInputSingle(ExactInputSingleParams calldata params) external returns (uint256 amountOut);
+}

--- a/contracts/router/interfaces/algebra/IAlgebraStaticQuoter.sol
+++ b/contracts/router/interfaces/algebra/IAlgebraStaticQuoter.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.17;
+
+import {QuoteExactInputSingleParams} from "./AlgebraStructs.sol";
+
+interface IAlgebraStaticQuoter {
+    function quoteExactInputSingle(QuoteExactInputSingleParams memory params) external view returns (uint256 amountOut);
+}

--- a/contracts/router/modules/pool/algebra/AlgebraModule.sol
+++ b/contracts/router/modules/pool/algebra/AlgebraModule.sol
@@ -37,7 +37,7 @@ contract AlgebraModule is OnlyDelegateCall, IPoolModule {
         // Prepare Algebra Router params for the swap, see for reference:
         // https://docs.algebra.finance/en/docs/contracts/guides/swaps/single-swaps
         // We set `amountOutMinimum` to 0, as the slippage checks are done outside of Pool Module
-        // We set `sqrtPriceLimitX96` to 0, as we don't want to limit the price (same reason as above)
+        // We set `limitSqrtPrice` to 0, as we don't want to limit the price (same reason as above)
         ExactInputSingleParams memory params = ExactInputSingleParams({
             tokenIn: tokenIn,
             tokenOut: tokenTo.token,
@@ -45,7 +45,7 @@ contract AlgebraModule is OnlyDelegateCall, IPoolModule {
             deadline: block.timestamp,
             amountIn: amountIn,
             amountOutMinimum: 0,
-            sqrtPriceLimitX96: 0
+            limitSqrtPrice: 0
         });
         // Swap the tokens, we can trust Algebra Router to return the correct amountOut
         amountOut = algebraRouter.exactInputSingle(params);
@@ -67,7 +67,7 @@ contract AlgebraModule is OnlyDelegateCall, IPoolModule {
             tokenIn: tokenFrom.token,
             tokenOut: tokenTo.token,
             amountIn: amountIn,
-            sqrtPriceLimitX96: 0
+            limitSqrtPrice: 0
         });
         amountOut = algebraStaticQuoter.quoteExactInputSingle(params);
     }

--- a/contracts/router/modules/pool/algebra/AlgebraModule.sol
+++ b/contracts/router/modules/pool/algebra/AlgebraModule.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IndexedToken, IPoolModule} from "../../../interfaces/IPoolModule.sol";
+import {IAlgebraPool} from "../../../interfaces/algebra/IAlgebraPool.sol";
+import {ExactInputSingleParams, IAlgebraRouter} from "../../../interfaces/algebra/IAlgebraRouter.sol";
+// prettier-ignore
+import {
+    QuoteExactInputSingleParams, IAlgebraStaticQuoter
+} from "../../../interfaces/algebra/IAlgebraStaticQuoter.sol";
+import {UniversalTokenLib} from "../../../libs/UniversalToken.sol";
+import {OnlyDelegateCall} from "../../OnlyDelegateCall.sol";
+
+contract AlgebraModule is OnlyDelegateCall, IPoolModule {
+    using UniversalTokenLib for address;
+
+    /// These need to be immutable in order to be accessed via delegatecall
+    IAlgebraRouter public immutable algebraRouter;
+    IAlgebraStaticQuoter public immutable algebraStaticQuoter;
+
+    constructor(address algebraRouter_, address algebraStaticQuoter_) {
+        algebraRouter = IAlgebraRouter(algebraRouter_);
+        algebraStaticQuoter = IAlgebraStaticQuoter(algebraStaticQuoter_);
+    }
+
+    /// @inheritdoc IPoolModule
+    function poolSwap(
+        address,
+        IndexedToken memory tokenFrom,
+        IndexedToken memory tokenTo,
+        uint256 amountIn
+    ) external returns (uint256 amountOut) {
+        // This function should be only called via delegatecall
+        assertDelegateCall();
+        address tokenIn = tokenFrom.token;
+        tokenIn.universalApproveInfinity(address(algebraRouter), amountIn);
+        // Prepare Algebra Router params for the swap, see for reference:
+        // https://docs.algebra.finance/en/docs/contracts/guides/swaps/single-swaps
+        // We set `amountOutMinimum` to 0, as the slippage checks are done outside of Pool Module
+        // We set `sqrtPriceLimitX96` to 0, as we don't want to limit the price (same reason as above)
+        ExactInputSingleParams memory params = ExactInputSingleParams({
+            tokenIn: tokenIn,
+            tokenOut: tokenTo.token,
+            recipient: address(this),
+            deadline: block.timestamp,
+            amountIn: amountIn,
+            amountOutMinimum: 0,
+            sqrtPriceLimitX96: 0
+        });
+        // Swap the tokens, we can trust Algebra Router to return the correct amountOut
+        amountOut = algebraRouter.exactInputSingle(params);
+    }
+
+    // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
+
+    /// @inheritdoc IPoolModule
+    function getPoolQuote(
+        address,
+        IndexedToken memory tokenFrom,
+        IndexedToken memory tokenTo,
+        uint256 amountIn,
+        bool // probePaused
+    ) external view returns (uint256 amountOut) {
+        // We are ignoring the probePaused flag because Algebra pools cannot be paused
+        // See `poolSwap()` for more details on the parameters
+        QuoteExactInputSingleParams memory params = QuoteExactInputSingleParams({
+            tokenIn: tokenFrom.token,
+            tokenOut: tokenTo.token,
+            amountIn: amountIn,
+            sqrtPriceLimitX96: 0
+        });
+        amountOut = algebraStaticQuoter.quoteExactInputSingle(params);
+    }
+
+    /// @inheritdoc IPoolModule
+    function getPoolTokens(address pool) external view returns (address[] memory tokens) {
+        // Algebra pools always have exactly 2 tokens
+        tokens = new address[](2);
+        tokens[0] = IAlgebraPool(pool).token0();
+        tokens[1] = IAlgebraPool(pool).token1();
+    }
+}

--- a/test/router/modules/pool/LinkedPool.Algebra.Integration.Base.t.sol
+++ b/test/router/modules/pool/LinkedPool.Algebra.Integration.Base.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {LinkedPoolIntegrationTest} from "./LinkedPoolIntegration.sol";
+
+import {AlgebraModule} from "../../../../contracts/router/modules/pool/algebra/AlgebraModule.sol";
+
+contract LinkedPoolAlgebraModuleBaseTestFork is LinkedPoolIntegrationTest {
+    // 2023-10-25
+    uint256 public constant BASE_BLOCK_NUMBER = 5731450;
+
+    // Eden's Algebra Static Quoter on Base
+    address public constant SYNTH_SWAP_STATIC_QUOTER = 0x1Db5a1d5D80fDEfc098635d3869Fa94d6fA44F5a;
+
+    // SynthSwap Router on Base
+    address public constant SYNTH_SWAP_ROUTER = 0x2dD788D8B399caa4eE92B5492A6A238Fdf2437de;
+    // SynthSwap USDC.e/DAI pool on Base
+    address public constant SYNTH_SWAP_DAI_POOL = 0x2C1E1A69ee809d3062AcE40fB83A9bFB59623d95;
+    // SynthSwap USDC.e/WETH pool on Base
+    address public constant SYNTH_SWAP_WETH_POOL = 0xE0712C087ECb8A0Dd20914626152eBf4890708c2;
+
+    // Bridged USDC (USDC_E) on Base
+    address public constant USDC_E = 0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA;
+    // DAI on Base
+    address public constant DAI = 0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb;
+    // WETH on Base
+    address public constant WETH = 0x4200000000000000000000000000000000000006;
+
+    address public synthSwapModule;
+
+    constructor() LinkedPoolIntegrationTest("base", "AlgebraModule.SynthSwap", BASE_BLOCK_NUMBER) {}
+
+    function deployModule() public override {
+        synthSwapModule = address(new AlgebraModule(SYNTH_SWAP_ROUTER, SYNTH_SWAP_STATIC_QUOTER));
+    }
+
+    function addExpectedTokens() public override {
+        // Expected order of tokens:
+        // 0: USDC.e
+        // 1: DAI
+        // 2: WETH
+        addExpectedToken(USDC_E, "USDC.e");
+        addExpectedToken(DAI, "DAI");
+        addExpectedToken(WETH, "WETH");
+    }
+
+    function addPools() public override {
+        addPool({poolName: "USDC.e/DAI", nodeIndex: 0, pool: SYNTH_SWAP_DAI_POOL, poolModule: synthSwapModule});
+        addPool({poolName: "USDC.e/WETH", nodeIndex: 0, pool: SYNTH_SWAP_WETH_POOL, poolModule: synthSwapModule});
+    }
+}

--- a/test/router/modules/pool/algebra/Algebra.Integration.Base.SynthSwap.t.sol
+++ b/test/router/modules/pool/algebra/Algebra.Integration.Base.SynthSwap.t.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IntegrationUtils} from "../../../../utils/IntegrationUtils.sol";
+
+import {LinkedPool} from "../../../../../contracts/router/LinkedPool.sol";
+import {IndexedToken, IPoolModule, AlgebraModule} from "../../../../../contracts/router/modules/pool/algebra/AlgebraModule.sol";
+
+import {IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/IERC20.sol";
+
+contract AlgebraModuleSynthSwapBaseTestFork is IntegrationUtils {
+    LinkedPool public linkedPool;
+    IPoolModule public synthSwapModule;
+
+    // 2023-10-25
+    uint256 public constant BASE_BLOCK_NUMBER = 5731450;
+
+    // Algebra Router on Base
+    address public constant SYNTH_SWAP_ROUTER = 0x2dD788D8B399caa4eE92B5492A6A238Fdf2437de;
+
+    // Eden's Algebra Static Quoter on Base
+    address public constant SYNTH_SWAP_STATIC_QUOTER = 0x1Db5a1d5D80fDEfc098635d3869Fa94d6fA44F5a;
+
+    // Algebra USDC.e/DAI pool on Base
+    address public constant SYNTH_SWAP_DAI_POOL = 0x2C1E1A69ee809d3062AcE40fB83A9bFB59623d95;
+
+    // Bridged USDC (USDC_E) on Base
+    address public constant USDC_E = 0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA;
+
+    // DAI on Base
+    address public constant DAI = 0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb;
+
+    address public user;
+
+    constructor() IntegrationUtils("base", "AlgebraModule.SynthSwap", BASE_BLOCK_NUMBER) {}
+
+    function afterBlockchainForked() public override {
+        synthSwapModule = new AlgebraModule(SYNTH_SWAP_ROUTER, SYNTH_SWAP_STATIC_QUOTER);
+        linkedPool = new LinkedPool(DAI, address(this));
+        user = makeAddr("User");
+
+        vm.label(SYNTH_SWAP_ROUTER, "AlgebraRouter");
+        vm.label(SYNTH_SWAP_STATIC_QUOTER, "AlgebraStaticQuoter");
+        vm.label(SYNTH_SWAP_DAI_POOL, "AlgebraDAIPool");
+        vm.label(USDC_E, "USDC.e");
+        vm.label(DAI, "DAI");
+    }
+
+    // ═══════════════════════════════════════════════ TESTS: VIEWS ════════════════════════════════════════════════════
+
+    function testGetPoolTokens() public {
+        address[] memory tokens = synthSwapModule.getPoolTokens(SYNTH_SWAP_DAI_POOL);
+        assertEq(tokens.length, 2);
+        // DAI address is lexicographically lower than USDC_E address
+        assertEq(tokens[0], DAI);
+        assertEq(tokens[1], USDC_E);
+    }
+
+    // ══════════════════════════════════════════════ TESTS: ADD POOL ══════════════════════════════════════════════════
+
+    function addPool() public {
+        linkedPool.addPool({nodeIndex: 0, pool: SYNTH_SWAP_DAI_POOL, poolModule: address(synthSwapModule)});
+    }
+
+    function testAddPool() public {
+        addPool();
+        assertEq(linkedPool.getToken(0), DAI);
+        assertEq(linkedPool.getToken(1), USDC_E);
+    }
+
+    // ════════════════════════════════════════════════ TESTS: SWAP ════════════════════════════════════════════════════
+
+    function swap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 amount
+    ) public returns (uint256 amountOut) {
+        vm.prank(user);
+        amountOut = linkedPool.swap({
+            nodeIndexFrom: tokenIndexFrom,
+            nodeIndexTo: tokenIndexTo,
+            dx: amount,
+            minDy: 0,
+            deadline: type(uint256).max
+        });
+    }
+
+    function testSwapFromDAItoUSDCe() public {
+        addPool();
+        uint256 amount = 100 * 10**18;
+        prepareUser(DAI, amount);
+        uint256 expectedAmountOut = linkedPool.calculateSwap({nodeIndexFrom: 0, nodeIndexTo: 1, dx: amount});
+        uint256 amountOut = swap({tokenIndexFrom: 0, tokenIndexTo: 1, amount: amount});
+        assertGt(amountOut, 0);
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(IERC20(DAI).balanceOf(user), 0);
+        assertEq(IERC20(USDC_E).balanceOf(user), amountOut);
+    }
+
+    function testSwapFromUSDCetoDAI() public {
+        addPool();
+        uint256 amount = 100 * 10**6;
+        prepareUser(USDC_E, amount);
+        uint256 expectedAmountOut = linkedPool.calculateSwap({nodeIndexFrom: 1, nodeIndexTo: 0, dx: amount});
+        uint256 amountOut = swap({tokenIndexFrom: 1, tokenIndexTo: 0, amount: amount});
+        assertGt(amountOut, 0);
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(IERC20(USDC_E).balanceOf(user), 0);
+        assertEq(IERC20(DAI).balanceOf(user), amountOut);
+    }
+
+    function testPoolSwapRevertsWhenDirectCall() public {
+        vm.expectRevert("Not a delegate call");
+        synthSwapModule.poolSwap({
+            pool: SYNTH_SWAP_DAI_POOL,
+            tokenFrom: IndexedToken({index: 0, token: DAI}),
+            tokenTo: IndexedToken({index: 1, token: USDC_E}),
+            amountIn: 100 * 10**6
+        });
+    }
+
+    function prepareUser(address token, uint256 amount) public {
+        deal(token, user, amount);
+        vm.prank(user);
+        IERC20(token).approve(address(linkedPool), amount);
+    }
+}


### PR DESCRIPTION
## Description

Adds Algebra Module, which is very similar to the UniswapV3 module.

Eden's Static Quoter contract is used again:
https://github.com/eden-network/uniswap-v3-static-quoter/blob/master/contracts/AlgebraQuoter/AlgebraStaticQuoter.sol

Comes along with tests covering SynthSwap integration on Base

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Updated the base API endpoint to enhance the system's connectivity and reliability.
- New Feature: Introduced new data structures for exact input single swaps and quote exact input single swaps, improving the flexibility and functionality of transactions.
- New Feature: Added new interfaces `IAlgebraPool` and `IAlgebraRouter` to streamline token management and transactions.
- New Feature: Implemented `AlgebraModule` contract, providing users with the ability to swap tokens and get token quotes using the Algebra protocol.
- Test: Added new test contracts for `AlgebraModule` and `LinkedPool` contracts, ensuring the robustness and reliability of the new features.
  
These updates aim to enhance the system's functionality, improve transaction flexibility, and ensure the robustness of the new features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->