### PR TITLE
Chore: update quoter v2 config

### DIFF
--- a/deployments/canto/DefaultPoolCalc.json
+++ b/deployments/canto/DefaultPoolCalc.json
@@ -1,0 +1,30 @@
+{
+  "address": "0x0000000000Cc5af216a3E1614091a20e11bbfD32",
+  "constructorArgs": "0x",
+  "abi": [
+    {
+      "type": "function",
+      "name": "calculateAddLiquidity",
+      "inputs": [
+        {
+          "name": "pool",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "amounts",
+          "type": "uint256[]",
+          "internalType": "uint256[]"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "amountOut",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    }
+  ]
+}

--- a/deployments/canto/SwapQuoterV2.json
+++ b/deployments/canto/SwapQuoterV2.json
@@ -1,0 +1,703 @@
+{
+  "address": "0x55DEc55aDbd9a2102438339A294CB921A5248285",
+  "constructorArgs": "0x0000000000000000000000007e7a0e201fd38d3adaa9523da6c109a07118c96a0000000000000000000000000000000000cc5af216a3e1614091a20e11bbfd32000000000000000000000000826551890dc65655a0aceca109ab11abdbd7a07b0000000000000000000000000fea3e5840334fc758a3decf14546bfdfbef5cd3",
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "synapseRouter_",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "defaultPoolCalc_",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "weth_",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "owner_",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "addPools",
+      "inputs": [
+        {
+          "name": "pools",
+          "type": "tuple[]",
+          "internalType": "struct SwapQuoterV2.BridgePool[]",
+          "components": [
+            {
+              "name": "bridgeToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "poolType",
+              "type": "uint8",
+              "internalType": "enum SwapQuoterV2.PoolType"
+            },
+            {
+              "name": "pool",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "allPools",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "pools",
+          "type": "tuple[]",
+          "internalType": "struct Pool[]",
+          "components": [
+            {
+              "name": "pool",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "lpToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tokens",
+              "type": "tuple[]",
+              "internalType": "struct PoolToken[]",
+              "components": [
+                {
+                  "name": "isWeth",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "token",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "areConnectedTokens",
+      "inputs": [
+        {
+          "name": "tokenIn",
+          "type": "tuple",
+          "internalType": "struct LimitedToken",
+          "components": [
+            {
+              "name": "actionMask",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "name": "tokenOut",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "calculateAddLiquidity",
+      "inputs": [
+        {
+          "name": "pool",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "amounts",
+          "type": "uint256[]",
+          "internalType": "uint256[]"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "amountOut",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "calculateRemoveLiquidity",
+      "inputs": [
+        {
+          "name": "pool",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "amountsOut",
+          "type": "uint256[]",
+          "internalType": "uint256[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "calculateSwap",
+      "inputs": [
+        {
+          "name": "pool",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "tokenIndexFrom",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "tokenIndexTo",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "dx",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "amountOut",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "calculateWithdrawOneToken",
+      "inputs": [
+        {
+          "name": "pool",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "tokenAmount",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "tokenIndex",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "amountOut",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "defaultPoolCalc",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "findConnectedTokens",
+      "inputs": [
+        {
+          "name": "bridgeTokensIn",
+          "type": "tuple[]",
+          "internalType": "struct LimitedToken[]",
+          "components": [
+            {
+              "name": "actionMask",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "name": "tokenOut",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "amountFound",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "isConnected",
+          "type": "bool[]",
+          "internalType": "bool[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getAmountOut",
+      "inputs": [
+        {
+          "name": "tokenIn",
+          "type": "tuple",
+          "internalType": "struct LimitedToken",
+          "components": [
+            {
+              "name": "actionMask",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "name": "tokenOut",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "amountIn",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "query",
+          "type": "tuple",
+          "internalType": "struct SwapQuery",
+          "components": [
+            {
+              "name": "routerAdapter",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tokenOut",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "minAmountOut",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "deadline",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "rawParams",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getBridgePools",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "bridgePools",
+          "type": "tuple[]",
+          "internalType": "struct SwapQuoterV2.BridgePool[]",
+          "components": [
+            {
+              "name": "bridgeToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "poolType",
+              "type": "uint8",
+              "internalType": "enum SwapQuoterV2.PoolType"
+            },
+            {
+              "name": "pool",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getOriginDefaultPools",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "originDefaultPools",
+          "type": "address[]",
+          "internalType": "address[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getOriginLinkedPools",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "originLinkedPools",
+          "type": "address[]",
+          "internalType": "address[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "owner",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "poolInfo",
+      "inputs": [
+        {
+          "name": "pool",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "numTokens",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "lpToken",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "poolTokens",
+      "inputs": [
+        {
+          "name": "pool",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "tokens",
+          "type": "tuple[]",
+          "internalType": "struct PoolToken[]",
+          "components": [
+            {
+              "name": "isWeth",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "poolsAmount",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "amtPools",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "removePools",
+      "inputs": [
+        {
+          "name": "pools",
+          "type": "tuple[]",
+          "internalType": "struct SwapQuoterV2.BridgePool[]",
+          "components": [
+            {
+              "name": "bridgeToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "poolType",
+              "type": "uint8",
+              "internalType": "enum SwapQuoterV2.PoolType"
+            },
+            {
+              "name": "pool",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "renounceOwnership",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setSynapseRouter",
+      "inputs": [
+        {
+          "name": "synapseRouter_",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "synapseRouter",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "transferOwnership",
+      "inputs": [
+        {
+          "name": "newOwner",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "weth",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "event",
+      "name": "OwnershipTransferred",
+      "inputs": [
+        {
+          "name": "previousOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PoolAdded",
+      "inputs": [
+        {
+          "name": "bridgeToken",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "poolType",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum SwapQuoterV2.PoolType"
+        },
+        {
+          "name": "pool",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PoolRemoved",
+      "inputs": [
+        {
+          "name": "bridgeToken",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "poolType",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum SwapQuoterV2.PoolType"
+        },
+        {
+          "name": "pool",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SynapseRouterUpdated",
+      "inputs": [
+        {
+          "name": "synapseRouter",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "error",
+      "name": "SwapQuoterV2__DuplicatedPool",
+      "inputs": [
+        {
+          "name": "pool",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "SwapQuoterV2__UnknownPool",
+      "inputs": [
+        {
+          "name": "pool",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    }
+  ]
+}

--- a/script/configs/SwapQuoterV2.ignored.json
+++ b/script/configs/SwapQuoterV2.ignored.json
@@ -1,3 +1,6 @@
 {
-  "contractNames": ["AvaxJewelSwap", "MockSwap"]
+  "global": ["AvaxJewelSwap", "MockSwap"],
+  "chain": {
+    "canto": ["ETHPool"]
+  }
 }

--- a/script/configs/avalanche/SwapQuoterV2.dc.json
+++ b/script/configs/avalanche/SwapQuoterV2.dc.json
@@ -9,7 +9,7 @@
     "1": {
       "description": "nUSD",
       "isLinked": false,
-      "pool": "0xED2a7edd7413021d440b09D654f3b87712abAB66",
+      "pool": "0xA196a03653f6cc5cA0282A8BD7Ec60e93f620afc",
       "token": "0xCFc37A6AB183dd4aED08C204D1c2773c0b1BDf46"
     },
     "2": {

--- a/script/configs/canto/SwapQuoterV2.dc.json
+++ b/script/configs/canto/SwapQuoterV2.dc.json
@@ -1,0 +1,10 @@
+{
+  "pools": {
+    "0": {
+      "description": "nUSD",
+      "isLinked": false,
+      "pool": "0x0271984e4cfA2A0f02664baACD551CcFCC9920E8",
+      "token": "0xD8836aF2e565D3Befce7D906Af63ee45a57E8f80"
+    }
+  }
+}


### PR DESCRIPTION
<!--  Pull Request Template -->

## Description

Also includes the artifacts for SwapQuoterV2 on Canto which was deployed some time ago, but never pushed :face_exhaling: 

## Checklist

- [ ] New Contracts have been tested
- [ ] Lint has been run
- [ ] I have checked my code and corrected any misspellings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of ignored pools in the `SaveConfigQuoterV2` contract, allowing for more flexible configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->