### PR TITLE
Add integration tests for linked pool configs

### DIFF
--- a/script/foundry-integration.sh
+++ b/script/foundry-integration.sh
@@ -30,9 +30,7 @@ for TEST_FILE in $INTEGRATION_TESTS; do
   #   $CHAIN_NAME $CONTRACT_NAME
   # We need to extract the chain and contract name from this output.
   TEST_ARGS=$(forge script $INSPECT_PATH --sig "run(string)" $INSPECT_ARGS | awk '/==/ {getline; print}')
-  CHAIN_NAME=$(awk '{print $1}' <<<$TEST_ARGS)
-  CONTRACT_NAME=$(awk '{print $2}' <<<$TEST_ARGS)
-  RUN_IF_DEPLOYED=$(awk '{print $3}' <<<$TEST_ARGS)
+  read -r CHAIN_NAME CONTRACT_NAME RUN_IF_DEPLOYED <<< "$TEST_ARGS"
   # Check that both the chain and contract name are not empty.
   if [ -z "$CHAIN_NAME" ] || [ -z "$CONTRACT_NAME" ]; then
     echo "  [CHAIN_NAME=$CHAIN_NAME] [CONTRACT_NAME=$CONTRACT_NAME]"

--- a/script/foundry-integration.sh
+++ b/script/foundry-integration.sh
@@ -62,7 +62,7 @@ done
 echo "Running ${#TESTS_TO_RUN[@]} integration tests"
 # Run integration tests one by one to decrease the amount of rate limit errors.
 for TEST_FILE in ${TESTS_TO_RUN[@]}; do
-  forge test --match-path $TEST_FILE
+  forge test -vv --match-path $TEST_FILE
   # Sleep for 5 seconds to avoid rate limit errors.
   sleep 5
 done

--- a/script/integration/InspectIntegration.s.sol
+++ b/script/integration/InspectIntegration.s.sol
@@ -8,7 +8,12 @@ import {console, Script} from "forge-std/Script.sol";
 contract InspectIntegration is Script {
     function run(string memory testContractName) external {
         IntegrationTest testContract = IntegrationTest(deployCode(testContractName));
-        // Log chain and contract name.
-        console.log("%s %s", testContract.chainName(), testContract.contractName());
+        // Log chain and contract name. Also log the "run-if-deployed" flag.
+        console.log(
+            "%s %s %s",
+            testContract.chainName(),
+            testContract.contractName(),
+            testContract.runIfDeployed() ? 1 : 0
+        );
     }
 }

--- a/test/interfaces/ISynth.sol
+++ b/test/interfaces/ISynth.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.12;
+
+/// @notice Interface to enable minting of sUSD in tests
+/// @dev Instead of using `deal(sUSD, user, amount)` in tests, use:
+/// `deal(ISynth(sUSD).target().tokenState(), user, amount)`
+interface ISynth {
+    function target() external view returns (ITarget);
+}
+
+interface ITarget {
+    function tokenState() external view returns (address);
+}

--- a/test/router/linkedPool/LinkedPoolConfig.Integration.Arbitrum.USDC.t.sol
+++ b/test/router/linkedPool/LinkedPoolConfig.Integration.Arbitrum.USDC.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {LinkedPoolConfigIntegrationTest} from "./LinkedPoolConfigIntegration.sol";
+
+contract LinkedPoolConfigUSDCArbTestFork is LinkedPoolConfigIntegrationTest {
+    // 2023-11-04
+    uint256 public constant ARB_BLOCK_NUMBER = 147000000;
+
+    /// @notice Test swaps worth 10_000 USDC
+    uint256 public constant SWAP_VALUE = 10_000;
+
+    /// @notice Used pools have accurate quoting functions, so should have no delta
+    uint256 public constant MAX_PERCENT_DELTA = 0;
+
+    constructor()
+        LinkedPoolConfigIntegrationTest("arbitrum", ARB_BLOCK_NUMBER, "CCTP.USDC", SWAP_VALUE, MAX_PERCENT_DELTA)
+    {}
+}

--- a/test/router/linkedPool/LinkedPoolConfig.Integration.Avalanche.USDC.t.sol
+++ b/test/router/linkedPool/LinkedPoolConfig.Integration.Avalanche.USDC.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {LinkedPoolConfigIntegrationTest} from "./LinkedPoolConfigIntegration.sol";
+
+contract LinkedPoolConfigUSDCAvaxTestFork is LinkedPoolConfigIntegrationTest {
+    // 2023-11-04
+    uint256 public constant AVAX_BLOCK_NUMBER = 37320000;
+
+    /// @notice Test swaps worth 10_000 USDC
+    uint256 public constant SWAP_VALUE = 10_000;
+
+    /// @notice Used pools have accurate quoting functions, so should have no delta
+    uint256 public constant MAX_PERCENT_DELTA = 0;
+
+    constructor()
+        LinkedPoolConfigIntegrationTest("avalanche", AVAX_BLOCK_NUMBER, "CCTP.USDC", SWAP_VALUE, MAX_PERCENT_DELTA)
+    {}
+}

--- a/test/router/linkedPool/LinkedPoolConfig.Integration.Base.USDC.t.sol
+++ b/test/router/linkedPool/LinkedPoolConfig.Integration.Base.USDC.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {LinkedPoolConfigIntegrationTest} from "./LinkedPoolConfigIntegration.sol";
+
+contract LinkedPoolConfigUSDCBaseTestFork is LinkedPoolConfigIntegrationTest {
+    // 2023-11-04
+    uint256 public constant BASE_BLOCK_NUMBER = 6150000;
+
+    /// @notice Test swaps worth 10_000 USDC
+    uint256 public constant SWAP_VALUE = 10_000;
+
+    /// @notice Used pools have accurate quoting functions, so should have no delta
+    uint256 public constant MAX_PERCENT_DELTA = 0;
+
+    constructor()
+        LinkedPoolConfigIntegrationTest("base", BASE_BLOCK_NUMBER, "CCTP.USDC", SWAP_VALUE, MAX_PERCENT_DELTA)
+    {}
+}

--- a/test/router/linkedPool/LinkedPoolConfig.Integration.Optimism.USDC.t.sol
+++ b/test/router/linkedPool/LinkedPoolConfig.Integration.Optimism.USDC.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {LinkedPoolConfigIntegrationTest} from "./LinkedPoolConfigIntegration.sol";
+import {ISynth} from "../../interfaces/ISynth.sol";
+
+contract LinkedPoolConfigUSDCOptTestFork is LinkedPoolConfigIntegrationTest {
+    // 2023-11-04
+    uint256 public constant OPT_BLOCK_NUMBER = 111750000;
+
+    /// @notice Test swaps worth 10_000 USDC
+    uint256 public constant SWAP_VALUE = 10_000;
+
+    /// @notice Used pools have accurate quoting functions, so should have no delta
+    uint256 public constant MAX_PERCENT_DELTA = 0;
+
+    /// @notice Optimism sUSD
+    address public constant SUSD = 0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9;
+
+    constructor()
+        LinkedPoolConfigIntegrationTest("optimism", OPT_BLOCK_NUMBER, "CCTP.USDC", SWAP_VALUE, MAX_PERCENT_DELTA)
+    {}
+
+    /// @dev sUSD requires special logic for deal cheatcode to work, as the balances are stored externally
+    function setBalance(address token, uint256 amount) internal virtual override {
+        if (token == SUSD) {
+            token = ISynth(SUSD).target().tokenState();
+        }
+        super.setBalance(token, amount);
+    }
+}

--- a/test/router/linkedPool/LinkedPoolConfig.Integration.Optimism.nUSD.t.sol
+++ b/test/router/linkedPool/LinkedPoolConfig.Integration.Optimism.nUSD.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {LinkedPoolConfigIntegrationTest} from "./LinkedPoolConfigIntegration.sol";
+import {ISynth} from "../../interfaces/ISynth.sol";
+
+contract LinkedPoolConfigNUSDOptTestFork is LinkedPoolConfigIntegrationTest {
+    // 2023-11-04
+    uint256 public constant OPT_BLOCK_NUMBER = 111750000;
+
+    /// @notice Test swaps worth 10_000 USDC
+    uint256 public constant SWAP_VALUE = 10_000;
+
+    /// @notice Used pools have accurate quoting functions, so should have no delta
+    uint256 public constant MAX_PERCENT_DELTA = 0;
+
+    /// @notice Optimism sUSD
+    address public constant SUSD = 0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9;
+
+    constructor()
+        LinkedPoolConfigIntegrationTest("optimism", OPT_BLOCK_NUMBER, "nUSD", SWAP_VALUE, MAX_PERCENT_DELTA)
+    {}
+
+    /// @dev sUSD requires special logic for deal cheatcode to work, as the balances are stored externally
+    function setBalance(address token, uint256 amount) internal virtual override {
+        if (token == SUSD) {
+            token = ISynth(SUSD).target().tokenState();
+        }
+        super.setBalance(token, amount);
+    }
+}

--- a/test/router/linkedPool/LinkedPoolConfigIntegration.sol
+++ b/test/router/linkedPool/LinkedPoolConfigIntegration.sol
@@ -73,6 +73,10 @@ abstract contract LinkedPoolConfigIntegrationTest is IntegrationUtils {
         maxPercentDelta = maxPercentDelta_;
     }
 
+    function runIfDeployed() external pure override returns (bool) {
+        return true;
+    }
+
     // ═══════════════════════════════════════════════════ SETUP ═══════════════════════════════════════════════════════
 
     function afterBlockchainForked() public virtual override {

--- a/test/router/linkedPool/LinkedPoolConfigIntegration.sol
+++ b/test/router/linkedPool/LinkedPoolConfigIntegration.sol
@@ -73,10 +73,6 @@ abstract contract LinkedPoolConfigIntegrationTest is IntegrationUtils {
         maxPercentDelta = maxPercentDelta_;
     }
 
-    function runIfDeployed() external pure override returns (bool) {
-        return true;
-    }
-
     // ═══════════════════════════════════════════════════ SETUP ═══════════════════════════════════════════════════════
 
     function afterBlockchainForked() public virtual override {

--- a/test/router/linkedPool/LinkedPoolConfigIntegration.sol
+++ b/test/router/linkedPool/LinkedPoolConfigIntegration.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {LinkedPool} from "../../../contracts/router/LinkedPool.sol";
+
+import {ModuleNaming} from "../../../script/router/linkedPool/ModuleNaming.sol";
+import {StringUtils} from "../../../script/templates/StringUtils.sol";
+
+import {IntegrationUtils} from "../../utils/IntegrationUtils.sol";
+
+import {console2, stdJson} from "forge-std/Test.sol";
+
+import {IERC20, SafeERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/utils/SafeERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts-4.5.0/token/ERC20/extensions/IERC20Metadata.sol";
+
+abstract contract LinkedPoolConfigIntegrationTest is IntegrationUtils {
+    using ModuleNaming for string;
+    using SafeERC20 for IERC20;
+    using stdJson for string;
+    using StringUtils for *;
+
+    // enforce alphabetical order to match the JSON order
+    struct PoolParams {
+        uint256 nodeIndex;
+        address pool;
+        string poolModule;
+    }
+
+    LinkedPool public linkedPool;
+    uint256 public tokenNodesAmount;
+    string public linkedPoolAlias;
+    string public linkedPoolConfig;
+
+    address[] public tokens;
+    mapping(address => string) public tokenSymbols;
+    mapping(address => uint256) public tokenDecimals;
+    // nodeIndexFrom => nodeIndexTo => common pools address (zero if none)
+    mapping(uint256 => mapping(uint256 => address)) public commonPool;
+
+    /// @notice Swap value to be used as amountIn for all swaps, before token decimals are applied
+    /// @dev Use something like 10_000 for USD tokens, 10 for ETH tokens
+    uint256 public swapValue;
+
+    address public user;
+
+    constructor(
+        string memory chainName_,
+        uint256 forkBlockNumber,
+        string memory bridgeSymbol_,
+        uint256 swapValue_
+    ) IntegrationUtils(chainName_, linkedPoolAlias = string.concat("LinkedPool.", bridgeSymbol_), forkBlockNumber) {
+        user = makeAddr("User");
+        swapValue = swapValue_;
+    }
+
+    // ═══════════════════════════════════════════════════ SETUP ═══════════════════════════════════════════════════════
+
+    function afterBlockchainForked() public virtual override {
+        readPoolConfig();
+        deployLinkedPool();
+        addPools();
+        readTokens();
+    }
+
+    function readPoolConfig() internal virtual {
+        string memory configFN = string.concat("script/configs/", chainName, "/", linkedPoolAlias, ".dc.json");
+        linkedPoolConfig = vm.readFile(configFN);
+    }
+
+    function deployLinkedPool() internal virtual {
+        address bridgeToken = linkedPoolConfig.readAddress(".bridgeToken");
+        linkedPool = new LinkedPool({bridgeToken: bridgeToken, owner_: address(this)});
+    }
+
+    function addPools() internal virtual {
+        bytes memory encodedPools = linkedPoolConfig.parseRaw(".pools");
+        PoolParams[] memory poolParamsList = abi.decode(encodedPools, (PoolParams[]));
+        for (uint256 i = 0; i < poolParamsList.length; i++) {
+            addPool(poolParamsList[i]);
+        }
+    }
+
+    function addPool(PoolParams memory poolParams) internal virtual {
+        address poolModule = bytes(poolParams.poolModule).length == 0
+            ? address(0)
+            : getDeploymentAddress(poolParams.poolModule.getModuleDeploymentName());
+        uint256 amountBefore = linkedPool.tokenNodesAmount();
+        linkedPool.addPool(poolParams.nodeIndex, poolParams.pool, poolModule);
+        uint256 amountAfter = linkedPool.tokenNodesAmount();
+        // New node indexes are [amountBefore, amountAfter)
+        for (uint256 i = amountBefore; i < amountAfter; i++) {
+            markSamePool(poolParams.nodeIndex, i, poolParams.pool);
+            for (uint256 j = amountBefore; j < i; j++) {
+                markSamePool(i, j, poolParams.pool);
+            }
+        }
+    }
+
+    function markSamePool(
+        uint256 nodeIndexFrom,
+        uint256 nodeIndexTo,
+        address pool
+    ) internal virtual {
+        if (nodeIndexFrom == nodeIndexTo) {
+            return;
+        }
+        commonPool[nodeIndexFrom][nodeIndexTo] = pool;
+        commonPool[nodeIndexTo][nodeIndexFrom] = pool;
+    }
+
+    function readTokens() internal virtual {
+        tokenNodesAmount = linkedPool.tokenNodesAmount();
+        for (uint8 i = 0; i < tokenNodesAmount; i++) {
+            address token = linkedPool.getToken(i);
+            tokens.push(token);
+            tokenSymbols[token] = IERC20Metadata(token).symbol();
+            tokenDecimals[token] = IERC20Metadata(token).decimals();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════ TESTS ═══════════════════════════════════════════════════════
+
+    function testSwapsFromRoot() public {
+        for (uint8 nodeIndexFrom = 1; nodeIndexFrom < tokenNodesAmount; nodeIndexFrom++) {
+            checkSwap(0, nodeIndexFrom);
+        }
+    }
+
+    function testSwapsToRoot() public {
+        for (uint8 nodeIndexTo = 1; nodeIndexTo < tokenNodesAmount; nodeIndexTo++) {
+            checkSwap(nodeIndexTo, 0);
+        }
+    }
+
+    function testSwapsBetweenNodes() public {
+        for (uint8 nodeIndexFrom = 1; nodeIndexFrom < tokenNodesAmount; nodeIndexFrom++) {
+            for (uint8 nodeIndexTo = 1; nodeIndexTo < tokenNodesAmount; nodeIndexTo++) {
+                checkSwap(nodeIndexFrom, nodeIndexTo);
+            }
+        }
+    }
+
+    function checkSwap(uint8 nodeIndexFrom, uint8 nodeIndexTo) internal {
+        if (nodeIndexFrom == nodeIndexTo) {
+            return;
+        }
+        uint256 snapshotId = vm.snapshot();
+        (uint256 amountIn, uint256 expectedAmountOut) = logExpectedSwap(nodeIndexFrom, nodeIndexTo);
+        // Record balance before minting in case tokenFrom == tokenTo
+        uint256 amountBefore = IERC20(tokens[nodeIndexTo]).balanceOf(user);
+        prepareUser(tokens[nodeIndexFrom], amountIn);
+        if (expectedAmountOut == 0) {
+            vm.expectRevert();
+        }
+        vm.prank(user);
+        linkedPool.swap({
+            nodeIndexFrom: nodeIndexFrom,
+            nodeIndexTo: nodeIndexTo,
+            dx: amountIn,
+            minDy: 0,
+            deadline: block.timestamp
+        });
+        if (expectedAmountOut > 0) {
+            uint256 amountAfter = IERC20(tokens[nodeIndexTo]).balanceOf(user);
+            assertEq(amountAfter - amountBefore, expectedAmountOut);
+        }
+        // Revert to the snapshot to reset the balances
+        // This way every test is independent
+        assert(vm.revertTo(snapshotId));
+    }
+
+    // ══════════════════════════════════════════════════ LOGGING ══════════════════════════════════════════════════════
+
+    function logExpectedSwap(uint8 nodeIndexFrom, uint8 nodeIndexTo)
+        internal
+        view
+        returns (uint256 amountIn, uint256 expectedAmountOut)
+    {
+        address tokenFrom = tokens[nodeIndexFrom];
+        address tokenTo = tokens[nodeIndexTo];
+        amountIn = getTestAmount(tokenFrom);
+        expectedAmountOut = linkedPool.calculateSwap(nodeIndexFrom, nodeIndexTo, amountIn);
+        console2.log("Swapping %s -> %s", nodeIndexFrom, nodeIndexTo);
+        console2.log("   amountIn: %s %s", amountIn.fromFloat(tokenDecimals[tokenFrom]), tokenSymbols[tokenFrom]);
+        console2.log("  amountOut: %s %s", expectedAmountOut.fromFloat(tokenDecimals[tokenTo]), tokenSymbols[tokenTo]);
+        if (expectedAmountOut == 0) {
+            logAmountOutZero(nodeIndexFrom, nodeIndexTo);
+        }
+    }
+
+    function logAmountOutZero(uint8 nodeIndexFrom, uint8 nodeIndexTo) internal view {
+        // Print a warning only if the swap path contains exactly 1 pool to avoid spamming the console
+        address pool = commonPool[nodeIndexFrom][nodeIndexTo];
+        if (pool == address(0)) return;
+        console2.log(unicode"❗❗❗ WARNING: no quote for pool %s", pool);
+    }
+
+    // ══════════════════════════════════════════════════ HELPERS ══════════════════════════════════════════════════════
+
+    function getDeploymentAddress(string memory contractAlias) internal view returns (address) {
+        string memory deploymentFN = string.concat("deployments/", chainName, "/", contractAlias, ".json");
+        string memory deploymentJSON = vm.readFile(deploymentFN);
+        return deploymentJSON.readAddress(".address");
+    }
+
+    function getTestAmount(address token) internal view virtual returns (uint256) {
+        return swapValue * 10**IERC20Metadata(token).decimals();
+    }
+
+    // Could be overridden if `deal` does not work with the token
+    function setBalance(address token, uint256 amount) internal virtual {
+        deal(token, user, amount);
+    }
+
+    function prepareUser(address token, uint256 amount) internal {
+        setBalance(token, amount);
+        vm.startPrank(user);
+        IERC20(token).safeApprove(address(linkedPool), amount);
+        vm.stopPrank();
+    }
+}

--- a/test/utils/IntegrationTest.sol
+++ b/test/utils/IntegrationTest.sol
@@ -8,4 +8,9 @@ interface IntegrationTest {
     /// @notice Returns the name of the contract to be tested.
     /// @dev The integration test will be skipped if the contract has already been deployed.
     function contractName() external view returns (string memory);
+
+    /// @notice Whether to run the integration test, if the tested contract is already deployed.
+    /// @dev This is set to false by default. Could be overridden to true to enable the CI workflow
+    /// for the deployed contract that has the config updated.
+    function runIfDeployed() external view returns (bool);
 }

--- a/test/utils/IntegrationUtils.sol
+++ b/test/utils/IntegrationUtils.sol
@@ -9,7 +9,9 @@ import {Test, console} from "forge-std/Test.sol";
 abstract contract IntegrationUtils is Test, IntegrationTest {
     using StringUtils for string;
 
+    /// @inheritdoc IntegrationTest
     string public chainName;
+    /// @inheritdoc IntegrationTest
     string public contractName;
 
     string private _envRPC;
@@ -43,4 +45,9 @@ abstract contract IntegrationUtils is Test, IntegrationTest {
     }
 
     function afterBlockchainForked() public virtual {}
+
+    /// @inheritdoc IntegrationTest
+    function runIfDeployed() external view virtual returns (bool) {
+        return false;
+    }
 }


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

Adds a template for running an integration tests for LinkedPool configs, assuming the pool modules are already deployed. Test is split into three sub-tests for better readability:
- Swaps from a root node (bridge token) into other nodes.
- Swaps from a non-root node into the root node.
- Swaps between non-root nodes.

For every tested route we check that the swap matches the quote returned by `linkedPool.calculateSwap()`:
- It is possible to define a max relative error for the quote, if any of the pools doesn't have a precise quote getter.
- If `linkedPool.calculateSwap()` returns zero, two things are done:
  - We check that the swap ends up in a revert
  - We log such situation, if the nodes are connected by the same pool. We don't revert here, as some of the pools might be able to swap only in a single direction (e.g. GMX when unbalanced), but it's a good idea to track such logs to make sure we don't have pools that do nothing in the config.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new testing interfaces and contracts to enhance the testing process.
  - Added a new flag "run-if-deployed" to control the execution of tests based on contract deployment status.
- **Refactor**
  - Renamed and introduced new variables in the foundry integration script for better readability and functionality.
- **Tests**
  - Added new functions to the `IntegrationTest` interface to provide more control over the testing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->