### PR TITLE
Fix: bridge module approvals

### DIFF
--- a/contracts/router/SynapseRouterV2.sol
+++ b/contracts/router/SynapseRouterV2.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 import {Ownable} from "@openzeppelin/contracts-4.5.0/access/Ownable.sol";
 import {Address} from "@openzeppelin/contracts-4.5.0/utils/Address.sol";
 import {EnumerableMap} from "@openzeppelin/contracts-4.5.0/utils/structs/EnumerableMap.sol";
+import {SafeERC20, IERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/utils/SafeERC20.sol";
 
 import {DefaultRouter} from "./DefaultRouter.sol";
 import {Arrays} from "./libs/Arrays.sol";
@@ -21,6 +22,7 @@ contract SynapseRouterV2 is IRouterV2, DefaultRouter, Ownable {
     using Arrays for address[][];
     using Arrays for address[];
     using EnumerableMap for EnumerableMap.UintToAddressMap;
+    using SafeERC20 for IERC20;
 
     /// @notice swap quoter
     ISwapQuoterV2 public swapQuoter;
@@ -85,6 +87,15 @@ contract SynapseRouterV2 is IRouterV2, DefaultRouter, Ownable {
     function setSwapQuoter(ISwapQuoterV2 _swapQuoter) external onlyOwner {
         emit QuoterSet(address(swapQuoter), address(_swapQuoter));
         swapQuoter = _swapQuoter;
+    }
+
+    /// @inheritdoc IRouterV2
+    function setAllowance(
+        address token,
+        address spender,
+        uint256 amount
+    ) external onlyOwner {
+        IERC20(token).safeApprove(spender, amount);
     }
 
     /// @inheritdoc IRouterV2

--- a/contracts/router/interfaces/IRouterV2.sol
+++ b/contracts/router/interfaces/IRouterV2.sol
@@ -66,6 +66,14 @@ interface IRouterV2 {
     /// @param _swapQuoter Swap Quoter
     function setSwapQuoter(ISwapQuoterV2 _swapQuoter) external;
 
+    /// @notice Sets a custom allowance for the given token.
+    /// @dev Reverts if not router owner. To be used for the wrapper token setups.
+    function setAllowance(
+        address token,
+        address spender,
+        uint256 amount
+    ) external;
+
     /// @notice Whitelists a new bridge module for users to route through
     /// @dev Reverts if not router owner
     /// @param moduleId Unique bridge module ID

--- a/contracts/router/modules/bridge/SynapseBridgeModule.sol
+++ b/contracts/router/modules/bridge/SynapseBridgeModule.sol
@@ -38,8 +38,11 @@ contract SynapseBridgeModule is OnlyDelegateCall, IBridgeModule {
         (ILocalBridgeConfig.TokenType tokenType, address bridgeToken) = localBridgeConfig.config(token);
         // Use config.bridgeToken as the token address for the bridging purposes
         if (bridgeToken == address(0)) revert SynapseBridgeModule__UnsupportedToken(token);
-        // Approve the bridge to spend the token
-        bridgeToken.universalApproveInfinity({spender: address(synapseBridge), amountToSpend: amount});
+        // Don't issue the approval if the wrapper token is involved
+        // In this case the approval is either unnecessary or manually set in the SynapseRouterV2 using `setAllowance`
+        if (token == bridgeToken) {
+            bridgeToken.universalApproveInfinity({spender: address(synapseBridge), amountToSpend: amount});
+        }
         // Proceed with the bridging transaction based on the token type
         if (tokenType == ILocalBridgeConfig.TokenType.Redeem) {
             _redeemToken(to, chainId, bridgeToken, amount, destQuery);

--- a/test/router/modules/bridge/SynapseBridgeModule.Integration.Avalanche.t.sol
+++ b/test/router/modules/bridge/SynapseBridgeModule.Integration.Avalanche.t.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {Action, DefaultParams, SwapQuery} from "../../../../contracts/router/libs/Structs.sol";
+import {DelegateCaller} from "./DelegateCaller.sol";
+import {IntegrationUtils} from "../../../utils/IntegrationUtils.sol";
+import {SynapseBridgeModule, SynapseRouterV2BridgeUtils} from "../../v2/integration/SynapseRouterV2.BridgeUtils.sol";
+
+contract SynapseBridgeModuleAvalancheIntegrationTestFork is SynapseRouterV2BridgeUtils, IntegrationUtils {
+    // 2023-11-01
+    uint256 public constant AVAX_BLOCK_NUMBER = 37199000;
+
+    address private constant AVAX_SYN_ROUTER_V1 = 0x7E7A0e201FD38d3ADAA9523Da6C109a07118C96a;
+    address private constant AVAX_SYN_BRIDGE = 0xC05e61d0E7a63D27546389B7aD62FdFf5A91aACE;
+
+    // Deposit token
+    address private constant BTC_B = 0x152b9d0FdC40C096757F570A51E494bd4b943E50;
+
+    // Redeem token
+    address private constant NUSD = 0xCFc37A6AB183dd4aED08C204D1c2773c0b1BDf46;
+
+    // Redeem token with a wrapper
+    address private constant GMX = 0x62edc0692BD897D2295872a9FFCac5425011c661;
+    address private constant GMX_WRAPPER = 0x20A9DC684B4d0407EF8C9A302BEAaA18ee15F656;
+
+    DelegateCaller public routerMock;
+
+    constructor() IntegrationUtils("avalanche", "SynapseBridgeModule", AVAX_BLOCK_NUMBER) {}
+
+    function afterBlockchainForked() public override {
+        synapseLocalBridgeConfig = AVAX_SYN_ROUTER_V1;
+        synapseBridge = AVAX_SYN_BRIDGE;
+
+        deploySynapseBridgeModule();
+        routerMock = new DelegateCaller();
+    }
+
+    function test_delegateBridge_deposit() public {
+        // Deal tokens directly to the Router Mock
+        uint256 amount = 1e8;
+        deal(BTC_B, address(routerMock), amount);
+        depositEvent = DepositEvent({to: address(1), chainId: 2, token: BTC_B, amount: amount});
+        SwapQuery memory destQuery;
+        bytes memory delegatedCall = abi.encodeCall(
+            SynapseBridgeModule.delegateBridge,
+            (address(1), 2, BTC_B, amount, destQuery)
+        );
+        expectDepositEvent();
+        routerMock.performDelegateCall(synapseBridgeModule, delegatedCall);
+    }
+
+    function test_delegateBridge_depositAndSwap() public {
+        // Deal tokens directly to the Router Mock
+        uint256 amount = 1e8;
+        deal(BTC_B, address(routerMock), amount);
+        depositAndSwapEvent = DepositAndSwapEvent({
+            to: address(1),
+            chainId: 2,
+            token: BTC_B,
+            amount: amount,
+            tokenIndexFrom: 3,
+            tokenIndexTo: 4,
+            minDy: 5,
+            deadline: 6
+        });
+        SwapQuery memory destQuery = SwapQuery({
+            routerAdapter: address(7),
+            tokenOut: address(8),
+            minAmountOut: 5,
+            deadline: 6,
+            rawParams: getSwapParams({pool: address(9), indexFrom: 3, indexTo: 4})
+        });
+        bytes memory delegatedCall = abi.encodeCall(
+            SynapseBridgeModule.delegateBridge,
+            (address(1), 2, BTC_B, amount, destQuery)
+        );
+        expectDepositAndSwapEvent();
+        routerMock.performDelegateCall(synapseBridgeModule, delegatedCall);
+    }
+
+    function test_delegateBridge_redeem() public {
+        // Deal tokens directly to the Router Mock
+        uint256 amount = 1e18;
+        deal(NUSD, address(routerMock), amount);
+        redeemEvent = RedeemEvent({to: address(1), chainId: 2, token: NUSD, amount: amount});
+        SwapQuery memory destQuery;
+        bytes memory delegatedCall = abi.encodeCall(
+            SynapseBridgeModule.delegateBridge,
+            (address(1), 2, NUSD, amount, destQuery)
+        );
+        expectRedeemEvent();
+        routerMock.performDelegateCall(synapseBridgeModule, delegatedCall);
+    }
+
+    function test_delegateBridge_redeem_wrapper_GMX() public {
+        // Deal GMX tokens (the user facing token) directly to the Router Mock
+        uint256 amount = 1e18;
+        deal(GMX, address(routerMock), amount);
+        // The actual bridge token is the wrapper
+        redeemEvent = RedeemEvent({to: address(1), chainId: 2, token: GMX_WRAPPER, amount: amount});
+        SwapQuery memory destQuery;
+        bytes memory delegatedCall = abi.encodeCall(
+            SynapseBridgeModule.delegateBridge,
+            (address(1), 2, GMX, amount, destQuery)
+        );
+        expectRedeemEvent();
+        routerMock.performDelegateCall(synapseBridgeModule, delegatedCall);
+    }
+
+    function test_delegateBridge_redeemAndSwap() public {
+        // Deal tokens directly to the Router Mock
+        uint256 amount = 1e18;
+        deal(NUSD, address(routerMock), amount);
+        redeemAndSwapEvent = RedeemAndSwapEvent({
+            to: address(1),
+            chainId: 2,
+            token: NUSD,
+            amount: amount,
+            tokenIndexFrom: 3,
+            tokenIndexTo: 4,
+            minDy: 5,
+            deadline: 6
+        });
+        SwapQuery memory destQuery = SwapQuery({
+            routerAdapter: address(7),
+            tokenOut: address(8),
+            minAmountOut: 5,
+            deadline: 6,
+            rawParams: getSwapParams({pool: address(9), indexFrom: 3, indexTo: 4})
+        });
+        bytes memory delegatedCall = abi.encodeCall(
+            SynapseBridgeModule.delegateBridge,
+            (address(1), 2, NUSD, amount, destQuery)
+        );
+        expectRedeemAndSwapEvent();
+        routerMock.performDelegateCall(synapseBridgeModule, delegatedCall);
+    }
+
+    function test_delegateBridge_redeemAndRemove() public {
+        // Deal tokens directly to the Router Mock
+        uint256 amount = 1e18;
+        deal(NUSD, address(routerMock), amount);
+        redeemAndRemoveEvent = RedeemAndRemoveEvent({
+            to: address(1),
+            chainId: 2,
+            token: NUSD,
+            amount: amount,
+            swapTokenIndex: 3,
+            swapMinAmount: 4,
+            swapDeadline: 5
+        });
+        SwapQuery memory destQuery = SwapQuery({
+            routerAdapter: address(6),
+            tokenOut: address(7),
+            minAmountOut: 4,
+            deadline: 5,
+            rawParams: getRemoveLiquidityParams({pool: address(8), indexTo: 3})
+        });
+        bytes memory delegatedCall = abi.encodeCall(
+            SynapseBridgeModule.delegateBridge,
+            (address(1), 2, NUSD, amount, destQuery)
+        );
+        expectRedeemAndRemoveEvent();
+        routerMock.performDelegateCall(synapseBridgeModule, delegatedCall);
+    }
+
+    function getSwapParams(
+        address pool,
+        uint8 indexFrom,
+        uint8 indexTo
+    ) internal pure returns (bytes memory) {
+        return abi.encode(DefaultParams(Action.Swap, pool, indexFrom, indexTo));
+    }
+
+    function getRemoveLiquidityParams(address pool, uint8 indexTo) internal pure returns (bytes memory) {
+        // indexFrom is set to 0xFF
+        return abi.encode(DefaultParams(Action.RemoveLiquidity, pool, 0xFF, indexTo));
+    }
+}

--- a/test/router/modules/bridge/SynapseBridgeModule.Wrappers.t.sol
+++ b/test/router/modules/bridge/SynapseBridgeModule.Wrappers.t.sol
@@ -16,6 +16,12 @@ contract SynapseBridgeModuleWrappersTest is SynapseBridgeModuleTest {
         redeemWrapperToken = address(new MockWrapperToken(redeemToken));
         vm.label(depositWrapperToken, "DWT");
         vm.label(redeemWrapperToken, "RWT");
+        // Approve spending of wrapper tokens on behalf of the delegate caller
+        // In practice, this would be done by SynapseRouter.setAllowance()
+        vm.startPrank(address(delegateCaller));
+        MockWrapperToken(depositWrapperToken).approve(synapseBridge, type(uint256).max);
+        MockWrapperToken(redeemWrapperToken).approve(synapseBridge, type(uint256).max);
+        vm.stopPrank();
     }
 
     function addTokens() public virtual override {

--- a/test/router/v2/SynapseRouterV2.Management.t.sol
+++ b/test/router/v2/SynapseRouterV2.Management.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import {BasicSynapseRouterV2Test} from "./BasicSynapseRouterV2.t.sol";
+import {BasicSynapseRouterV2Test, MockERC20} from "./BasicSynapseRouterV2.t.sol";
 import {SwapQuoterV2} from "../../../contracts/router/quoter/SwapQuoterV2.sol";
 import {SynapseRouterV2} from "../../../contracts/router/SynapseRouterV2.sol";
 
@@ -49,6 +49,19 @@ contract SynapseRouterV2ManagementTest is BasicSynapseRouterV2Test {
 
         vm.expectRevert("Ownable: caller is not the owner");
         router.setSwapQuoter(newSwapQuoter);
+    }
+
+    function test_setAllowance_setsAllowance() public {
+        MockERC20 token = new MockERC20("Mock", 18);
+        vm.prank(owner);
+        router.setAllowance(address(token), address(1234), 5678);
+        assertEq(token.allowance(address(router), address(1234)), 5678);
+    }
+
+    function test_setAllowance_revert_callerNotOwner() public {
+        MockERC20 token = new MockERC20("Mock", 18);
+        vm.expectRevert("Ownable: caller is not the owner");
+        router.setAllowance(address(token), address(1234), 5678);
     }
 
     function test_connectBridgeModule(bytes32 moduleId, address module) public {


### PR DESCRIPTION
## Description

Ports the SynapseRouterV1 approach to approving bridge tokens, when interacting with `SynapseBridge`. Tokens that have different contracts for "user-facing token" and "bridge token" (aka bridge wrapper token) are now no longer approved prior to Bridge interaction. Instead, the `SynapseRouterV2` owner is supposed to manually approve these tokens, if needed.

For instance, GMX on Avalanche is the edge case here. Uses a separate wrapper contract, which doesn't require any additional approvals.
https://github.com/synapsecns/synapse-contracts/blob/c83ded215bf72642bf5c0e2f206986ae22b6cf8c/test/router/modules/bridge/SynapseBridgeModule.Integration.Avalanche.t.sol#L95-L108

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

New Features:
- Added `setAllowance` function in `SynapseRouterV2` and `IRouterV2` interface, enabling the router owner to set custom token allowances.
- Introduced a condition in `SynapseBridgeModule` to handle wrapper token cases, improving token approval process.

Tests:
- Created `SynapseBridgeModuleAvalancheIntegrationTestFork` contract for comprehensive testing of deposit, swap, and redeem functionalities.
- Added tests in `SynapseRouterV2.Management.t.sol` to verify the correct operation of the new `setAllowance` function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->