### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
       FOUNDRY_FUZZ_RUNS: 2000
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to use newer actions for repository checkout in selected jobs; overall configuration and step order remain unchanged.
  * Existing submodule handling and test execution are retained without changes to application behavior.
  * No user-facing changes; functionality, performance, interfaces, and release artifacts are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->