### PR TITLE
Feat: nexus pool module

### DIFF
--- a/contracts/router/modules/pool/default/NexusPoolModule.sol
+++ b/contracts/router/modules/pool/default/NexusPoolModule.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
+import {IDefaultExtendedPool} from "../../../interfaces/IDefaultExtendedPool.sol";
 import {IDefaultPoolCalc} from "../../../interfaces/IDefaultPoolCalc.sol";
 import {IndexedToken, IPoolModule} from "../../../interfaces/IPoolModule.sol";
 
@@ -41,4 +42,25 @@ contract NexusPoolModule is OnlyDelegateCall, IPoolModule {
 
     /// @inheritdoc IPoolModule
     function getPoolTokens(address pool) external view returns (address[] memory tokens) {}
+
+    // ══════════════════════════════════════════════ INTERNAL VIEWS ═══════════════════════════════════════════════════
+
+    /// @dev Returns the LP token address for the given pool.
+    function _lpToken(address pool) internal view returns (address lpToken) {
+        (, , , , , , lpToken) = IDefaultExtendedPool(pool).swapStorage();
+    }
+
+    /// @dev Returns the number of tokens in the pool, excluding the LP token.
+    function _numTokens(address pool) internal view returns (uint256 numTokens) {
+        /// @dev same logic as LinkedPool.sol::_getPoolTokens
+        while (true) {
+            try IDefaultExtendedPool(pool).getToken(uint8(numTokens)) returns (address) {
+                unchecked {
+                    ++numTokens;
+                }
+            } catch {
+                break;
+            }
+        }
+    }
 }

--- a/contracts/router/modules/pool/default/NexusPoolModule.sol
+++ b/contracts/router/modules/pool/default/NexusPoolModule.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.17;
 
 import {IDefaultExtendedPool} from "../../../interfaces/IDefaultExtendedPool.sol";
 import {IDefaultPoolCalc} from "../../../interfaces/IDefaultPoolCalc.sol";
+import {IPausable} from "../../../interfaces/IPausable.sol";
 import {IndexedToken, IPoolModule} from "../../../interfaces/IPoolModule.sol";
 
 import {OnlyDelegateCall} from "../../OnlyDelegateCall.sol";
@@ -13,6 +14,7 @@ import {OnlyDelegateCall} from "../../OnlyDelegateCall.sol";
 /// @dev Implements IPoolModule interface to be used with pools added to LinkedPool router
 contract NexusPoolModule is OnlyDelegateCall, IPoolModule {
     error NexusPoolModule__EqualIndexes(uint8 tokenIndex);
+    error NexusPoolModule__Paused();
     error NexusPoolModule__UnsupportedIndex(uint8 tokenIndex);
     error NexusPoolModule__UnsupportedPool(address pool);
 
@@ -69,6 +71,7 @@ contract NexusPoolModule is OnlyDelegateCall, IPoolModule {
         onlySupportedIndexes(tokenFrom.index, tokenTo.index)
         returns (uint256 amountOut)
     {
+        if (probePaused && IPausable(pool).paused()) revert NexusPoolModule__Paused();
         if (tokenFrom.index == nexusPoolNumTokens) {
             // Case 1: tokenFrom == nUSD -> remove liquidity
             amountOut = IDefaultExtendedPool(pool).calculateRemoveLiquidityOneToken({

--- a/contracts/router/modules/pool/default/NexusPoolModule.sol
+++ b/contracts/router/modules/pool/default/NexusPoolModule.sol
@@ -13,9 +13,17 @@ import {OnlyDelegateCall} from "../../OnlyDelegateCall.sol";
 /// @dev Implements IPoolModule interface to be used with pools added to LinkedPool router
 contract NexusPoolModule is OnlyDelegateCall, IPoolModule {
     IDefaultPoolCalc public immutable defaultPoolCalc;
+    /// These need to be immutable in order to be accessed via delegatecall
+    address public immutable nexusPool;
+    uint256 public immutable nexusPoolNumTokens;
+    address public immutable nexusPoolLpToken;
 
-    constructor(address defaultPoolCalc_) {
+    constructor(address defaultPoolCalc_, address nexusPool_) {
         defaultPoolCalc = IDefaultPoolCalc(defaultPoolCalc_);
+        // Save all the pool information during the deployment
+        nexusPool = nexusPool_;
+        nexusPoolNumTokens = _numTokens(nexusPool_);
+        nexusPoolLpToken = _lpToken(nexusPool_);
     }
 
     /// @inheritdoc IPoolModule

--- a/contracts/router/modules/pool/default/NexusPoolModule.sol
+++ b/contracts/router/modules/pool/default/NexusPoolModule.sol
@@ -22,15 +22,18 @@ contract NexusPoolModule is OnlyDelegateCall, IPoolModule {
     error NexusPoolModule__UnsupportedIndex(uint8 tokenIndex);
     error NexusPoolModule__UnsupportedPool(address pool);
 
+    /// @notice External contract that is used for precise addLiquidity calculations
     address public constant DEFAULT_POOL_CALC = 0x0000000000F54b784E70E1Cf1F99FB53b08D6FEA;
+    /// @notice Address of the pool this module is used for
     address public constant NEXUS_POOL = 0x1116898DdA4015eD8dDefb84b6e8Bc24528Af2d8;
 
-    uint256 public constant NUM_TOKENS = 3;
-    address public constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
-    address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
-    address public constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
-
-    address public constant NUSD = 0x1B84765dE8B7566e4cEAF4D0fD3c5aF52D3DdE4F;
+    /// @dev Hardcoded token addresses for the Nexus pool
+    uint256 internal constant NUM_TOKENS = 3;
+    address internal constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address internal constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+    /// @dev Address of the pool's LP token, which is also a token supported by SynapseBridge
+    address internal constant NUSD = 0x1B84765dE8B7566e4cEAF4D0fD3c5aF52D3DdE4F;
 
     modifier onlyNexusPool(address pool) {
         if (pool != NEXUS_POOL) revert NexusPoolModule__UnsupportedPool(pool);

--- a/contracts/router/modules/pool/default/NexusPoolModule.sol
+++ b/contracts/router/modules/pool/default/NexusPoolModule.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IDefaultPoolCalc} from "../../../interfaces/IDefaultPoolCalc.sol";
+import {IndexedToken, IPoolModule} from "../../../interfaces/IPoolModule.sol";
+
+import {OnlyDelegateCall} from "../../OnlyDelegateCall.sol";
+
+/// @notice PoolModule for the Nexus pool. Treats the pool's LP token (nUSD) as an additional pool token.
+/// poolToken -> lpToken is done by providing liquidity in a form of a single token.
+/// lpToken -> poolToken is done by removing liquidity in a form of a single token.
+/// @dev Implements IPoolModule interface to be used with pools added to LinkedPool router
+contract NexusPoolModule is OnlyDelegateCall, IPoolModule {
+    IDefaultPoolCalc public immutable defaultPoolCalc;
+
+    constructor(address defaultPoolCalc_) {
+        defaultPoolCalc = IDefaultPoolCalc(defaultPoolCalc_);
+    }
+
+    /// @inheritdoc IPoolModule
+    function poolSwap(
+        address pool,
+        IndexedToken memory tokenFrom,
+        IndexedToken memory tokenTo,
+        uint256 amountIn
+    ) external returns (uint256 amountOut) {
+        // This function should be only called via delegatecall
+        assertDelegateCall();
+    }
+
+    // ═══════════════════════════════════════════════════ VIEWS ═══════════════════════════════════════════════════════
+
+    /// @inheritdoc IPoolModule
+    function getPoolQuote(
+        address pool,
+        IndexedToken memory tokenFrom,
+        IndexedToken memory tokenTo,
+        uint256 amountIn,
+        bool probePaused
+    ) external view returns (uint256 amountOut) {}
+
+    /// @inheritdoc IPoolModule
+    function getPoolTokens(address pool) external view returns (address[] memory tokens) {}
+}

--- a/contracts/router/modules/pool/default/NexusPoolModule.sol
+++ b/contracts/router/modules/pool/default/NexusPoolModule.sol
@@ -24,7 +24,12 @@ contract NexusPoolModule is OnlyDelegateCall, IPoolModule {
 
     address public constant DEFAULT_POOL_CALC = 0x0000000000F54b784E70E1Cf1F99FB53b08D6FEA;
     address public constant NEXUS_POOL = 0x1116898DdA4015eD8dDefb84b6e8Bc24528Af2d8;
+
     uint256 public constant NUM_TOKENS = 3;
+    address public constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address public constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+
     address public constant NUSD = 0x1B84765dE8B7566e4cEAF4D0fD3c5aF52D3DdE4F;
 
     modifier onlyNexusPool(address pool) {
@@ -119,12 +124,12 @@ contract NexusPoolModule is OnlyDelegateCall, IPoolModule {
     }
 
     /// @inheritdoc IPoolModule
-    function getPoolTokens(address pool) external view onlyNexusPool(pool) returns (address[] memory tokens) {
+    function getPoolTokens(address pool) external pure onlyNexusPool(pool) returns (address[] memory tokens) {
         // Extend the list of pool tokens with the LP token
-        tokens = new address[](NUM_TOKENS + 1);
-        for (uint256 i = 0; i < NUM_TOKENS; i++) {
-            tokens[i] = IDefaultExtendedPool(pool).getToken(uint8(i));
-        }
-        tokens[NUM_TOKENS] = NUSD;
+        tokens = new address[](4);
+        tokens[0] = DAI;
+        tokens[1] = USDC;
+        tokens[2] = USDT;
+        tokens[3] = NUSD;
     }
 }

--- a/deployments/mainnet/NexusPoolModule.json
+++ b/deployments/mainnet/NexusPoolModule.json
@@ -1,0 +1,210 @@
+{
+  "address": "0x1Db5a1d5D80fDEfc098635d3869Fa94d6fA44F5a",
+  "constructorArgs": "0x",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "uint8",
+          "name": "tokenIndex",
+          "type": "uint8"
+        }
+      ],
+      "name": "NexusPoolModule__EqualIndexes",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NexusPoolModule__Paused",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint8",
+          "name": "tokenIndex",
+          "type": "uint8"
+        }
+      ],
+      "name": "NexusPoolModule__UnsupportedIndex",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "NexusPoolModule__UnsupportedPool",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "DEFAULT_POOL_CALC",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "NEXUS_POOL",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint8",
+              "name": "index",
+              "type": "uint8"
+            },
+            {
+              "internalType": "address",
+              "name": "token",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct IndexedToken",
+          "name": "tokenFrom",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint8",
+              "name": "index",
+              "type": "uint8"
+            },
+            {
+              "internalType": "address",
+              "name": "token",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct IndexedToken",
+          "name": "tokenTo",
+          "type": "tuple"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "probePaused",
+          "type": "bool"
+        }
+      ],
+      "name": "getPoolQuote",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolTokens",
+      "outputs": [
+        {
+          "internalType": "address[]",
+          "name": "tokens",
+          "type": "address[]"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint8",
+              "name": "index",
+              "type": "uint8"
+            },
+            {
+              "internalType": "address",
+              "name": "token",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct IndexedToken",
+          "name": "tokenFrom",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint8",
+              "name": "index",
+              "type": "uint8"
+            },
+            {
+              "internalType": "address",
+              "name": "token",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct IndexedToken",
+          "name": "tokenTo",
+          "type": "tuple"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "poolSwap",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+}

--- a/script/DeployNoArgs.s.sol
+++ b/script/DeployNoArgs.s.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {BasicSynapseScript} from "./templates/BasicSynapse.s.sol";
+
+/// @notice A generic deployment script, which deploys a contract with no constructor arguments,
+/// and saves its deployment artifact in the deployments directory.
+contract DeployNoArgs is BasicSynapseScript {
+    function run(string memory contractName) external {
+        // Setup the BasicSynapseScript
+        setUp();
+        vm.startBroadcast();
+        // Use `deploy` as the callback function, which will extract the deployment bytecode
+        // for `contractName` from the forge artifact and deploy it.
+        deployAndSave({contractName: contractName, constructorArgs: "", deployCode: deploy});
+        vm.stopBroadcast();
+    }
+}

--- a/test/interfaces/IPausable.sol
+++ b/test/interfaces/IPausable.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.12;
+
+interface IPausable {
+    function paused() external view returns (bool);
+
+    function pause() external;
+
+    function unpause() external;
+}

--- a/test/router/modules/pool/default/NexusPoolModule.Integration.Mainnet.t.sol
+++ b/test/router/modules/pool/default/NexusPoolModule.Integration.Mainnet.t.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IntegrationUtils} from "../../../../utils/IntegrationUtils.sol";
+
+import {LinkedPool} from "../../../../../contracts/router/LinkedPool.sol";
+import {IndexedToken, NexusPoolModule} from "../../../../../contracts/router/modules/pool/default/NexusPoolModule.sol";
+
+import {IERC20, SafeERC20} from "@openzeppelin/contracts-4.5.0/token/ERC20/utils/SafeERC20.sol";
+
+contract NexusPoolModuleEthTestFork is IntegrationUtils {
+    using SafeERC20 for IERC20;
+
+    LinkedPool public linkedPool;
+    NexusPoolModule public nexusPoolModule;
+
+    // 2023-11-03
+    uint256 public constant ETH_BLOCK_NUMBER = 18490000;
+
+    // DAI/USDC/USDT Nexus DefaultPool on Ethereum
+    address public constant NEXUS_POOL = 0x1116898DdA4015eD8dDefb84b6e8Bc24528Af2d8;
+    address public constant NUSD = 0x1B84765dE8B7566e4cEAF4D0fD3c5aF52D3DdE4F;
+    address public constant DEFAULT_POOL_CALC = 0x0000000000F54b784E70E1Cf1F99FB53b08D6FEA;
+
+    // Native USDC on Ethereum
+    address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    // Native USDT on Ethereum
+    address public constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+    // Native DAI on Ethereum
+    address public constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+
+    address public user;
+
+    constructor() IntegrationUtils("mainnet", "NexusPoolModule", ETH_BLOCK_NUMBER) {}
+
+    function afterBlockchainForked() public override {
+        nexusPoolModule = new NexusPoolModule({defaultPoolCalc_: DEFAULT_POOL_CALC, nexusPool_: NEXUS_POOL});
+        linkedPool = new LinkedPool(USDC, address(this));
+        user = makeAddr("User");
+    }
+
+    // ═══════════════════════════════════════════════ TESTS: VIEWS ════════════════════════════════════════════════════
+
+    function testImmutables() public {
+        assertEq(address(nexusPoolModule.defaultPoolCalc()), DEFAULT_POOL_CALC);
+        assertEq(nexusPoolModule.nexusPool(), NEXUS_POOL);
+        assertEq(nexusPoolModule.nexusPoolNumTokens(), 3);
+        assertEq(nexusPoolModule.nexusPoolLpToken(), NUSD);
+    }
+
+    function testGetPoolTokens() public {
+        address[] memory tokens = nexusPoolModule.getPoolTokens(NEXUS_POOL);
+        assertEq(tokens.length, 4);
+        assertEq(tokens[0], DAI);
+        assertEq(tokens[1], USDC);
+        assertEq(tokens[2], USDT);
+        assertEq(tokens[3], NUSD);
+    }
+
+    // ══════════════════════════════════════════════ TESTS: ADD POOL ══════════════════════════════════════════════════
+
+    function addPool() public {
+        linkedPool.addPool({nodeIndex: 0, pool: NEXUS_POOL, poolModule: address(nexusPoolModule)});
+    }
+
+    function testAddPool() public {
+        addPool();
+        assertEq(linkedPool.getToken(0), USDC);
+        assertEq(linkedPool.getToken(1), DAI);
+        assertEq(linkedPool.getToken(2), USDT);
+        assertEq(linkedPool.getToken(3), NUSD);
+    }
+
+    // ════════════════════════════════════════════════ TESTS: SWAP ════════════════════════════════════════════════════
+
+    function swap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 amount
+    ) public returns (uint256 amountOut) {
+        vm.prank(user);
+        amountOut = linkedPool.swap({
+            nodeIndexFrom: tokenIndexFrom,
+            nodeIndexTo: tokenIndexTo,
+            dx: amount,
+            minDy: 0,
+            deadline: type(uint256).max
+        });
+    }
+
+    function testSwapFromNusdToUsdc() public {
+        addPool();
+        uint256 amount = 100 * 10**18;
+        prepareUser(NUSD, amount);
+        uint256 expectedAmountOut = linkedPool.calculateSwap({nodeIndexFrom: 3, nodeIndexTo: 0, dx: amount});
+        uint256 amountOut = swap({tokenIndexFrom: 3, tokenIndexTo: 0, amount: amount});
+        assertGt(amountOut, 0);
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(IERC20(NUSD).balanceOf(user), 0);
+        assertEq(IERC20(USDC).balanceOf(user), amountOut);
+    }
+
+    function testSwapFromUsdcToDai() public {
+        addPool();
+        uint256 amount = 100 * 10**6;
+        prepareUser(USDC, amount);
+        uint256 expectedAmountOut = linkedPool.calculateSwap({nodeIndexFrom: 0, nodeIndexTo: 1, dx: amount});
+        uint256 amountOut = swap({tokenIndexFrom: 0, tokenIndexTo: 1, amount: amount});
+        assertGt(amountOut, 0);
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(IERC20(USDC).balanceOf(user), 0);
+        assertEq(IERC20(DAI).balanceOf(user), amountOut);
+    }
+
+    function testSwapFromDaiToNusd() public {
+        addPool();
+        uint256 amount = 100 * 10**18;
+        prepareUser(DAI, amount);
+        uint256 expectedAmountOut = linkedPool.calculateSwap({nodeIndexFrom: 1, nodeIndexTo: 3, dx: amount});
+        uint256 amountOut = swap({tokenIndexFrom: 1, tokenIndexTo: 3, amount: amount});
+        assertGt(amountOut, 0);
+        assertEq(amountOut, expectedAmountOut);
+        assertEq(IERC20(DAI).balanceOf(user), 0);
+        assertEq(IERC20(NUSD).balanceOf(user), amountOut);
+    }
+
+    function prepareUser(address token, uint256 amount) public {
+        deal(token, user, amount, false);
+        vm.startPrank(user);
+        IERC20(token).safeApprove(address(linkedPool), amount);
+        vm.stopPrank();
+    }
+}

--- a/test/router/modules/pool/default/NexusPoolModule.Integration.Mainnet.t.sol
+++ b/test/router/modules/pool/default/NexusPoolModule.Integration.Mainnet.t.sol
@@ -40,7 +40,7 @@ contract NexusPoolModuleEthTestFork is IntegrationUtils {
     constructor() IntegrationUtils("mainnet", "NexusPoolModule", ETH_BLOCK_NUMBER) {}
 
     function afterBlockchainForked() public override {
-        nexusPoolModule = new NexusPoolModule({defaultPoolCalc_: DEFAULT_POOL_CALC, nexusPool_: NEXUS_POOL});
+        nexusPoolModule = new NexusPoolModule();
         linkedPool = new LinkedPool(USDC, address(this));
         user = makeAddr("User");
         caller = new DelegateCaller();
@@ -181,13 +181,6 @@ contract NexusPoolModuleEthTestFork is IntegrationUtils {
     }
 
     // ═══════════════════════════════════════════════ TESTS: VIEWS ════════════════════════════════════════════════════
-
-    function testImmutables() public {
-        assertEq(address(nexusPoolModule.defaultPoolCalc()), DEFAULT_POOL_CALC);
-        assertEq(nexusPoolModule.nexusPool(), NEXUS_POOL);
-        assertEq(nexusPoolModule.nexusPoolNumTokens(), 3);
-        assertEq(nexusPoolModule.nexusPoolLpToken(), NUSD);
-    }
 
     function testGetPoolTokens() public {
         address[] memory tokens = nexusPoolModule.getPoolTokens(NEXUS_POOL);


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

Adds a pool module for the [Ethereum Nexus Pool](https://etherscan.io/address/0x1116898DdA4015eD8dDefb84b6e8Bc24528Af2d8).

The Nexus pool conforms to the Default Pool interface (so by default it does not need a pool module), however its LP token is the `nUSD` bridge token. This module allows to add the Nexus Pool to the LinkedPool config, allowing to do `DAI/USDC/USDT <> nUSD` swaps. This enables starting from an external token, swap it for USDC via external pool, then to nUSD via Nexus pool using the new module, and then finally bridge it, all in one transaction.

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new Nexus Pool Module with capabilities for token swapping, quote calculation, and pool token retrieval.
	- Added a new interface, `IPausable`, to manage contract pause and unpause states.
- **Tests**
	- Updated the Nexus Pool Module test suite with new test functions and updated contract dependencies.
- **Chores**
	- Implemented a new `DeployNoArgs` script for deploying contracts without constructor arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->